### PR TITLE
Remove andyjakubowski from CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 # Default owners for everything in the repository
-* @saltenasl @jamesbhobbs @Artmann @andyjakubowski
+* @saltenasl @jamesbhobbs @Artmann


### PR DESCRIPTION
# Remove andyjakubowski from CODEOWNERS

## Summary
This PR removes @andyjakubowski from the default CODEOWNERS list. The intent is to stop automatically requesting reviews from that user on new pull requests in this repository.

This is part of a broader cleanup across Deepnote repositories.

## Review & Testing Checklist for Human
- [ ] Validate that the remaining default owners are correct and sufficient for this repo’s governance.
- [ ] Sanity check GitHub recognizes the change by opening or updating a test PR targeting main and confirming that @andyjakubowski is no longer auto-requested as a reviewer.
- [ ] Optionally grep this repo to confirm there are no other references to the user that should be removed.

### Notes
- Scope: configuration-only change in .github/CODEOWNERS; no runtime impact expected.
- Link to Devin run: https://app.devin.ai/sessions/5a8f5921776546b797c99b41edeb78bb
- Requested by: James Hobbs (james@deepnote.com), GitHub: @jamesbhobbs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal code ownership configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->