### PR TITLE
fix(runtime-core): report failed agent-added code blocks via onBlockDone

### DIFF
--- a/packages/runtime-core/src/agent-handler.ts
+++ b/packages/runtime-core/src/agent-handler.ts
@@ -180,7 +180,7 @@ export async function executeAgentBlock(block: AgentBlock, context: AgentBlockCo
 
   const addCodeBlockTool = tool({
     description:
-      'Add a Python code block to the notebook and execute it. Returns stdout, stderr, and execution results.',
+      'Add a Python code block to the notebook and execute it. Returns the combined output text or an error message.',
     inputSchema: z.object({
       code: z.string().describe('Python code to execute'),
     }),

--- a/packages/runtime-core/src/execution-engine.test.ts
+++ b/packages/runtime-core/src/execution-engine.test.ts
@@ -1006,6 +1006,15 @@ describe('ExecutionEngine', () => {
       expect(addedCodeBlock).toEqual(expect.objectContaining({ type: 'code', content: helperCode }))
       expect(onBlockDone).toHaveBeenCalledWith(
         expect.objectContaining({
+          blockId: addedCodeBlock.id,
+          blockType: 'code',
+          success: false,
+          outputs: [expect.objectContaining({ output_type: 'error', evalue: 'Kernel crash' })],
+          executionCount: null,
+        })
+      )
+      expect(onBlockDone).toHaveBeenCalledWith(
+        expect.objectContaining({
           blockType: 'agent',
           success: false,
           outputs: [expect.objectContaining({ output_type: 'error', evalue: 'Execution error: Kernel crash' })],
@@ -1225,12 +1234,28 @@ describe('ExecutionEngine', () => {
           return { finalOutput: 'Done.' }
         })
 
+        const onBlockDone = vi.fn()
         await engine.start()
-        await engine.runProject(AGENT_FIXTURE)
+        await engine.runProject(AGENT_FIXTURE, { onBlockDone })
 
         expect(results).toHaveLength(1)
         expect(results[0]).toMatch(/^Execution failed:/)
         expect(results[0]).toContain('invalid syntax')
+
+        const failedAddedBlock = onBlockDone.mock.calls.find(
+          (args: unknown[]) =>
+            (args[0] as { blockType: string }).blockType === 'code' &&
+            (args[0] as { success: boolean }).success === false
+        )
+        expect(failedAddedBlock).toBeDefined()
+        expect(failedAddedBlock?.[0]).toEqual(
+          expect.objectContaining({
+            blockType: 'code',
+            success: false,
+            executionCount: 2,
+            outputs: [expect.objectContaining({ output_type: 'error', evalue: 'invalid syntax' })],
+          })
+        )
       })
 
       it('surfaces kernel.execute rejection as failure', async () => {

--- a/packages/runtime-core/src/execution-engine.ts
+++ b/packages/runtime-core/src/execution-engine.ts
@@ -251,7 +251,12 @@ export class ExecutionEngine {
           const notebookContext = serializeNotebookContext(file, notebookIndex, collectedOutputs)
 
           let insertIndex = agentBlockIndex + 1
-          const blockOutputs: Array<{ blockId: string; outputs: unknown[]; executionCount: number | null }> = []
+          const blockOutputs: Array<{
+            blockId: string
+            outputs: IOutput[]
+            executionCount: number | null
+            success: boolean
+          }> = []
 
           const projectMcpServers = file.project.settings?.mcpServers ?? []
 
@@ -277,6 +282,7 @@ export class ExecutionEngine {
                 blockId: newBlock.id,
                 outputs: result.outputs,
                 executionCount: result.executionCount,
+                success: result.success,
               })
 
               collectedOutputs.set(newBlock.id, {
@@ -287,8 +293,19 @@ export class ExecutionEngine {
               const outputText = extractOutputsText(result.outputs, { includeTraceback: true }) || '(no output)'
               return result.success ? `Output:\n${outputText}` : `Execution failed:\n${outputText}`
             } catch (error) {
-              const message = error instanceof Error ? error.message : String(error)
-              return `Execution error: ${message}`
+              const executionError = error instanceof Error ? error : new Error(String(error))
+              const errorOutputs: IOutput[] = [createErrorOutput(executionError)]
+
+              blockOutputs.push({
+                blockId: newBlock.id,
+                outputs: errorOutputs,
+                executionCount: null,
+                success: false,
+              })
+
+              collectedOutputs.set(newBlock.id, { outputs: errorOutputs, executionCount: null })
+
+              return `Execution error: ${executionError.message}`
             }
           }
 
@@ -318,26 +335,28 @@ export class ExecutionEngine {
             integrations: options.integrations,
           }
 
-          const agentResult = await executeAgentBlock(block, agentContext)
+          let agentResult: { finalOutput: string }
+          try {
+            agentResult = await executeAgentBlock(block, agentContext)
+          } finally {
+            // Always report added blocks — even if the agent threw partway through —
+            // so consumers see completion for blocks that were inserted into the notebook.
+            for (const bo of blockOutputs) {
+              for (const output of bo.outputs) {
+                options.onOutput?.(bo.blockId, output)
+              }
 
-          // Report outputs from blocks added by the agent block
-          for (const bo of blockOutputs) {
-            collectedOutputs.set(bo.blockId, { outputs: bo.outputs, executionCount: bo.executionCount })
-
-            for (const output of bo.outputs as IOutput[]) {
-              options.onOutput?.(bo.blockId, output)
-            }
-
-            const addedBlock = notebook.blocks.find(b => b.id === bo.blockId)
-            if (addedBlock) {
-              await options.onBlockDone?.({
-                blockId: bo.blockId,
-                blockType: addedBlock.type,
-                success: true,
-                outputs: bo.outputs as IOutput[],
-                executionCount: bo.executionCount,
-                durationMs: 0,
-              })
+              const addedBlock = notebook.blocks.find(b => b.id === bo.blockId)
+              if (addedBlock) {
+                await options.onBlockDone?.({
+                  blockId: bo.blockId,
+                  blockType: addedBlock.type,
+                  success: bo.success,
+                  outputs: bo.outputs,
+                  executionCount: bo.executionCount,
+                  durationMs: 0,
+                })
+              }
             }
           }
 


### PR DESCRIPTION
Chained on top of #342. Quick fixes from the review of that PR.

## What this changes

When the agent inserts a code block via `addAndExecuteCodeBlock`, the runtime tracks the *outcome* of that kernel execution and surfaces it through `onBlockDone`. Previously:

- A `kernel.execute` resolution with `success: false` (e.g. SyntaxError) was reported via `onBlockDone` with `success: true` — the success flag was dropped between `blockOutputs` and the post-loop.
- A `kernel.execute` rejection was never reported via `onBlockDone` at all — the catch path returned the error string to the agent but never pushed to `blockOutputs`, so the post-loop skipped it. The block was already inserted into `notebook.blocks`, leaving consumers with an inserted-but-never-completed block.
- When `executeAgentBlock` itself threw partway through, the post-loop never ran, so even successfully-completed added blocks weren't reported.

## The fix

- Track `success: boolean` on each `blockOutputs` entry.
- Push an entry on `kernel.execute` rejection (with a synthesized error output via the existing `createErrorOutput` helper) so the failed block still gets `onBlockDone`.
- Wrap the `executeAgentBlock` call in `try/finally` so added blocks are drained even when the agent throws.
- Pass `bo.success` through to `onBlockDone` instead of hardcoded `true`.
- Drop the redundant `collectedOutputs.set` in the post-loop (the per-block set inside `addAndExecuteCodeBlock` already covers all paths now).
- Type `blockOutputs.outputs` as `IOutput[]` to drop the two `as IOutput[]` casts.
- Tighten the `add_code_block` tool description (it claimed "stdout, stderr, and execution results" but actually returns a single formatted string).

## Tests

- Augmented `surfaces addAndExecuteCodeBlock failures when kernel execution rejects` to assert the failed code block now gets `onBlockDone` with `success: false` and a synthesized error output.
- Augmented `returns failure when kernel execution fails` to assert `success: false` propagates for the resolved-failure path too.

All 204 tests in `runtime-core` pass; typecheck and biome clean.

## Out of scope (deliberately)

From the review:
- `onLog` regression (#1) — `context.onLog` was never set by any caller, so the lost log lines were already no-ops.
- `serializeNotebookContext` export ambiguity (#2) — JSDoc nudge worth doing but a separate concern.
- Direct test coverage for `serializeNotebookContextFromBlocks` (#7) — covered transitively; not blocking.
- Verbose helper name (#8) — public-API rename, worth its own discussion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error handling and reporting for code blocks executed by agents. Callbacks are now reliably emitted even when execution fails, and each block's success/failure status is accurately tracked and reported.

* **Tests**
  * Added tests to verify proper error reporting and callback emission when agent-executed code blocks encounter execution failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->