### PR TITLE
fix(blocks): escape double quotes in escapePythonString for GRN-4900

### DIFF
--- a/packages/blocks/src/blocks/data-frame.test.ts
+++ b/packages/blocks/src/blocks/data-frame.test.ts
@@ -65,6 +65,8 @@ describe('createDataFrameConfig', () => {
       cellFormattingRules: [],
       wrappedTextColumnIds: [],
     })
+      .replaceAll('\\', '\\\\')
+      .replaceAll('"', '\\"')
 
     expect(result).toEqual(dedent`
       if '_dntk' in globals():
@@ -112,6 +114,8 @@ describe('createDataFrameConfig', () => {
       cellFormattingRules: [],
       wrappedTextColumnIds: [],
     })
+      .replaceAll('\\', '\\\\')
+      .replaceAll('"', '\\"')
 
     expect(result).toEqual(dedent`
       if '_dntk' in globals():
@@ -157,13 +161,13 @@ describe('createDataFrameConfig', () => {
 
     const result = createDataFrameConfig(block)
 
-    // The escapePythonString function escapes backslashes and single quotes
-    // JSON.stringify already escapes double quotes to \" and escapePythonString then escapes the \ to \\
+    // The escapePythonString function escapes backslashes, single quotes, and double quotes
+    // JSON.stringify produces {"key":"value"} and escapePythonString escapes all double quotes to \"
     expect(result).toEqual(dedent`
       if '_dntk' in globals():
-        _dntk.dataframe_utils.configure_dataframe_formatter('{"columnDisplayNames":[{"columnName":"value","displayName":"It\\'s a \\\\"test"}]}')
+        _dntk.dataframe_utils.configure_dataframe_formatter('{\\"columnDisplayNames\\":[{\\"columnName\\":\\"value\\",\\"displayName\\":\\"It\\'s a \\\\\\\"test\\"}]}')
       else:
-        _deepnote_current_table_attrs = '{"columnDisplayNames":[{"columnName":"value","displayName":"It\\'s a \\\\"test"}]}'
+        _deepnote_current_table_attrs = '{\\"columnDisplayNames\\":[{\\"columnName\\":\\"value\\",\\"displayName\\":\\"It\\'s a \\\\\\\"test\\"}]}'
     `)
   })
 
@@ -204,6 +208,8 @@ describe('createDataFrameConfig', () => {
       cellFormattingRules: [{ column: 'value', rule: 'color' }],
       wrappedTextColumnIds: ['category'],
     })
+      .replaceAll('\\', '\\\\')
+      .replaceAll('"', '\\"')
 
     expect(result).toEqual(dedent`
       if '_dntk' in globals():

--- a/packages/blocks/src/blocks/input-blocks.test.ts
+++ b/packages/blocks/src/blocks/input-blocks.test.ts
@@ -54,7 +54,7 @@ describe('createPythonCodeForInputTextBlock', () => {
 
     const result = createPythonCodeForInputTextBlock(block)
 
-    expect(result).toEqual("my_input = 'It\\'s a \"test\"'")
+    expect(result).toEqual("my_input = 'It\\'s a \\\"test\\\"'")
   })
 })
 

--- a/packages/blocks/src/blocks/python-utils.ts
+++ b/packages/blocks/src/blocks/python-utils.ts
@@ -1,6 +1,6 @@
 export function escapePythonString(value: string): string {
-  // We have to escape backslashes, single quotes, and newlines
-  const escaped = value.replaceAll('\\', '\\\\').replaceAll("'", "\\'").replaceAll('\n', '\\n')
+  // We have to escape backslashes, single quotes, double quotes, and newlines
+  const escaped = value.replaceAll('\\', '\\\\').replaceAll("'", "\\'").replaceAll('"', '\\"').replaceAll('\n', '\\n')
 
   // Wrap the escaped string in single quotes
   return `'${escaped}'`


### PR DESCRIPTION
# fix(blocks): escape double quotes in escapePythonString for GRN-4900

## Summary
Fixes a bug where big number charts (and other blocks) fail with "unterminated string literal" Python errors when titles contain double quotes. The root cause was that the `escapePythonString` utility function only escaped backslashes, single quotes, and newlines, but not double quotes. When titles like `Total "Sales"` were embedded in generated Python code wrapped in single quotes, the unescaped double quotes caused syntax errors.

The fix adds double quote escaping to `escapePythonString`, changing:
```typescript
.replaceAll('\\', '\\\\').replaceAll("'", "\\'").replaceAll('\n', '\\n')
```
to:
```typescript
.replaceAll('\\', '\\\\').replaceAll("'", "\\'").replaceAll('"', '\\"').replaceAll('\n', '\\n')
```

All affected tests have been updated to expect escaped double quotes in the generated Python code.

## Review & Testing Checklist for Human
- [ ] **[CRITICAL] End-to-end test**: Create a big number block in Deepnote with title `Total "Sales"` and comparison title `vs "a"`, then execute the block to verify it runs without "unterminated string literal" errors
- [ ] **Test edge cases**: Try titles with mixed quotes (e.g., `It's a "test"`), multiple double quotes, and already-escaped characters to ensure proper escaping
- [ ] **Backward compatibility**: Verify that existing blocks without double quotes still work correctly (spot check a few existing notebooks)
- [ ] **Review escaping order**: Confirm that backslash → single quote → double quote → newline is the correct order
- [ ] **Check for missed locations**: Verify there are no other places in the codebase where double quotes should be escaped in Python string generation

### Test Plan
1. Create a new notebook
2. Add a big number block with title: `Total "Sales"` and value: `100`
3. Add comparison title: `vs "a"` and comparison value: `90`
4. Execute the block
5. Verify no Python errors occur and the block displays correctly
6. Test with other block types (input text blocks with double quotes, SQL queries with double quotes, etc.)

### Notes
- Linear ticket: GRN-4900
- This change affects all block types that use `escapePythonString`: big number blocks, input blocks, SQL blocks, visualization blocks, and data frame configurations
- All 125 tests pass and linting/typecheck are clean
- Link to Devin run: https://app.devin.ai/sessions/a1ba2b283791498e8312d0eb73527b61
- Requested by: Zuzana Benova (zuzana@deepnote.com) / @haskinator

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved escaping of special characters in generated Python code to ensure backslashes and double quotes are properly handled in string values, particularly when titles and content contain these characters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->