### PR TITLE
ci: add fetch-depth: 0 to qlty checkout for proper git history access

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,6 +69,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
+        with:
+          fetch-depth: 0
 
       - name: Install qlty
         uses: qltysh/qlty-action/install@a19242102d17e497f437d7466aa01b528537e899


### PR DESCRIPTION
# ci: add fetch-depth: 0 to qlty checkout for proper git history access

## Summary
Added `fetch-depth: 0` to the checkout action in the qlty CI job. This ensures qlty has access to the full git history, which is required for it to properly analyze code changes and compare against previous commits.

The change updates the checkout step to fetch all history instead of doing a shallow clone (default behavior), allowing qlty to function correctly.

## Review & Testing Checklist for Human
- [ ] Verify the YAML syntax is correct and properly indented
- [ ] Confirm CI passes with the new configuration (qlty should now work properly)

### Notes
- This change was applied consistently across 4 repositories: deepnote, jupyterlab-deepnote, deepnote-internal, and vscode-deepnote
- The `fetch-depth: 0` parameter is standard practice for tools that need git history analysis
- This is a low-risk configuration change with no code logic modifications

---
**Devin run:** https://app.devin.ai/sessions/8e83a17c48d34c79be89b985c9b936ee  
**Requested by:** James Hobbs (james@deepnote.com) / @jamesbhobbs