### PR TITLE
chore: add draftPR to renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:recommended", "helpers:pinGitHubActionDigests"],
+  "draftPR": true,
   "pinDigests": true,
   "platformAutomerge": false,
   "prCreation": "immediate",


### PR DESCRIPTION
# chore: add draftPR to renovate config

## Summary
Added `"draftPR": true` to the Renovate configuration to make all dependency update PRs created by Renovate bot appear as drafts instead of immediately ready for review.

This is a simple one-line configuration change that affects Renovate's behavior going forward. 
## Review & Testing Checklist for Human
- [ ] **Confirm this workflow change is desired**: Verify that the team wants Renovate PRs to be created as drafts. This means someone will need to manually mark them as "ready for review" when they want to merge them.
- [ ] **Check for dependent automation**: Ensure no CI/CD processes or GitHub Actions depend on Renovate PRs being non-draft (e.g., auto-merge workflows, notification systems).
- [ ] **Verify testing approach**: The change will only take effect when Renovate next runs. Consider monitoring the next few Renovate PRs to confirm they appear as drafts as expected.

### Notes
- This change cannot be tested locally; effects will only be visible when Renovate creates its next PR
- The configuration is a standard Renovate option documented at https://docs.renovatebot.com/configuration-options/#draftpr
- Easy to revert if needed by removing the line

---
**Devin session**: https://app.devin.ai/sessions/39ddd2987cd74590bdd9f562103987e3  
**Requested by**: James Hobbs (@jamesbhobbs)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Configured the automated dependency management tool to create pull requests as drafts rather than immediately opening them, allowing time for review before activation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->