### PR TITLE
Change qlty smells mode from comment to block

### DIFF
--- a/.qlty/qlty.toml
+++ b/.qlty/qlty.toml
@@ -30,7 +30,7 @@ exclude_patterns = [
 
 # Code Smells Configuration
 [smells]
-mode = "comment"
+mode = "block"
 
 [smells.boolean_logic]
 enabled = true


### PR DESCRIPTION
# Change qlty smells mode from comment to block

## Summary
Changed the qlty code smells detection mode from "comment" to "block" in `.qlty/qlty.toml`. This means qlty will now fail CI builds when code smells are detected above configured thresholds, rather than just adding comments to PRs.

## Review & Testing Checklist for Human
- [ ] **Verify qlty "block" mode works in CI** - Check that the qlty job runs successfully and actually blocks when code smells are detected
- [ ] **Confirm no existing code smells cause immediate failures** - Ensure this change doesn't break existing PRs or main branch builds due to pre-existing code smells
- [ ] **Validate alignment with team workflow** - Confirm that blocking builds for code smells aligns with the team's development process expectations

### Notes
- This is a behavioral change that will make code quality enforcement stricter
- The change was not testable locally due to qlty not being available in the development environment
- Requested by James Hobbs (@jamesbhobbs) in [Devin session](https://app.devin.ai/sessions/ec3a1ece99554b579706acabbdd083d4)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal code quality configuration to switch smell reporting from inline comments to block format, improving consistency in CI feedback.
* **User Impact**
  * No user-facing changes; functionality and UI remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->