### PR TITLE
chore(ci): Update CI workflow to run multiple Node.js versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,8 +113,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: &node_versions
-          # Pinned version from .nvmrc for deterministic local/CI behavior
+        node-version:
+          &node_versions # Pinned version from .nvmrc for deterministic local/CI behavior
           - 'nvmrc'
           # Test compatibility with newer major versions
           - '22'


### PR DESCRIPTION
Fixes https://github.com/deepnote/deepnote/issues/152

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI pipeline updated with a Node.js version matrix (including a pinned version from config plus multiple numbered versions), job names now reflect Node version, and Build/Test timeouts increased for greater reliability.
  * Node setup now handles pinned vs explicit versions, and coverage upload is restricted to the pinned Node version to avoid duplication.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->