### PR TITLE
refactor(@deepnote/blocks): dedupe SQL codegen and validate return type

### DIFF
--- a/packages/blocks/src/blocks/sql-blocks.test.ts
+++ b/packages/blocks/src/blocks/sql-blocks.test.ts
@@ -4,6 +4,7 @@ import { describe, expect, it } from 'vitest'
 import type { SqlBlock } from '../deepnote-file/deepnote-file-schema'
 import { InvalidValueError } from '../errors'
 import {
+  createPythonCodeForSqlBlock,
   createPythonCodeForSqlBlockWithConnectionJson,
   type SqlCacheMode,
   type SqlCellVariableType,
@@ -311,5 +312,67 @@ describe('createPythonCodeForSqlBlockWithConnectionJson', () => {
         connectionJson: '{}',
       })
     ).toThrow(InvalidValueError)
+  })
+})
+
+describe('createPythonCodeForSqlBlock', () => {
+  it('generates an execute_sql call with the default env var and dataframe return type', () => {
+    const block: SqlBlock = {
+      id: '1',
+      type: 'sql',
+      content: 'SELECT 1',
+      blockGroup: 'g',
+      sortingKey: 'a0',
+      metadata: {},
+    }
+
+    expect(createPythonCodeForSqlBlock(block)).toEqual(dedent`
+      if '_dntk' in globals():
+        _dntk.dataframe_utils.configure_dataframe_formatter('{}')
+      else:
+        _deepnote_current_table_attrs = '{}'
+
+      _dntk.execute_sql(
+        'SELECT 1',
+        'SQL_ALCHEMY_JSON_ENV_VAR',
+        audit_sql_comment='',
+        sql_cache_mode='cache_disabled',
+        return_variable_type='dataframe'
+      )
+    `)
+  })
+
+  it('assigns and echoes the sanitized variable name when deepnote_variable_name is set', () => {
+    const block: SqlBlock = {
+      id: '1',
+      type: 'sql',
+      content: 'SELECT 1',
+      blockGroup: 'g',
+      sortingKey: 'a0',
+      metadata: {
+        deepnote_variable_name: 'my df name!',
+      },
+    }
+
+    const result = createPythonCodeForSqlBlock(block)
+
+    expect(result).toContain('my_df_name = _dntk.execute_sql(')
+    expect(result.trimEnd().endsWith('my_df_name')).toBe(true)
+  })
+
+  it('throws InvalidValueError when deepnote_return_variable_type is not in the allowlist', () => {
+    // biome-ignore lint/suspicious/noExplicitAny: testing invalid block
+    const invalidBlock: any = {
+      id: '1',
+      type: 'sql',
+      content: 'SELECT 1',
+      blockGroup: 'g',
+      sortingKey: 'a0',
+      metadata: {
+        deepnote_return_variable_type: 'unexpected_value',
+      },
+    }
+
+    expect(() => createPythonCodeForSqlBlock(invalidBlock)).toThrow(InvalidValueError)
   })
 })

--- a/packages/blocks/src/blocks/sql-blocks.test.ts
+++ b/packages/blocks/src/blocks/sql-blocks.test.ts
@@ -361,8 +361,7 @@ describe('createPythonCodeForSqlBlock', () => {
   })
 
   it('throws InvalidValueError when deepnote_return_variable_type is not in the allowlist', () => {
-    // biome-ignore lint/suspicious/noExplicitAny: testing invalid block
-    const invalidBlock: any = {
+    const invalidBlock = {
       id: '1',
       type: 'sql',
       content: 'SELECT 1',
@@ -373,6 +372,6 @@ describe('createPythonCodeForSqlBlock', () => {
       },
     }
 
-    expect(() => createPythonCodeForSqlBlock(invalidBlock)).toThrow(InvalidValueError)
+    expect(() => createPythonCodeForSqlBlock(invalidBlock as unknown as SqlBlock)).toThrow(InvalidValueError)
   })
 })

--- a/packages/blocks/src/blocks/sql-blocks.ts
+++ b/packages/blocks/src/blocks/sql-blocks.ts
@@ -15,10 +15,7 @@ const sqlCellVariableTypeSchema = z.enum(SQL_CELL_VARIABLE_TYPES)
 
 export function createPythonCodeForSqlBlock(block: SqlBlock): string {
   const query = block.content ?? ''
-  const pythonVariableName = block.metadata?.deepnote_variable_name
-  const sanitizedPythonVariableName =
-    pythonVariableName !== undefined ? sanitizePythonVariableName(pythonVariableName) || 'input_1' : undefined
-  const returnVariableType = block.metadata?.deepnote_return_variable_type ?? 'dataframe'
+  const returnVariableType = assertSqlCellVariableType(block.metadata?.deepnote_return_variable_type ?? 'dataframe')
 
   const integrationId = block.metadata?.sql_integration_id
   const connectionEnvVarName = integrationId
@@ -26,8 +23,6 @@ export function createPythonCodeForSqlBlock(block: SqlBlock): string {
     : 'SQL_ALCHEMY_JSON_ENV_VAR'
 
   const escapedQuery = escapePythonString(query)
-
-  const dataFrameConfig = createDataFrameConfig(block)
 
   const executeSqlFunctionCall = dedent`
     _dntk.execute_sql(
@@ -39,22 +34,23 @@ export function createPythonCodeForSqlBlock(block: SqlBlock): string {
     )
   `
 
-  if (sanitizedPythonVariableName === undefined) {
-    return dedent`
-      ${dataFrameConfig}
-
-      ${executeSqlFunctionCall}
-    `
-  }
-
-  return dedent`
-    ${dataFrameConfig}
-
-    ${sanitizedPythonVariableName} = ${executeSqlFunctionCall}
-    ${sanitizedPythonVariableName}
-  `
+  return wrapSqlExecution(block, executeSqlFunctionCall)
 }
 
+/**
+ * Generates Python for a SQL block that connects via an inline connection-JSON
+ * literal instead of an env-var reference (the sibling of `createPythonCodeForSqlBlock`).
+ *
+ * Value sourcing is intentionally split:
+ * - `connectionJson`, `auditComment`, and `sqlCacheMode` come from `options` — they are
+ *   supplied by the caller / execution context and are not persisted on the block.
+ * - `returnVariableType` is read from `block.metadata.deepnote_return_variable_type`,
+ *   because it is part of the saved block definition.
+ *
+ * The query, `connectionJson`, and `auditComment` are escaped into single-quoted Python
+ * string literals. `sqlCacheMode` and `returnVariableType` are interpolated outside
+ * quotes, so they are validated against allowlists rather than escaped.
+ */
 export function createPythonCodeForSqlBlockWithConnectionJson(
   block: SqlBlock,
   options: {
@@ -64,17 +60,12 @@ export function createPythonCodeForSqlBlockWithConnectionJson(
   }
 ): string {
   const query = block.content ?? ''
-  const pythonVariableName = block.metadata?.deepnote_variable_name
-  const sanitizedPythonVariableName =
-    pythonVariableName !== undefined ? sanitizePythonVariableName(pythonVariableName) || 'input_1' : undefined
   const returnVariableType = assertSqlCellVariableType(block.metadata?.deepnote_return_variable_type ?? 'dataframe')
 
   const escapedQuery = escapePythonString(query)
   const escapedConnectionJson = escapePythonString(options.connectionJson)
   const escapedAuditComment = escapePythonString(options.auditComment ?? '')
   const sqlCacheMode = assertSqlCacheMode(options.sqlCacheMode ?? 'cache_disabled')
-
-  const dataFrameConfig = createDataFrameConfig(block)
 
   const executeSqlFunctionCall = dedent`
     _dntk.execute_sql_with_connection_json(
@@ -85,6 +76,22 @@ export function createPythonCodeForSqlBlockWithConnectionJson(
       return_variable_type='${returnVariableType}'
     )
   `
+
+  return wrapSqlExecution(block, executeSqlFunctionCall)
+}
+
+/**
+ * Wraps a generated `_dntk.execute_sql*` call with the shared dataframe-formatter
+ * prelude and, when the block defines a result variable name, an assignment plus a
+ * trailing echo of that variable. Both SQL helpers share this logic, including the
+ * `input_1` fallback applied to the result variable name.
+ */
+function wrapSqlExecution(block: SqlBlock, executeSqlFunctionCall: string): string {
+  const pythonVariableName = block.metadata?.deepnote_variable_name
+  const sanitizedPythonVariableName =
+    pythonVariableName !== undefined ? sanitizePythonVariableName(pythonVariableName) || 'input_1' : undefined
+
+  const dataFrameConfig = createDataFrameConfig(block)
 
   if (sanitizedPythonVariableName === undefined) {
     return dedent`

--- a/packages/blocks/src/blocks/sql-blocks.ts
+++ b/packages/blocks/src/blocks/sql-blocks.ts
@@ -48,8 +48,10 @@ export function createPythonCodeForSqlBlock(block: SqlBlock): string {
  *   because it is part of the saved block definition.
  *
  * The query, `connectionJson`, and `auditComment` are escaped into single-quoted Python
- * string literals. `sqlCacheMode` and `returnVariableType` are interpolated outside
- * quotes, so they are validated against allowlists rather than escaped.
+ * string literals. `sqlCacheMode` and `returnVariableType` are interpolated into
+ * single-quoted literals without escaping; instead they are validated against fixed
+ * allowlists, so the only possible values are known-safe identifiers that cannot break
+ * out of the surrounding quotes.
  */
 export function createPythonCodeForSqlBlockWithConnectionJson(
   block: SqlBlock,


### PR DESCRIPTION
## Summary

Stacked on top of #379 (base = `tk/export-federated-auth-helpers`). Addresses three review follow-ups on the SQL codegen helpers added there:

1. **Dedupe.** The dataframe-formatter prelude + variable-name sanitization (`input_1` fallback) + assignment/echo wrapping was copy-pasted across `createPythonCodeForSqlBlock` and `createPythonCodeForSqlBlockWithConnectionJson`. Extracted into a single private `wrapSqlExecution(block, executeSqlFunctionCall)` that both call. Each public function now only builds its own `executeSqlFunctionCall` string.

2. **Validate `return_variable_type` on the env-var path too.** `createPythonCodeForSqlBlock` previously interpolated `deepnote_return_variable_type` straight into the generated Python with no validation (relying solely on the upstream zod schema). It now runs through the same `assertSqlCellVariableType` allowlist guard as its connection-JSON sibling, so a hand-constructed block that bypasses the schema throws `InvalidValueError` instead of emitting unexpected/unsafe code.

3. **Document the option/metadata split.** Added a doc comment to `createPythonCodeForSqlBlockWithConnectionJson` explaining that `connectionJson`/`auditComment`/`sqlCacheMode` come from `options` while `returnVariableType` comes from `block.metadata` — and why the first group is escaped while the last two are allowlist-validated.

## Behavior

**Output is byte-identical** for all valid inputs — the dedupe only moves code, it doesn't change the generated Python. The only observable change is that an *invalid* `deepnote_return_variable_type` on the env-var path now throws (previously it silently produced bad Python).

## Tests

Added a direct `describe('createPythonCodeForSqlBlock', ...)` block — this function previously had **no direct tests** (only indirect coverage via the `createPythonCode` dispatcher):
- exact-output regression guard for the default env-var case (locks in the dedupe)
- variable-name assignment + trailing echo
- `InvalidValueError` on an out-of-allowlist `deepnote_return_variable_type`

Verified locally:
- `vitest run sql-blocks.test.ts python-code.test.ts` → 57 passed (incl. the 39 dispatcher tests that exercise the env-var path)
- `tsc --noEmit` (blocks) → clean
- `biome check` + `cspell` on changed files → clean

> [!NOTE]
> Targets #379's branch, so the diff shown here is just this change on top of #379. Merge #379 first; this will then re-target `main` automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for SQL code generation, covering default execution, returned-variable scenarios, and invalid return-type handling.

* **Refactor**
  * Centralized SQL execution formatting and strengthened validation/escaping for return types and connection/execution parameters to improve safety and consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->