### PR TITLE
chore: use npm to publish

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -90,4 +90,4 @@ jobs:
           PACKAGE="${{ steps.package_info.outputs.package_name }}"
           PKG_DIR="packages/${PACKAGE#@deepnote/}"
           cd "$PKG_DIR" || exit 1
-          npm publish --no-git-checks
+          npm publish


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the continuous deployment workflow to use npm for package publishing, replacing the previous package manager while keeping the publish step targeted to the package directory.
  * No other workflow steps or logic were changed; existing configuration and working-directory behavior remain unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->