### PR TITLE
fix(@deepnote/cli): mock saveExecutionSnapshot

### DIFF
--- a/packages/cli/src/commands/run.test.ts
+++ b/packages/cli/src/commands/run.test.ts
@@ -2,7 +2,8 @@ import fs from 'node:fs'
 import os from 'node:os'
 import { join } from 'node:path'
 import { Command } from 'commander'
-import { afterEach, beforeEach, describe, expect, it, type Mock, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, type Mock, type MockedFunction, vi } from 'vitest'
+import type { saveExecutionSnapshot } from '../utils/output-persistence'
 
 // Create mock engine functions
 const mockStart = vi.fn()
@@ -50,12 +51,14 @@ vi.mock('../utils/open-file-in-cloud', () => ({
 }))
 
 // Mock saveExecutionSnapshot to prevent writing to real files during tests
-const mockSaveExecutionSnapshot = vi.fn().mockResolvedValue({ snapshotPath: '/mock/snapshot.snapshot.deepnote' })
+const mockSaveExecutionSnapshot: MockedFunction<typeof saveExecutionSnapshot> = vi
+  .fn()
+  .mockResolvedValue({ snapshotPath: '/mock/snapshot.snapshot.deepnote' })
 vi.mock('../utils/output-persistence', async importOriginal => {
   const actual = await importOriginal<typeof import('../utils/output-persistence')>()
   return {
     ...actual,
-    saveExecutionSnapshot: (...args: unknown[]) => mockSaveExecutionSnapshot(...args),
+    saveExecutionSnapshot: (...args: Parameters<typeof saveExecutionSnapshot>) => mockSaveExecutionSnapshot(...args),
   }
 })
 


### PR DESCRIPTION
The `run.test.ts` tests were writing to real snapshot files in `examples/snapshots/` because `saveExecutionSnapshot` wasn't mocked, causing it to save (empty) execution outputs to disk whenever tests ran against the real example files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved test isolation by mocking snapshot persistence to avoid real file writes and ensure consistent, deterministic snapshot paths across runs; added resets before relevant tests to maintain stable mock behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->