### PR TITLE
chore(codeowners): update repository ownership

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 # Default owners for everything in the repository
-* @saltenasl @jamesbhobbs
+* @saltenasl @jamesbhobbs @Artmann @andyjakubowski

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,1 @@
+CODEOWNERS


### PR DESCRIPTION
Adding @Artmann @andyjakubowski as codeowners to speed up PR merging.

Right now every PR by @jamesbhobbs requires approval specifically by @saltenasl before it can be merged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Updated repository ownership list to include additional maintainers, aligning review responsibilities with the current team.
  - Adjusted formatting configuration to exclude administrative files from automated formatting.
  - No user-facing changes or behavior impacts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->