### PR TITLE
chore: update GET /integrations with includeMetadata

### DIFF
--- a/packages/cli/src/integrations/fetch-integrations.test.ts
+++ b/packages/cli/src/integrations/fetch-integrations.test.ts
@@ -43,7 +43,7 @@ describe('fetchIntegrations', () => {
     const result = await fetchIntegrations(mockBaseUrl, mockToken)
 
     expect(result).toEqual(mockIntegrations)
-    expect(global.fetch).toHaveBeenCalledWith(`${mockBaseUrl}/v2/integrations`, {
+    expect(global.fetch).toHaveBeenCalledWith(`${mockBaseUrl}/v2/integrations?includeMetadata=true`, {
       method: 'GET',
       headers: {
         Authorization: `Bearer ${mockToken}`,

--- a/packages/cli/src/integrations/fetch-integrations.ts
+++ b/packages/cli/src/integrations/fetch-integrations.ts
@@ -46,6 +46,7 @@ export async function fetchIntegrations(
   integrationIds?: string[]
 ): Promise<ApiIntegration[]> {
   const endpoint = new URL(`${baseUrl}/v2/integrations`)
+  endpoint.searchParams.set('includeMetadata', 'true')
   if (integrationIds && integrationIds.length > 0) {
     endpoint.searchParams.set('integrationIds', integrationIds.join(','))
   }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Integration requests now automatically include metadata, providing users with more complete information about available integrations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->