### PR TITLE
fix: override ajv to >=8.18.0 to fix ReDoS vulnerability (GHSA-2g4f-4pwh-qvx6)

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
   "pnpm": {
     "overrides": {
       "@isaacs/brace-expansion": ">=5.0.1",
+      "ajv": ">=8.18.0",
       "diff": ">=8.0.3",
       "glob": ">=11.1.0",
       "lodash@<4.17.23": "^4.17.23",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,6 +9,7 @@ overrides:
   diff: '>=8.0.3'
   glob: '>=11.1.0'
   lodash@<4.17.23: ^4.17.23
+  ajv: '>=8.18.0'
   lodash-es@<4.17.23: ^4.17.23
 
 importers:
@@ -1257,13 +1258,13 @@ packages:
   ajv-formats@3.0.1:
     resolution: {integrity: sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==}
     peerDependencies:
-      ajv: ^8.0.0
+      ajv: '>=8.18.0'
     peerDependenciesMeta:
       ajv:
         optional: true
 
-  ajv@8.17.1:
-    resolution: {integrity: sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==}
+  ajv@8.18.0:
+    resolution: {integrity: sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==}
 
   ansi-escapes@7.1.1:
     resolution: {integrity: sha512-Zhl0ErHcSRUaVfGUeUdDuLgpkEo8KIFjB4Y9uAc46ScOpdDiU1Dbyplh7qWJeJ/ZHpbyMSM26+X3BySgnIz40Q==}
@@ -3261,7 +3262,7 @@ snapshots:
       '@lumino/disposable': 2.1.5
       '@lumino/signaling': 2.1.5
       '@rjsf/utils': 5.24.13(react@19.2.3)
-      ajv: 8.17.1
+      ajv: 8.18.0
       json5: 2.2.3
       react: 19.2.3
 
@@ -3317,8 +3318,8 @@ snapshots:
   '@modelcontextprotocol/sdk@1.26.0(zod@3.25.76)':
     dependencies:
       '@hono/node-server': 1.19.9(hono@4.11.9)
-      ajv: 8.17.1
-      ajv-formats: 3.0.1(ajv@8.17.1)
+      ajv: 8.18.0
+      ajv-formats: 3.0.1(ajv@8.18.0)
       content-type: 1.0.5
       cors: 2.8.6
       cross-spawn: 7.0.6
@@ -3617,11 +3618,11 @@ snapshots:
       mime-types: 3.0.2
       negotiator: 1.0.0
 
-  ajv-formats@3.0.1(ajv@8.17.1):
+  ajv-formats@3.0.1(ajv@8.18.0):
     optionalDependencies:
-      ajv: 8.17.1
+      ajv: 8.18.0
 
-  ajv@8.17.1:
+  ajv@8.18.0:
     dependencies:
       fast-deep-equal: 3.1.3
       fast-uri: 3.1.0


### PR DESCRIPTION
ajv <=8.17.1 is vulnerable to Regular Expression Denial of Service when the $data option is enabled. The pattern keyword accepts runtime data via JSON Pointer syntax, which is passed directly to the RegExp constructor without validation. An attacker can inject a malicious regex pattern combined with crafted input to cause catastrophic backtracking — a 31-character payload blocks the CPU for ~44 seconds, doubling with each additional character.

ajv is a transitive dependency pulled in by @jupyterlab/settingregistry and @modelcontextprotocol/sdk, so a pnpm override is used to force all instances to the patched version.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package dependency constraints to ensure system stability and compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->