### PR TITLE
chore: bump minor versions for blocks, cli, mcp, and convert

### DIFF
--- a/packages/blocks/package.json
+++ b/packages/blocks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@deepnote/blocks",
-  "version": "4.2.0",
+  "version": "4.3.0",
   "description": "",
   "keywords": [],
   "repository": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@deepnote/cli",
-  "version": "0.1.4",
+  "version": "0.2.0",
   "description": "Command-line interface for running Deepnote projects locally and on Deepnote Cloud",
   "keywords": [
     "cli",

--- a/packages/convert/package.json
+++ b/packages/convert/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@deepnote/convert",
-  "version": "3.1.1",
+  "version": "3.2.0",
   "description": "",
   "keywords": [],
   "repository": {

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@deepnote/mcp",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "description": "MCP server for AI-assisted Deepnote notebook creation and manipulation",
   "keywords": [
     "mcp",


### PR DESCRIPTION
## Summary
- Bump `@deepnote/blocks` from 4.2.0 to 4.3.0
- Bump `@deepnote/cli` from 0.1.4 to 0.2.0
- Bump `@deepnote/mcp` from 0.1.1 to 0.2.0
- Bump `@deepnote/convert` from 3.1.1 to 3.2.0
