### PR TITLE
fix(convert): update readme and build bin file

### DIFF
--- a/packages/convert/README.md
+++ b/packages/convert/README.md
@@ -5,7 +5,7 @@ Convert Jupyter Notebook files (`.ipynb`) to Deepnote project files (`.deepnote`
 ## Installation
 
 ```bash
-npm install @deepnote/convert
+npm install -g @deepnote/convert
 ```
 
 ## CLI Usage
@@ -78,17 +78,14 @@ You can also use the conversion function programmatically in your Node.js or Typ
 ### Basic Usage
 
 ```typescript
-import { convertIpynbFilesToDeepnoteFile } from '@deepnote/convert'
+import { convertIpynbFilesToDeepnoteFile } from "@deepnote/convert";
 
-await convertIpynbFilesToDeepnoteFile(
-  ['path/to/notebook.ipynb'],
-  {
-    outputPath: 'output.deepnote',
-    projectName: 'My Project'
-  }
-)
+await convertIpynbFilesToDeepnoteFile(["path/to/notebook.ipynb"], {
+  outputPath: "output.deepnote",
+  projectName: "My Project",
+});
+```
 
 ## License
 
 Apache-2.0
-```

--- a/packages/convert/package.json
+++ b/packages/convert/package.json
@@ -28,9 +28,9 @@
     "package.json"
   ],
   "scripts": {
-    "build": "tsdown --format esm --dts",
+    "build": "tsdown --format esm --dts src/bin.ts src/index.ts",
     "test": "vitest",
-    "watch": "tsdown --watch --format esm --dts"
+    "watch": "tsdown --watch --format esm --dts src/bin.ts src/index.ts"
   },
   "dependencies": {
     "@deepnote/blocks": "workspace:*",


### PR DESCRIPTION
When I installed `@deepnote/convert` the CLI said "command not found".

I found out that the `bin` file is missing in the `dist` folder.

Also fixed the installation script.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Installation instructions updated to use a global install option.
  * Code usage examples refined for consistent formatting and punctuation.

* **Chores**
  * Build configuration adjusted to explicitly include additional source entry points for packaging and type output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->