### PR TITLE
refactor(runtime-core): remove unused onLog field from AgentBlockContext

### DIFF
--- a/packages/runtime-core/src/agent-handler.ts
+++ b/packages/runtime-core/src/agent-handler.ts
@@ -18,7 +18,6 @@ export interface AgentBlockContext {
   notebookContext: string
   addAndExecuteCodeBlock: (args: { code: string }) => Promise<string>
   addMarkdownBlock: (args: { content: string }) => Promise<string>
-  onLog?: (message: string) => void
   onAgentEvent?: (event: AgentStreamEvent) => void | Promise<void>
   integrations?: Array<{ id: string; name: string; type: string }>
 }
@@ -210,10 +209,6 @@ export async function executeAgentBlock(block: AgentBlock, context: AgentBlockCo
     ...(baseURL ? {} : { providerOptions: { openai: { reasoningSummary: 'auto' } } }),
   })
 
-  context.onLog?.(
-    `[agent] Running agent with model=${modelName}, maxTurns=${maxTurns}, mcpServers=${mcpClients.length}`
-  )
-
   try {
     const streamResult = await agent.stream({ prompt: block.content ?? '' })
 
@@ -243,7 +238,7 @@ export async function executeAgentBlock(block: AgentBlock, context: AgentBlockCo
       } catch (error) {
         const serverName = mergedMcpConfig[index]?.name ?? `server-${index + 1}`
         const message = error instanceof Error ? error.message : String(error)
-        context.onLog?.(`[agent] Failed to close MCP client "${serverName}": ${message}`)
+        console.error(`[agent] Failed to close MCP client "${serverName}": ${message}`)
       }
     }
   }


### PR DESCRIPTION
Chained on top of #369 (which is itself chained on #342).

`context.onLog` is declared on `AgentBlockContext` (an exported public type) but no caller in this repo ever sets it. The two call sites in `executeAgentBlock` were always no-ops:

- The informational `'[agent] Running agent with model=...'` log — dropped.
- The MCP-client close error log — replaced with `console.error` so teardown failures aren't silently swallowed.

## Why

Smaller public API surface, no dead `onLog?` confusing future readers of `AgentBlockContext`. The MCP close error path keeps visibility via `console.error` — for a runtime library this is conventional and beats silent swallow.

## Caveat

`AgentBlockContext` is exported from `index.ts`, so removing the field is technically a breaking change to the public type. Verified via grep that no caller in this repo sets it. If a future external consumer wants to capture these logs, they can add the field back behind a clearer name (e.g. `onDebugLog`) — but YAGNI for now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Breaking Changes**
  * Removed optional `onLog` callback from agent block context interface. Applications relying on custom logging through this callback must update their implementation.

* **Refactor**
  * Simplified MCP client shutdown error handling by logging errors directly to console instead of custom callbacks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->