### PR TITLE
chore: add codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Default owners for everything in the repository
+* @saltenasl @jamesbhobbs


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Established default code ownership rules across the repository, assigning two maintainers as owners for all paths.
  * Streamlines automatic reviewer assignment on pull requests and clarifies points of contact for changes.
  * Enhances consistency and accountability in the review process without impacting application behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->