### PR TITLE
feat(schema): make contentHash prefix optional

### DIFF
--- a/packages/blocks/package.json
+++ b/packages/blocks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@deepnote/blocks",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "",
   "keywords": [],
   "repository": {

--- a/packages/blocks/src/deserialize-file/deepnote-file-schema.ts
+++ b/packages/blocks/src/deserialize-file/deepnote-file-schema.ts
@@ -65,7 +65,7 @@ const baseBlockFields = {
   sortingKey: z.string(),
   contentHash: z
     .string()
-    .regex(/^(md5|sha256):[a-f0-9]+$/i)
+    .regex(/^([a-z0-9]+:)?[a-f0-9]+$/i)
     .optional(),
   version: z.number().optional(),
 }


### PR DESCRIPTION
## Summary
- Updated the `contentHash` regex from `/^(md5|sha256):[a-f0-9]+$/i` to `/^([a-z0-9]+:)?[a-f0-9]+$/i` to make the prefix optional
- Added comprehensive tests for contentHash validation covering prefixed hashes, plain hex strings, and invalid inputs

## Test plan
- [x] Existing tests pass (backward compatibility with `md5:` and `sha256:` prefixes)
- [x] New tests verify plain hex strings without prefix are accepted
- [x] New tests verify other prefixes (e.g., `blake2:`) are accepted
- [x] New tests verify invalid formats are rejected

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced file hash validation to support additional hash algorithm formats beyond previously supported types.

* **Chores**
  * Version bump to 3.0.1.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->