### PR TITLE
chore: bump @deepnote/blocks to 1.2.0

### DIFF
--- a/packages/blocks/package.json
+++ b/packages/blocks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@deepnote/blocks",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "",
   "keywords": [],
   "repository": {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Incremented package version to 1.2.0 for the Blocks package.
  * No functional, UI, performance, or configuration changes included.
  * Maintenance update aligning release numbering and distribution metadata.
  * Existing workflows remain unchanged and fully compatible.
  * No action required unless you wish to adopt the new version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->