### PR TITLE
docs: add build instructions for local development in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,6 +49,16 @@ pnpm install
 
 This will install all dependencies for the monorepo and its packages.
 
+### Build packages
+
+After installing dependencies, build all packages to ensure they're ready for development and testing:
+
+```bash
+pnpm build
+```
+
+This compiles TypeScript packages and generates output files. **This step is required before running tests** to avoid resolution errors, as packages reference each other through their compiled `dist/` directories.
+
 ---
 
 ## 🧪 Testing


### PR DESCRIPTION
Added build instructions for local development in CONTRIBUTING.md because it is required before running tests to avoid resolution errors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated local development guidelines with a new build step, explaining how to compile TypeScript packages using pnpm, where compiled files are output, and that this step is required before running tests.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->