### PR TITLE
fix(@deepnote/convert): add dual ESM/CJS support

### DIFF
--- a/packages/convert/package.json
+++ b/packages/convert/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@deepnote/convert",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "",
   "keywords": [],
   "repository": {


### PR DESCRIPTION
## Summary
- Add CommonJS output to `@deepnote/convert` to support CJS consumers
- Align package exports configuration with other packages in the monorepo (`@deepnote/blocks`, `@deepnote/database-integrations`, `@deepnote/reactivity`)

## Problem
The package was ESM-only, causing import errors in CommonJS environments:
```
SyntaxError: Cannot use import statement outside a module
```

## Solution
- Updated build script to output both ESM (`.js`) and CJS (`.cjs`) formats
- Added `require` condition to package exports
- Set `main` to CJS entry point for Node.js CJS resolution
- Added `module` field for bundler ESM resolution


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package configuration to properly support both CommonJS and ES Module imports with explicit export mappings.
  * Enhanced type definitions accessibility in package exports.
  * Optimized build system to generate both module formats.
  * Bumped version to 2.1.1.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->