### PR TITLE
docs: Add IPYNB-to-PDF converter links to docs

### DIFF
--- a/docs/converting-notebooks.md
+++ b/docs/converting-notebooks.md
@@ -16,6 +16,7 @@ The `@deepnote/convert` package provides a command-line tool and programmatic AP
 - Preserve code, markdown, outputs, and execution counts
 - Create multi-notebook Deepnote projects
 - Convert Deepnote projects back to Jupyter notebooks via [deepnote.com](https://deepnote.com)
+- Convert [ipynb files to PDF](https://deepnote.com/ipynb-to-pdf) when you need a static, shareable document rather than an editable notebook
 
 ## How to install [@deepnote/convert](https://www.npmjs.com/package/@deepnote/convert)
 

--- a/docs/export-pdf.md
+++ b/docs/export-pdf.md
@@ -23,3 +23,5 @@ You can export a notebook to PDF directly from the project toolbar in just a few
 - **PDF without code** excludes code cells from the exported PDF.
 
   ![Exported PDF without code](../assets/docs/export-pdf/pdf-without-code.webp)
+
+If you have a standalone `.ipynb` file that isn't already in Deepnote, you can convert [ipynb files to PDF](https://deepnote.com/ipynb-to-pdf) directly in your browser — no import step required.

--- a/docs/importing-and-exporting-jupyter-notebooks.md
+++ b/docs/importing-and-exporting-jupyter-notebooks.md
@@ -29,6 +29,8 @@ To download a notebook as a `.ipynb` file, click the three dots next to the note
 
 ![Export_Notebooks.jpg](https://media.graphassets.com/hydWm3T3RNOROOzvq969)
 
+Need a different output format? You can also convert [Jupyter notebooks to PDF](https://deepnote.com/ipynb-to-pdf) when you want a readable document to share with stakeholders who don't need to run the code.
+
 <Callout status="info">
 
 While we do our best to maintain compatibility with Jupyter, specialized blocks in Deepnote cannot be represented exactly in Jupyter (e.g., SQL, chart, input, and rich text blocks). Upon export, queries in SQL blocks will be converted to a string representation and rich text blocks will be converted to Markdown.

--- a/docs/migrating-to-ipynb.md
+++ b/docs/migrating-to-ipynb.md
@@ -15,6 +15,7 @@ While Deepnote's format offers enhanced features like input blocks, visualizatio
 - Publishing to repositories or documentation sites
 - Running in traditional Jupyter environments
 - Archiving or backup purposes
+- Producing a print-ready document: once exported, you can convert [ipynb files to PDF](https://deepnote.com/ipynb-to-pdf) for reviewers who prefer a static format
 
 ## Available export methods
 

--- a/docs/submissions.md
+++ b/docs/submissions.md
@@ -18,4 +18,4 @@ If your instructor allows you to submit your work as a link, you can [share a li
 
 ## Export your work as a PDF or other static file
 
-If your instructor prefers a static file, such as a PDF, you can [export your Deepnote project as a PDF](https://deepnote.com/docs/export-pdf) or other file type. To do this, click the "File" menu and select "Export." Choose the file type you want to export to, then select the cells you want to include in the export. You can then save the file to your local computer and submit it as directed by your instructor.
+If your instructor prefers a static file, such as a PDF, you can [export your Deepnote project as a PDF](https://deepnote.com/docs/export-pdf) or other file type. To do this, click the "File" menu and select "Export." Choose the file type you want to export to, then select the cells you want to include in the export. You can then save the file to your local computer and submit it as directed by your instructor. If you already have a `.ipynb` file on your computer, you can also use Deepnote's [IPYNB to PDF](https://deepnote.com/ipynb-to-pdf) converter to generate a PDF directly in your browser before submitting.


### PR DESCRIPTION
Adds contextual internal links to Deepnote’s [IPYNB-to-PDF converter](https://deepnote.com/ipynb-to-pdf) across five relevant doc webpages.
_CC: @mikayelh_ 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced guidance on converting Jupyter notebooks to static PDFs for sharing and print-ready review
  * Clarified PDF export workflows and added instructions for browser-based conversion options
  * Improved documentation to help users create shareable, static files for stakeholders

<!-- end of auto-generated comment: release notes by coderabbit.ai -->