### PR TITLE
docs: add minimal SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,4 +2,4 @@
 
 Report vulnerabilities to security@deepnote.com. If you need to encrypt your message, use our [PGP key](https://deepnote.com/.well-known/pgp-key.txt).
 
-For full security policy and contact information, see https://deepnote.com/.well-known/security.txt
+For full security policy and contact information, see [security policy](https://deepnote.com/.well-known/security.txt)


### PR DESCRIPTION
# Add minimal SECURITY.md

## Summary
Adds a minimal SECURITY.md file to the repository root with just the essential contact information for reporting vulnerabilities and a link to the canonical security policy at https://deepnote.com/.well-known/security.txt. This avoids duplicating policy details that could become stale and keeps the file as a stable pointer to the authoritative source.

## Review & Testing Checklist for Human
- [ ] Verify the contact email (security@deepnote.com) is correct
- [ ] Test that both links work and point to the correct resources:
  - PGP key: https://deepnote.com/.well-known/pgp-key.txt
  - Security policy: https://deepnote.com/.well-known/security.txt
- [ ] Confirm this level of "minimal" meets your requirements
- [ ] Consider if you also want a copy at `.github/SECURITY.md` for GitHub's security tab UI (currently only at root)

### Notes
- Intentionally minimal to avoid policy drift - all details live in the canonical security.txt
- This is an OSS repo, so the file points to public security contact information only
- Devin run: https://app.devin.ai/sessions/438185883eb74719998759b503cc47b5
- Requested by: James Hobbs (james@deepnote.com) (@jamesbhobbs)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive security vulnerability reporting guidance, including how to report issues to the security team (security@deepnote.com), instructions for encrypted communication using the provided PGP key reference, and a link to the full security policy and contact details on the public security page.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->