### PR TITLE
docs: add Maintainer Guidelines to CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -87,6 +87,7 @@ Biome is available as a first-party extension in your favorite editors.
 - Keep pull requests small and focused on a single purpose. Unless your PR is entirely self-explanatory, link the related issue in your PR description.
 - Respect authorship: only add `Co-authored-by:` lines with explicit consent.
 - Maintain issue hygiene: label issues consistently (`bug`, `feat`, `chore`, etc.) and close them only with a final comment explaining the resolution, linking to the relevant PR or documentation. See [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
+- If decisions happen in Slack, meetings, or other offline channels, post a short TL;DR summary in the relevant issue or PR so the full context is preserved.
 
 ---
 


### PR DESCRIPTION
This PR introduces a new Maintainer Guidelines section to CONTRIBUTING.md. The goal is to make our OSS repo easier to work in by spelling out clear expectations for maintainers and contributors.

The section covers:
	•	Protected main branch (no direct commits, no force pushes).
	•	Clear rule: never rebase or force push another person’s branch. Use merge commits when resolving conflicts.
	•	PR etiquette: small, single-purpose PRs, always linked to an issue.
	•	Authorship respect: only add Co-authored-by: with consent; never rewrite another person’s commits.
	•	Issue hygiene: consistent labels, and closing issues only with a resolution comment linking to PRs/docs.
	•	Reference to Conventional Commits.

This makes expectations explicit for both Deepnote engineers and external contributors, avoiding the kinds of OSS pitfalls we’ve run into before (e.g., unclear issue closures, force pushes to others’ PRs).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Adds a "Maintainer Guidelines" section to the contributing guide covering workflow hygiene: protected main branch, avoid rebases/force-pushes, keep PRs small, ensure correct authorship, use consistent issue labels, and properly close issues. Clarifies maintainer/contributor expectations to streamline reviews; rest of the guide unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->