### PR TITLE
fix SqlAlchemyInput.ssh_options.enabled typing to properly disable SSH

### DIFF
--- a/packages/database-integrations/src/database-integration-env-vars.test.ts
+++ b/packages/database-integrations/src/database-integration-env-vars.test.ts
@@ -74,7 +74,7 @@ describe('Database integration env variables', () => {
           params: expect.anything(),
           param_style: 'pyformat',
           ssh_options: {
-            enabled: 'true',
+            enabled: true,
             host: 'my-ssh-host',
             port: '255',
             user: 'my-ssh-user',
@@ -597,7 +597,7 @@ describe('Database integration env variables', () => {
           params: {},
           param_style: 'pyformat',
           ssh_options: {
-            enabled: 'true',
+            enabled: true,
             host: 'my-ssh-host',
             port: '255',
             user: 'my-ssh-user',
@@ -674,7 +674,7 @@ describe('Database integration env variables', () => {
           },
           param_style: 'pyformat',
           ssh_options: {
-            enabled: 'true',
+            enabled: true,
             host: 'my-ssh-host',
             port: '255',
             user: 'my-ssh-user',
@@ -743,7 +743,7 @@ describe('Database integration env variables', () => {
           params: {},
           param_style: 'pyformat',
           ssh_options: {
-            enabled: 'true',
+            enabled: true,
             host: 'my-ssh-host',
             port: '255',
             user: 'my-ssh-user',
@@ -851,7 +851,7 @@ describe('Database integration env variables', () => {
           params: expect.anything(),
           param_style: 'pyformat',
           ssh_options: {
-            enabled: 'true',
+            enabled: true,
             host: 'my-ssh-host',
             port: '255',
             user: 'my-ssh-user',
@@ -1054,7 +1054,7 @@ describe('Database integration env variables', () => {
           params: expect.anything(),
           param_style: 'pyformat',
           ssh_options: {
-            enabled: 'true',
+            enabled: true,
             host: 'my-ssh-host',
             port: '255',
             user: 'my-ssh-user',
@@ -1255,7 +1255,7 @@ describe('Database integration env variables', () => {
           params: expect.anything(),
           param_style: 'pyformat',
           ssh_options: {
-            enabled: 'true',
+            enabled: true,
             host: 'my-ssh-host',
             port: '255',
             user: 'my-ssh-user',
@@ -1497,7 +1497,7 @@ describe('Database integration env variables', () => {
           params: expect.anything(),
           param_style: 'pyformat',
           ssh_options: {
-            enabled: 'true',
+            enabled: true,
             host: 'my-ssh-host',
             port: '255',
             user: 'my-ssh-user',
@@ -1656,7 +1656,7 @@ describe('Database integration env variables', () => {
           params: expect.anything(),
           param_style: 'pyformat',
           ssh_options: {
-            enabled: 'true',
+            enabled: true,
             host: 'my-ssh-host',
             port: '255',
             user: 'my-ssh-user',
@@ -1884,7 +1884,7 @@ describe('Database integration env variables', () => {
           params: expect.anything(),
           param_style: 'pyformat',
           ssh_options: {
-            enabled: 'true',
+            enabled: true,
             host: 'my-ssh-host',
             port: '255',
             user: 'my-ssh-user',
@@ -2369,7 +2369,7 @@ describe('Database integration env variables', () => {
           params: {},
           param_style: 'pyformat',
           ssh_options: {
-            enabled: 'true',
+            enabled: true,
             host: 'my-ssh-host',
             port: '255',
             user: 'my-ssh-user',

--- a/packages/database-integrations/src/database-integration-env-vars.ts
+++ b/packages/database-integrations/src/database-integration-env-vars.ts
@@ -219,12 +219,14 @@ const getDatabricksSqlAlchemyInput = ({
       },
     },
     param_style: 'pyformat',
-    ssh_options: {
-      enabled: sshEnabled == null ? undefined : String(sshEnabled),
-      host: sshHost,
-      port: sshPort,
-      user: sshUser,
-    },
+    ssh_options: sshEnabled
+      ? {
+          enabled: true,
+          host: sshHost,
+          port: sshPort,
+          user: sshUser,
+        }
+      : {},
   }
 }
 
@@ -247,12 +249,14 @@ const getDremioSqlAlchemyInput = ({
     url: url.href,
     params: {},
     param_style: 'pyformat',
-    ssh_options: {
-      enabled: sshEnabled == null ? undefined : String(sshEnabled),
-      host: sshHost,
-      port: sshPort,
-      user: sshUser,
-    },
+    ssh_options: sshEnabled
+      ? {
+          enabled: true,
+          host: sshHost,
+          port: sshPort,
+          user: sshUser,
+        }
+      : {},
   }
 }
 
@@ -272,12 +276,14 @@ const getSQLServerVar = ({
     url: `mssql+pymssql://${encodeURIComponent(user)}:${encodeURIComponent(password)}@${host}${portSuffix}/${database}`,
     params: {},
     param_style: 'pyformat',
-    ssh_options: {
-      enabled: sshEnabled == null ? undefined : String(sshEnabled),
-      host: sshHost,
-      port: sshPort,
-      user: sshUser,
-    },
+    ssh_options: sshEnabled
+      ? {
+          enabled: true,
+          host: sshHost,
+          port: sshPort,
+          user: sshUser,
+        }
+      : {},
   }
 }
 
@@ -322,12 +328,14 @@ const getPostgresSqlAlchemyInput = (
       },
     },
     param_style: 'pyformat',
-    ssh_options: {
-      enabled: sshEnabled == null ? undefined : String(sshEnabled),
-      host: sshHost,
-      port: sshPort,
-      user: sshUser,
-    },
+    ssh_options: sshEnabled
+      ? {
+          enabled: true,
+          host: sshHost,
+          port: sshPort,
+          user: sshUser,
+        }
+      : {},
   }
 }
 
@@ -370,12 +378,14 @@ export const getRedshiftSqlAlchemyInput = (
       },
     },
     param_style: 'pyformat',
-    ssh_options: {
-      enabled: metadata.sshEnabled == null ? undefined : String(metadata.sshEnabled),
-      host: metadata.sshHost,
-      port: metadata.sshPort,
-      user: metadata.sshUser,
-    },
+    ssh_options: metadata.sshEnabled
+      ? {
+          enabled: true,
+          host: metadata.sshHost,
+          port: metadata.sshPort,
+          user: metadata.sshUser,
+        }
+      : {},
   }
 
   if (metadata.authMethod === AwsAuthMethods.IamRole && metadata.roleArn && metadata.roleExternalId) {
@@ -436,12 +446,14 @@ const getMaterializePostgresSqlAlchemyInput = (
       },
     },
     param_style: 'pyformat',
-    ssh_options: {
-      enabled: sshEnabled == null ? undefined : String(sshEnabled),
-      host: sshHost,
-      port: sshPort,
-      user: sshUser,
-    },
+    ssh_options: sshEnabled
+      ? {
+          enabled: true,
+          host: sshHost,
+          port: sshPort,
+          user: sshUser,
+        }
+      : {},
   }
 }
 
@@ -553,12 +565,14 @@ const getClickHouseSqlAlchemyInput = (
     url,
     params: {},
     param_style: 'pyformat',
-    ssh_options: {
-      enabled: sshEnabled == null ? undefined : String(sshEnabled),
-      host: sshHost,
-      port: sshPort,
-      user: sshUser,
-    },
+    ssh_options: sshEnabled
+      ? {
+          enabled: true,
+          host: sshHost,
+          port: sshPort,
+          user: sshUser,
+        }
+      : {},
   }
 
   return env
@@ -678,12 +692,14 @@ const getMySqlSqlAlchemyInput = (
       },
     },
     param_style: 'pyformat',
-    ssh_options: {
-      enabled: sshEnabled == null ? undefined : String(sshEnabled),
-      host: sshHost,
-      port: sshPort,
-      user: sshUser,
-    },
+    ssh_options: sshEnabled
+      ? {
+          enabled: true,
+          host: sshHost,
+          port: sshPort,
+          user: sshUser,
+        }
+      : {},
   }
 }
 

--- a/packages/database-integrations/src/sql-alchemy-types.ts
+++ b/packages/database-integrations/src/sql-alchemy-types.ts
@@ -6,7 +6,7 @@ export interface SqlAlchemyInput {
   params: Record<string, unknown>
   param_style: ParamStyle
   ssh_options?: {
-    enabled?: string | undefined
+    enabled?: boolean | undefined
     host?: string | undefined
     port?: string | undefined
     user?: string | undefined


### PR DESCRIPTION
We did not extract the SSH part of the SQL Alchemy input logic correctly - the `enabled` flag should have a boolean value, not a stringified one. `enabled: 'false'` was leading to the following error:

<img width="1756" height="393" alt="Screenshot 2025-11-07 at 13 48 28" src="https://github.com/user-attachments/assets/bab3caf9-9e98-449e-81b4-2538a6869795" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed SSH configuration handling across all database integrations by correcting the enabled flag data type from string to boolean, ensuring proper type consistency and optimizing the configuration structure to only include SSH settings when actively enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->