### PR TITLE
chore: publish packages from their dir instead of root

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -89,5 +89,5 @@ jobs:
         run: |
           PACKAGE="${{ steps.package_info.outputs.package_name }}"
           PKG_DIR="packages/${PACKAGE#@deepnote/}"
-          cd $PKG_DIR
+          cd "$PKG_DIR" || exit 1
           pnpm publish --no-git-checks


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the npm publishing workflow to publish each package from its own directory, improving release reliability and consistency and reducing publish errors during automated releases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->