### PR TITLE
fix(database-integrations): support legacy bigquery integrations with no auth method

### DIFF
--- a/packages/database-integrations/src/database-integration-metadata-schemas.test.ts
+++ b/packages/database-integrations/src/database-integration-metadata-schemas.test.ts
@@ -82,12 +82,12 @@ describe('SQL integration metadata schemas', () => {
       })
     })
 
-    it('should fail on metadata with auth method field missing', () => {
+    it('should not fail on metadata with auth method field missing', () => {
       const result = databaseMetadataSchemasByType['big-query'].safeParse({
         service_account: 'my-service-account',
       })
 
-      expect(result.success).toBe(false)
+      expect(result.success).toBe(true)
     })
 
     it('should fail on metadata with null auth method', () => {

--- a/packages/database-integrations/src/database-integration-metadata-schemas.ts
+++ b/packages/database-integrations/src/database-integration-metadata-schemas.ts
@@ -18,7 +18,8 @@ const athenaMetadataSchema = z.object({
 
 const bigqueryMetadataSchema = z.discriminatedUnion('authMethod', [
   z.object({
-    authMethod: z.literal(BigQueryAuthMethods.ServiceAccount),
+    // Legacy integrations may not have an authMethod, so we make it optional.
+    authMethod: z.literal(BigQueryAuthMethods.ServiceAccount).optional(),
     service_account: z.string(),
   }),
   z.object({

--- a/packages/database-integrations/src/sql-integration-auth-methods.test.ts
+++ b/packages/database-integrations/src/sql-integration-auth-methods.test.ts
@@ -122,5 +122,9 @@ describe('Auth methods', () => {
     it('should not claim metadata with any Trino non-federated auth methods is federated', () => {
       expect(isFederatedAuthMetadata({ authMethod: TrinoAuthMethods.Password })).toBe(false)
     })
+
+    it('should return false when authMethod is undefined', () => {
+      expect(isFederatedAuthMetadata({ authMethod: undefined })).toBe(false)
+    })
   })
 })

--- a/packages/database-integrations/src/sql-integration-auth-methods.ts
+++ b/packages/database-integrations/src/sql-integration-auth-methods.ts
@@ -53,8 +53,8 @@ export function isFederatedAuthMethod(authMethod: string): authMethod is Federat
   return federatedAuthMethods.includes(authMethod as FederatedAuthMethod)
 }
 
-export function isFederatedAuthMetadata<M extends { authMethod: string }>(
+export function isFederatedAuthMetadata<M extends { authMethod?: string }>(
   metadata: M
 ): metadata is Extract<M, { authMethod: FederatedAuthMethod }> {
-  return isFederatedAuthMethod(metadata.authMethod)
+  return metadata.authMethod !== undefined && isFederatedAuthMethod(metadata.authMethod)
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * BigQuery integrations now support metadata configurations with optional authentication method fields, enabling more flexible setup scenarios.

* **Tests**
  * Added validation tests for BigQuery service account authentication handling.
  * Updated tests to reflect new optional authentication method behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->