### PR TITLE
feat(blocks): dual format (ESM + CommonJS) support for blocks package

### DIFF
--- a/packages/blocks/package.json
+++ b/packages/blocks/package.json
@@ -24,7 +24,7 @@
   "scripts": {
     "build": "tsdown --format esm --format cjs --dts",
     "test": "vitest",
-    "watch": "tsdown --watch"
+    "watch": "tsdown --watch --format esm --format cjs --dts"
   },
   "dependencies": {
     "ts-dedent": "^2.2.0"


### PR DESCRIPTION
Signed-off-by: Andy Jakubowski <hello@andyjakubowski.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Package now provides both ESM and CommonJS entry points and exposes an exports map for improved resolution.
  * Published entry points and type declaration paths normalized to distribution output.
  * Build updated to produce ESM + CJS formats and type declarations; a watch script was added.
  * No functional API changes expected; verify import resolution if you rely on ESM-only imports.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->