### PR TITLE
feat(@deepnote/mcp): optimize tool invocations and token usage

### DIFF
--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -105,6 +105,7 @@ export function createServer(): Server {
       }
 
       if (
+        name === 'deepnote_read' ||
         name.startsWith('deepnote_inspect') ||
         name.startsWith('deepnote_cat') ||
         name.startsWith('deepnote_lint') ||

--- a/packages/mcp/src/tools/reading.test.ts
+++ b/packages/mcp/src/tools/reading.test.ts
@@ -1,0 +1,193 @@
+import * as fs from 'node:fs/promises'
+import * as os from 'node:os'
+import * as path from 'node:path'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { handleMagicTool } from './magic'
+import { handleReadingTool } from './reading'
+
+// Helper to extract result from MCP response
+function extractResult(response: { content: Array<{ type: string; text: string }> }): Record<string, unknown> {
+  return JSON.parse(response.content[0].text)
+}
+
+describe('reading tools handlers', () => {
+  let tempDir: string
+  let testNotebookPath: string
+
+  beforeEach(async () => {
+    tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'mcp-reading-test-'))
+
+    // Create a test notebook for reading tests
+    testNotebookPath = path.join(tempDir, 'test.deepnote')
+    await handleMagicTool('deepnote_scaffold', {
+      description: 'Test notebook with data analysis',
+      outputPath: testNotebookPath,
+    })
+  })
+
+  afterEach(async () => {
+    await fs.rm(tempDir, { recursive: true, force: true })
+  })
+
+  describe('deepnote_read', () => {
+    it('returns structure by default', async () => {
+      const response = await handleReadingTool('deepnote_read', {
+        path: testNotebookPath,
+      })
+
+      const result = extractResult(response)
+      expect(result.path).toBe(testNotebookPath)
+      expect(result.structure).toBeDefined()
+      expect(result.stats).toBeUndefined()
+      expect(result.lint).toBeUndefined()
+      expect(result.dag).toBeUndefined()
+    })
+
+    it('includes stats when requested', async () => {
+      const response = await handleReadingTool('deepnote_read', {
+        path: testNotebookPath,
+        include: ['stats'],
+      })
+
+      const result = extractResult(response)
+      expect(result.stats).toBeDefined()
+      const stats = result.stats as Record<string, unknown>
+      expect(stats.totalLines).toBeDefined()
+      expect(stats.importCount).toBeDefined()
+    })
+
+    it('includes lint when requested', async () => {
+      const response = await handleReadingTool('deepnote_read', {
+        path: testNotebookPath,
+        include: ['lint'],
+      })
+
+      const result = extractResult(response)
+      expect(result.lint).toBeDefined()
+      const lint = result.lint as Record<string, unknown>
+      expect(lint.issueCount).toBeDefined()
+    })
+
+    it('includes dag when requested', async () => {
+      const response = await handleReadingTool('deepnote_read', {
+        path: testNotebookPath,
+        include: ['dag'],
+      })
+
+      const result = extractResult(response)
+      expect(result.dag).toBeDefined()
+      expect(Array.isArray(result.dag)).toBe(true)
+    })
+
+    it('includes all sections when all is specified', async () => {
+      const response = await handleReadingTool('deepnote_read', {
+        path: testNotebookPath,
+        include: ['all'],
+      })
+
+      const result = extractResult(response)
+      expect(result.structure).toBeDefined()
+      expect(result.stats).toBeDefined()
+      expect(result.lint).toBeDefined()
+      expect(result.dag).toBeDefined()
+    })
+
+    it('combines multiple includes', async () => {
+      const response = await handleReadingTool('deepnote_read', {
+        path: testNotebookPath,
+        include: ['structure', 'stats'],
+      })
+
+      const result = extractResult(response)
+      expect(result.structure).toBeDefined()
+      expect(result.stats).toBeDefined()
+      expect(result.lint).toBeUndefined()
+      expect(result.dag).toBeUndefined()
+    })
+
+    it('supports compact mode', async () => {
+      const response = await handleReadingTool('deepnote_read', {
+        path: testNotebookPath,
+        include: ['structure'],
+        compact: true,
+      })
+
+      // Compact mode should not have pretty-printed JSON (no newlines)
+      expect(response.content[0].text).not.toContain('\n')
+      const result = extractResult(response)
+      expect(result.path).toBe(testNotebookPath)
+    })
+
+    it('structure includes project info', async () => {
+      const response = await handleReadingTool('deepnote_read', {
+        path: testNotebookPath,
+        include: ['structure'],
+      })
+
+      const result = extractResult(response)
+      const structure = result.structure as Record<string, unknown>
+      expect(structure.projectName).toBeDefined()
+      expect(structure.projectId).toBeDefined()
+      expect(structure.notebooks).toBeDefined()
+      expect(structure.totalBlocks).toBeDefined()
+      expect(structure.blockCounts).toBeDefined()
+    })
+  })
+
+  describe('deepnote_inspect', () => {
+    it('returns notebook metadata', async () => {
+      const response = await handleReadingTool('deepnote_inspect', {
+        path: testNotebookPath,
+      })
+
+      const result = extractResult(response)
+      expect(result.projectName).toBeDefined()
+      expect(result.notebooks).toBeDefined()
+      expect(result.totalBlocks).toBeDefined()
+    })
+  })
+
+  describe('deepnote_lint', () => {
+    it('returns lint issues', async () => {
+      const response = await handleReadingTool('deepnote_lint', {
+        path: testNotebookPath,
+      })
+
+      const result = extractResult(response)
+      expect(result.issueCount).toBeDefined()
+      expect(Array.isArray(result.issues)).toBe(true)
+    })
+  })
+
+  describe('deepnote_stats', () => {
+    it('returns statistics', async () => {
+      const response = await handleReadingTool('deepnote_stats', {
+        path: testNotebookPath,
+      })
+
+      const result = extractResult(response)
+      expect(result.totalLines).toBeDefined()
+      expect(result.importCount).toBeDefined()
+      expect(Array.isArray(result.uniqueImports)).toBe(true)
+    })
+  })
+
+  describe('error handling', () => {
+    it('returns error for unknown tool', async () => {
+      const response = (await handleReadingTool('deepnote_unknown', {})) as {
+        content: Array<{ type: string; text: string }>
+        isError?: boolean
+      }
+      expect(response.isError).toBe(true)
+      expect(response.content[0].text).toContain('Unknown reading tool')
+    })
+
+    it('throws for nonexistent file', async () => {
+      await expect(
+        handleReadingTool('deepnote_read', {
+          path: '/nonexistent/path.deepnote',
+        })
+      ).rejects.toThrow()
+    })
+  })
+})

--- a/packages/mcp/src/tools/tools.test.ts
+++ b/packages/mcp/src/tools/tools.test.ts
@@ -67,6 +67,7 @@ describe('MCP tools definitions', () => {
   describe('reading tools', () => {
     it('has expected tools', () => {
       const names = readingTools.map(t => t.name)
+      expect(names).toContain('deepnote_read')
       expect(names).toContain('deepnote_inspect')
       expect(names).toContain('deepnote_cat')
       expect(names).toContain('deepnote_lint')
@@ -84,6 +85,7 @@ describe('MCP tools definitions', () => {
 
     it('all reading tools require path parameter', () => {
       const pathRequiredTools = [
+        'deepnote_read',
         'deepnote_inspect',
         'deepnote_cat',
         'deepnote_lint',
@@ -97,6 +99,24 @@ describe('MCP tools definitions', () => {
         expect(schema?.properties?.path).toBeDefined()
         expect(schema?.required).toContain('path')
       }
+    })
+
+    it('deepnote_read supports include parameter', () => {
+      const tool = readingTools.find(t => t.name === 'deepnote_read')
+      const schema = tool?.inputSchema as InputSchema
+      expect(schema?.properties?.include).toBeDefined()
+      expect(schema?.properties?.include?.items?.enum).toContain('structure')
+      expect(schema?.properties?.include?.items?.enum).toContain('stats')
+      expect(schema?.properties?.include?.items?.enum).toContain('lint')
+      expect(schema?.properties?.include?.items?.enum).toContain('dag')
+      expect(schema?.properties?.include?.items?.enum).toContain('all')
+    })
+
+    it('deepnote_read supports compact parameter', () => {
+      const tool = readingTools.find(t => t.name === 'deepnote_read')
+      const schema = tool?.inputSchema as InputSchema
+      expect(schema?.properties?.compact).toBeDefined()
+      expect(schema?.properties?.compact?.type).toBe('boolean')
     })
   })
 
@@ -169,6 +189,20 @@ describe('MCP tools definitions', () => {
         expect(tool.annotations?.idempotentHint).toBe(false)
       }
     })
+
+    it('deepnote_run supports includeOutputSummary parameter', () => {
+      const tool = executionTools.find(t => t.name === 'deepnote_run')
+      const schema = tool?.inputSchema as InputSchema
+      expect(schema?.properties?.includeOutputSummary).toBeDefined()
+      expect(schema?.properties?.includeOutputSummary?.type).toBe('boolean')
+    })
+
+    it('deepnote_run supports compact parameter', () => {
+      const tool = executionTools.find(t => t.name === 'deepnote_run')
+      const schema = tool?.inputSchema as InputSchema
+      expect(schema?.properties?.compact).toBeDefined()
+      expect(schema?.properties?.compact?.type).toBe('boolean')
+    })
   })
 
   describe('magic tools', () => {
@@ -215,10 +249,30 @@ describe('MCP tools definitions', () => {
       expect(enhancements?.items?.enum).toContain('all')
     })
 
-    it('workflow tool requires steps parameter', () => {
+    it('workflow tool supports preset parameter', () => {
       const tool = magicTools.find(t => t.name === 'deepnote_workflow')
       const schema = tool?.inputSchema as InputSchema
-      expect(schema?.required).toContain('steps')
+      expect(schema?.properties?.preset).toBeDefined()
+      expect(schema?.properties?.preset?.enum).toContain('quickstart')
+      expect(schema?.properties?.preset?.enum).toContain('import')
+      expect(schema?.properties?.preset?.enum).toContain('polish')
+    })
+
+    it('workflow tool supports compact parameter', () => {
+      const tool = magicTools.find(t => t.name === 'deepnote_workflow')
+      const schema = tool?.inputSchema as InputSchema
+      expect(schema?.properties?.compact).toBeDefined()
+      expect(schema?.properties?.compact?.type).toBe('boolean')
+    })
+
+    it('magic tools with compact support have the parameter', () => {
+      const compactTools = ['deepnote_scaffold', 'deepnote_enhance', 'deepnote_fix', 'deepnote_suggest']
+      for (const name of compactTools) {
+        const tool = magicTools.find(t => t.name === name)
+        const schema = tool?.inputSchema as InputSchema
+        expect(schema?.properties?.compact).toBeDefined()
+        expect(schema?.properties?.compact?.type).toBe('boolean')
+      }
     })
   })
 
@@ -288,13 +342,13 @@ describe('MCP tools definitions', () => {
 
   describe('total tool count', () => {
     it('has correct number of tools', () => {
-      expect(readingTools.length).toBe(8) // Added validate
+      expect(readingTools.length).toBe(9) // Added validate and deepnote_read
       expect(writingTools.length).toBe(7)
       expect(conversionTools.length).toBe(3)
       expect(executionTools.length).toBe(3) // Added open
       expect(magicTools.length).toBe(10)
       expect(snapshotTools.length).toBe(4)
-      expect(allTools.length).toBe(35)
+      expect(allTools.length).toBe(36)
     })
   })
 })


### PR DESCRIPTION
Reduce tool calls and token usage by:
- Add includeOutputSummary to deepnote_run (default: true) to inline truncated block outputs, eliminating need for snapshot_load in most cases
- Add unified deepnote_read tool that combines inspect/stats/lint/dag operations with configurable include parameter
- Add compact output mode to key tools for minimal JSON formatting
- Add workflow presets (quickstart, import, polish) to deepnote_workflow for common multi-step operations in a single call
- Shorten verbose tool descriptions to reduce system prompt tokens

Changes:
- packages/mcp/src/tools/execution.ts: Add includeOutputSummary, compact params
- packages/mcp/src/tools/reading.ts: Add deepnote_read, formatOutput helper
- packages/mcp/src/tools/magic.ts: Add presets to workflow, compact to tools
- packages/mcp/src/server.ts: Route deepnote_read to reading handler
- Add reading.test.ts and update tools.test.ts, magic.test.ts with new tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added unified "Read Notebook" tool for comprehensive notebook analysis with filtering options.
  * Introduced compact output mode across all tools for reduced verbosity and streamlined results.
  * Added workflow presets (quickstart, polish) for common automation patterns.
  * Enhanced execution results with optional output summaries and improved formatting.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->