### PR TITLE
chore: Add a workflow for publishing the blocks package.

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -48,13 +48,9 @@ jobs:
         with:
           node-version-file: '.nvmrc'
           cache: 'pnpm'
-          registry-url: 'https://npm.pkg.github.com'
-          scope: '@deepnote'
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Validate package version
         run: |
@@ -82,9 +78,12 @@ jobs:
           echo "Version validation passed: $TAG_VERSION"
 
       - name: Build package
-        run: pnpm --filter ${{ steps.package_info.outputs.package_name }} run build
+        run: pnpm --filter "${{ steps.package_info.outputs.package_name }}..." run build
+
+      - name: Configure registry for publishing
+        run: |
+          echo "//npm.pkg.github.com/:_authToken=${{ secrets.GITHUB_TOKEN }}" > ~/.npmrc
+          echo "@deepnote:registry=https://npm.pkg.github.com" >> ~/.npmrc
 
       - name: Publish to GitHub Packages
         run: pnpm publish --filter ${{ steps.package_info.outputs.package_name }} --no-git-checks
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -100,7 +100,7 @@ To publish a new version of a package (using `@deepnote/blocks` as an example):
 
    ```bash
    git checkout -b release/blocks-1.2.0
-   git add packages/blocks/package.json pnpm-lock.yaml
+   git add -A
    git commit -m "chore: bump @deepnote/blocks to 1.2.0"
    git push origin release/blocks-1.2.0
    ```


### PR DESCRIPTION
It will publish the package when a release is created.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Chores
  - Added an automated package publishing workflow that runs on release tags, validates package/version alignment, builds the targeted package, and publishes to GitHub Packages to streamline per-package releases.

- Documentation
  - Added a step-by-step "Publishing Packages" guide describing the release/tag and publish workflow.
  - Expanded maintainer guidelines: no rebasing/force-pushing others’ branches; resolve conflicts by merging main; improved PR hygiene, authorship preservation, issue labeling, and communication practices.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->