### PR TITLE
feat(@deepnote/cli): show better imports in analyze command

### DIFF
--- a/packages/cli/src/commands/analyze.test.ts
+++ b/packages/cli/src/commands/analyze.test.ts
@@ -113,7 +113,6 @@ describe('analyze command', () => {
 
       const result = outputJsonSpy.mock.calls[0][0]
       expect(Array.isArray(result.dependencies.imports)).toBe(true)
-      expect(result.dependencies.packageAliases).toBeDefined()
       expect(Array.isArray(result.dependencies.missingIntegrations)).toBe(true)
     })
 

--- a/packages/cli/src/commands/analyze.ts
+++ b/packages/cli/src/commands/analyze.ts
@@ -42,7 +42,6 @@ interface AnalyzeResult {
   }
   dependencies: {
     imports: string[]
-    packageAliases: Record<string, string>
     missingIntegrations: string[]
   }
   suggestions: string[]
@@ -158,7 +157,6 @@ function buildAnalyzeResult(path: string, analysis: AnalysisResult, blockMap: Ma
     },
     dependencies: {
       imports: stats.imports,
-      packageAliases: stats.packageAliases,
       missingIntegrations: lint.integrations?.missing ?? [],
     },
     suggestions,
@@ -336,11 +334,7 @@ function outputAnalysis(result: AnalyzeResult, options: AnalyzeOptions): void {
   if (result.dependencies.imports.length > 0 || result.dependencies.missingIntegrations.length > 0) {
     output(c.bold('Dependencies'))
     if (result.dependencies.imports.length > 0) {
-      const formatted = result.dependencies.imports.map(pkg => {
-        const alias = result.dependencies.packageAliases[pkg]
-        return alias ? `${pkg} ${c.dim(`(as ${alias})`)}` : pkg
-      })
-      output(`  ${c.dim('Imports:')} ${formatted.join(', ')}`)
+      output(`  ${c.dim('Imports:')} ${result.dependencies.imports.join(', ')}`)
     }
     if (result.dependencies.missingIntegrations.length > 0) {
       output(`  ${c.red('Missing:')} ${result.dependencies.missingIntegrations.join(', ')}`)

--- a/packages/cli/src/commands/stats.test.ts
+++ b/packages/cli/src/commands/stats.test.ts
@@ -90,7 +90,6 @@ describe('stats command', () => {
       const output = getOutput(consoleSpy)
       expect(output).toContain('Imports')
       expect(output).toContain('pandas')
-      expect(output).toContain('(as pd)')
     })
   })
 
@@ -124,7 +123,6 @@ describe('stats command', () => {
       expect(parsed.blockTypesSummary).toBeDefined()
       expect(parsed.notebooks).toBeDefined()
       expect(parsed.imports).toBeDefined()
-      expect(parsed.packageAliases).toBeDefined()
     })
 
     it('includes notebook details', async () => {
@@ -334,7 +332,6 @@ describe('stats command', () => {
 
       expect(Array.isArray(parsed.imports)).toBe(true)
       expect(parsed.imports).toContain('pandas')
-      expect(parsed.packageAliases).toEqual(expect.objectContaining({ pandas: 'pd' }))
     })
   })
 

--- a/packages/cli/src/commands/stats.ts
+++ b/packages/cli/src/commands/stats.ts
@@ -85,11 +85,7 @@ function outputStats(stats: StatsFileResult, options: StatsOptions): void {
   // Imports
   if (stats.imports.length > 0) {
     output(c.bold('Imports'))
-    const formatted = stats.imports.map(pkg => {
-      const alias = stats.packageAliases[pkg]
-      return alias ? `${pkg} ${c.dim(`(as ${alias})`)}` : pkg
-    })
-    output(`  ${formatted.join(', ')}`)
+    output(`  ${stats.imports.join(', ')}`)
     output('')
   }
 

--- a/packages/cli/src/utils/analysis.test.ts
+++ b/packages/cli/src/utils/analysis.test.ts
@@ -197,8 +197,6 @@ describe('analysis utilities', () => {
       expect(result.stats.imports).toContain('numpy')
       expect(result.stats.imports).toContain('sklearn')
       expect(result.stats.imports).toHaveLength(3)
-
-      expect(result.stats.packageAliases).toEqual({ pandas: 'pd', numpy: 'np' })
     })
   })
 

--- a/packages/cli/src/utils/analysis.ts
+++ b/packages/cli/src/utils/analysis.ts
@@ -73,7 +73,6 @@ export interface ProjectStats {
   blockTypesSummary: BlockTypeStats[]
   notebooks: NotebookStats[]
   imports: string[]
-  packageAliases: Record<string, string>
 }
 
 export interface BlockInfo {
@@ -117,9 +116,8 @@ export async function analyzeProject(file: DeepnoteFile, options: AnalysisOption
   const { lint, dag } = await checkForIssues(file, options)
 
   const imports = extractImportsFromDag(dag)
-  const packageAliases = extractPackageAliasesFromDag(dag)
 
-  return { stats: { ...stats, imports, packageAliases }, lint, dag }
+  return { stats: { ...stats, imports }, lint, dag }
 }
 
 /**
@@ -181,7 +179,6 @@ export function computeProjectStats(file: DeepnoteFile, options: AnalysisOptions
     notebooks,
     // Imports are populated by analyzeProject using DAG analysis for accuracy
     imports: [],
-    packageAliases: {},
   }
 }
 
@@ -744,24 +741,6 @@ function extractImportsFromDag(dag: BlockDependencyDag): string[] {
     }
   }
   return Array.from(imports).sort()
-}
-
-/**
- * Extract package-to-alias mapping from DAG nodes.
- * Only includes explicit "as" renames (e.g. pandas → pd from "import pandas as pd").
- */
-function extractPackageAliasesFromDag(dag: BlockDependencyDag): Record<string, string> {
-  const unsorted: Record<string, string> = {}
-  for (const node of dag.nodes) {
-    for (const [pkg, alias] of Object.entries(node.packageAliases ?? {})) {
-      unsorted[pkg] = alias
-    }
-  }
-  const result: Record<string, string> = {}
-  for (const key of Object.keys(unsorted).sort()) {
-    result[key] = unsorted[key]
-  }
-  return result
 }
 
 // ============================================================================

--- a/packages/reactivity/src/ast-analyzer.ts
+++ b/packages/reactivity/src/ast-analyzer.ts
@@ -41,7 +41,6 @@ export interface BlockContentDepsWithOrder {
   usedVariables: string[]
   importedModules?: string[]
   importedPackages?: string[]
-  packageAliases?: Record<string, string>
   linesOfCode?: number
   error?: {
     type: string
@@ -59,7 +58,6 @@ const AstAnalyzerItemSchema = z.object({
   usedVariables: z.array(z.string()),
   importedModules: z.array(z.string()).optional(),
   importedPackages: z.array(z.string()).optional(),
-  packageAliases: z.record(z.string()).optional(),
   linesOfCode: z.number().optional(),
   error: z
     .object({

--- a/packages/reactivity/src/dag-builder.test.ts
+++ b/packages/reactivity/src/dag-builder.test.ts
@@ -184,7 +184,6 @@ describe('buildDagFromBlocks', () => {
       inputVariables: ['other_var'],
       importedModules: [],
       importedPackages: [],
-      packageAliases: {},
       order: 2,
       outputVariables: ['x'],
       usedImportedModules: ['numpy'],
@@ -192,7 +191,7 @@ describe('buildDagFromBlocks', () => {
     })
   })
 
-  it('should pass through package metadata fields', () => {
+  it('should pass through importedPackages field', () => {
     const blocks = [
       {
         id: '1',
@@ -200,7 +199,6 @@ describe('buildDagFromBlocks', () => {
         usedVariables: [],
         importedModules: ['pd'],
         importedPackages: ['pandas'],
-        packageAliases: { pandas: 'pd' },
         order: 1,
       },
     ]
@@ -209,7 +207,6 @@ describe('buildDagFromBlocks', () => {
     const node = dag.nodes[0]
 
     expect(node.importedPackages).toEqual(['pandas'])
-    expect(node.packageAliases).toEqual({ pandas: 'pd' })
   })
 
   it('should include error information in nodes', () => {

--- a/packages/reactivity/src/dag-builder.ts
+++ b/packages/reactivity/src/dag-builder.ts
@@ -41,7 +41,6 @@ export function buildDagFromBlocks(blocks: BlockContentDepsWithOrder[]): BlockDe
       order: block.order,
       importedModules: block.importedModules ?? [],
       importedPackages: block.importedPackages ?? [],
-      packageAliases: block.packageAliases ?? {},
       outputVariables: [...block.definedVariables],
       usedImportedModules: block.usedImportedModules ?? [],
       error: block.error ?? null,

--- a/packages/reactivity/src/scripts/ast-analyzer.py
+++ b/packages/reactivity/src/scripts/ast-analyzer.py
@@ -17,7 +17,6 @@ class VariableVisitor(ast.NodeVisitor):
         self.used_global_vars = set()  # Variables used and defined globally
         self.imported_modules = set()  # Local names introduced by imports (aliases)
         self.imported_packages = set()  # Top-level package names from import sources
-        self.package_aliases = {}  # package -> alias for explicit "as" renames
         self.scope_stack = []  # Stack to track scopes
         self.function_globals = set()  # Global variables declared in current function
 
@@ -124,8 +123,6 @@ class VariableVisitor(ast.NodeVisitor):
             self.imported_modules.add(alias.asname or alias.name)
             top_level = alias.name.split(".")[0]
             self.imported_packages.add(top_level)
-            if alias.asname:
-                self.package_aliases[top_level] = alias.asname
 
     def visit_ImportFrom(self, node):
         for alias in node.names:
@@ -144,7 +141,6 @@ def get_defined_used_variables(block):
         visitor.used_global_vars,
         visitor.imported_modules,
         visitor.imported_packages,
-        visitor.package_aliases,
     )
 
 
@@ -255,7 +251,7 @@ def analyze_blocks(blocks):
             loc = count_lines_of_code(content)
 
             if block.get("type") == "code" or block.get("type") is None:
-                block_defined, block_used, block_imported, block_packages, block_pkg_aliases = get_defined_used_variables(
+                block_defined, block_used, block_imported, block_packages = get_defined_used_variables(
                     block
                 )
                 block_defined_list = list(block_defined)
@@ -273,7 +269,6 @@ def analyze_blocks(blocks):
                         "usedVariables": block_used_list,
                         "importedModules": block_imported_list,
                         "importedPackages": block_packages_list,
-                        "packageAliases": block_pkg_aliases,
                         "linesOfCode": loc,
                     }
                 )

--- a/packages/reactivity/src/types.ts
+++ b/packages/reactivity/src/types.ts
@@ -23,7 +23,6 @@ export interface DagNode {
   inputVariables: string[]
   importedModules: string[]
   importedPackages?: string[]
-  packageAliases?: Record<string, string>
   order: number
   outputVariables: string[]
   usedImportedModules: string[]


### PR DESCRIPTION

<img width="793" height="460" alt="Screenshot 2026-02-23 at 10 07 23" src="https://github.com/user-attachments/assets/861b54a3-f3d8-4413-a44b-7984cc0c659a" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Import analysis now extracts and tracks actual package names (e.g., pandas, numpy) rather than module aliases, improving visibility into project dependencies across CLI output and analysis reports.

* **Chores**
  * Bumped reactivity package version to 1.2.0.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->