### PR TITLE
feat(integrations): add Google Cloud SQL to @deepnote/database-integrations

### DIFF
--- a/packages/cli/src/commands/integrations/add-integration.ts
+++ b/packages/cli/src/commands/integrations/add-integration.ts
@@ -22,6 +22,7 @@ import { promptForFieldsAlloydb } from './integrations-prompts/alloydb'
 import { promptForFieldsAthena } from './integrations-prompts/athena'
 import { promptForFieldsBigQuery } from './integrations-prompts/big-query'
 import { promptForFieldsClickhouse } from './integrations-prompts/clickhouse'
+import { promptForFieldsCloudSql } from './integrations-prompts/cloud-sql'
 import { promptForFieldsDatabricks } from './integrations-prompts/databricks'
 import { promptForFieldsDremio } from './integrations-prompts/dremio'
 import { promptForFieldsMariadb } from './integrations-prompts/mariadb'
@@ -90,6 +91,8 @@ export async function promptForIntegrationConfig({
       return promptForFieldsBigQuery({ id, type: integrationType, name })
     case 'clickhouse':
       return promptForFieldsClickhouse({ id, type: integrationType, name })
+    case 'cloud-sql':
+      return promptForFieldsCloudSql({ id, type: integrationType, name })
     case 'databricks':
       return promptForFieldsDatabricks({ id, type: integrationType, name })
     case 'dremio':

--- a/packages/cli/src/commands/integrations/edit-integration.ts
+++ b/packages/cli/src/commands/integrations/edit-integration.ts
@@ -23,6 +23,7 @@ import { promptForFieldsAlloydb } from './integrations-prompts/alloydb'
 import { promptForFieldsAthena } from './integrations-prompts/athena'
 import { promptForFieldsBigQuery } from './integrations-prompts/big-query'
 import { promptForFieldsClickhouse } from './integrations-prompts/clickhouse'
+import { promptForFieldsCloudSql } from './integrations-prompts/cloud-sql'
 import { promptForFieldsDatabricks } from './integrations-prompts/databricks'
 import { promptForFieldsDremio } from './integrations-prompts/dremio'
 import { promptForFieldsMariadb } from './integrations-prompts/mariadb'
@@ -147,6 +148,13 @@ export async function promptForIntegrationConfig(
       })
     case 'clickhouse':
       return promptForFieldsClickhouse({
+        id: existingConfig.id,
+        type: existingConfig.type,
+        name: newName,
+        defaultValues: existingConfig.metadata,
+      })
+    case 'cloud-sql':
+      return promptForFieldsCloudSql({
         id: existingConfig.id,
         type: existingConfig.type,
         name: newName,

--- a/packages/cli/src/commands/integrations/integrations-prompts/cloud-sql.ts
+++ b/packages/cli/src/commands/integrations/integrations-prompts/cloud-sql.ts
@@ -1,0 +1,30 @@
+import type { DatabaseIntegrationConfig, DatabaseIntegrationMetadataByType } from '@deepnote/database-integrations'
+import { promptForRequiredSecretField } from '../../../utils/inquirer'
+
+export async function promptForFieldsCloudSql({
+  id,
+  type,
+  name,
+  defaultValues,
+}: {
+  id: string
+  type: 'cloud-sql'
+  name: string
+  defaultValues?: DatabaseIntegrationMetadataByType['cloud-sql']
+}): Promise<DatabaseIntegrationConfig> {
+  const service_account = await promptForRequiredSecretField({
+    label: 'Service Account (JSON):',
+    defaultValue: defaultValues?.service_account,
+  })
+
+  const metadata: DatabaseIntegrationMetadataByType['cloud-sql'] = {
+    service_account,
+  }
+
+  return {
+    id,
+    type,
+    name,
+    metadata,
+  }
+}

--- a/packages/cli/src/commands/integrations/tests/add-integration.cloud-sql.test.ts
+++ b/packages/cli/src/commands/integrations/tests/add-integration.cloud-sql.test.ts
@@ -1,0 +1,70 @@
+import crypto from 'node:crypto'
+import { mkdtemp, readFile, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { screen } from '@inquirer/testing/vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('../../../output', () => ({ debug: vi.fn(), log: vi.fn(), output: vi.fn(), error: vi.fn() }))
+
+import { createIntegration } from '../add-integration'
+
+describe('add-integration cloud-sql', () => {
+  let tempDir: string
+
+  beforeEach(async () => {
+    vi.clearAllMocks()
+    vi.restoreAllMocks()
+    tempDir = await mkdtemp(join(tmpdir(), 'add-integration-cloud-sql-test-'))
+  })
+
+  afterEach(async () => {
+    await rm(tempDir, { recursive: true, force: true })
+  })
+
+  async function fillBaseFields(): Promise<void> {
+    expect(screen.getScreen()).toContain('Select integration type:')
+    screen.type('cloud-sql')
+    screen.keypress('enter')
+
+    await screen.next()
+    expect(screen.getScreen()).toContain('Integration name:')
+    screen.type('My Cloud SQL')
+    screen.keypress('enter')
+
+    await screen.next()
+    expect(screen.getScreen()).toContain('Service Account (JSON):')
+    screen.type('service-account-json-data')
+    screen.keypress('enter')
+  }
+
+  it('creates cloud-sql integration and stores service account as env ref', async () => {
+    const filePath = join(tempDir, 'integrations.yaml')
+    const envFilePath = join(tempDir, '.env')
+    const mockUUID: crypto.UUID = 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee'
+    vi.spyOn(crypto, 'randomUUID').mockReturnValue(mockUUID)
+
+    const promise = createIntegration({ file: filePath, envFile: envFilePath })
+    await fillBaseFields()
+    await promise
+
+    const yamlContent = await readFile(filePath, 'utf-8')
+    const envContent = await readFile(envFilePath, 'utf-8')
+
+    expect(yamlContent).toMatchInlineSnapshot(`
+      "#yaml-language-server: $schema=https://raw.githubusercontent.com/deepnote/deepnote/refs/heads/tk/integrations-config-file-schema/json-schemas/integrations-file-schema.json
+
+      integrations:
+        - id: aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee
+          type: cloud-sql
+          name: My Cloud SQL
+          metadata:
+            service_account: env:AAAAAAAA_BBBB_CCCC_DDDD_EEEEEEEEEEEE__SERVICE_ACCOUNT
+      "
+    `)
+    expect(envContent).toMatchInlineSnapshot(`
+      "AAAAAAAA_BBBB_CCCC_DDDD_EEEEEEEEEEEE__SERVICE_ACCOUNT=service-account-json-data
+      "
+    `)
+  })
+})

--- a/packages/cli/src/commands/integrations/tests/edit-integration.cloud-sql.test.ts
+++ b/packages/cli/src/commands/integrations/tests/edit-integration.cloud-sql.test.ts
@@ -111,5 +111,11 @@ integrations:
             service_account: env:CS_ID_001__SERVICE_ACCOUNT
       "
     `)
+
+    const envContent = await readFile(envFilePath, 'utf-8')
+    expect(envContent).toMatchInlineSnapshot(`
+      "CS_ID_001__SERVICE_ACCOUNT=new-service-account-data
+      "
+    `)
   })
 })

--- a/packages/cli/src/commands/integrations/tests/edit-integration.cloud-sql.test.ts
+++ b/packages/cli/src/commands/integrations/tests/edit-integration.cloud-sql.test.ts
@@ -1,0 +1,115 @@
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { screen } from '@inquirer/testing/vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('../../../output', () => ({ debug: vi.fn(), log: vi.fn(), output: vi.fn(), error: vi.fn() }))
+
+vi.mock('../../../utils/process-env', () => ({
+  getProcessEnv: () => ({}),
+}))
+
+import { editIntegration } from '../edit-integration'
+
+describe('edit-integration cloud-sql', () => {
+  let tempDir: string
+
+  const EXISTING_YAML = `#yaml-language-server: $schema=https://example.com/schema.json
+
+integrations:
+  - id: cs-id-001
+    name: Production Cloud SQL
+    type: cloud-sql
+    federated_auth_method: null
+    metadata:
+      service_account: env:CS_ID_001__SERVICE_ACCOUNT
+`
+
+  beforeEach(async () => {
+    vi.clearAllMocks()
+    vi.restoreAllMocks()
+    tempDir = await mkdtemp(join(tmpdir(), 'edit-integration-cloud-sql-test-'))
+  })
+
+  afterEach(async () => {
+    await rm(tempDir, { recursive: true, force: true })
+  })
+
+  it('edits cloud-sql integration keeping all defaults', async () => {
+    const filePath = join(tempDir, 'integrations.yaml')
+    const envFilePath = join(tempDir, '.env')
+
+    await writeFile(filePath, EXISTING_YAML)
+    await writeFile(envFilePath, 'CS_ID_001__SERVICE_ACCOUNT=service-account-data\n')
+
+    const promise = editIntegration({ file: filePath, envFile: envFilePath, id: 'cs-id-001' })
+
+    await screen.next()
+    expect(screen.getScreen()).toContain('Integration name: (Production Cloud SQL)')
+    screen.keypress('enter')
+
+    await screen.next()
+    expect(screen.getScreen()).toContain('Service Account (JSON):')
+    screen.type('service-account-data')
+    screen.keypress('enter')
+
+    await promise
+
+    const yamlContent = await readFile(filePath, 'utf-8')
+    expect(yamlContent).toMatchInlineSnapshot(`
+      "#yaml-language-server: $schema=https://example.com/schema.json
+
+      integrations:
+        - id: cs-id-001
+          name: Production Cloud SQL
+          type: cloud-sql
+          federated_auth_method: null
+          metadata:
+            service_account: env:CS_ID_001__SERVICE_ACCOUNT
+      "
+    `)
+
+    const envContent = await readFile(envFilePath, 'utf-8')
+    expect(envContent).toMatchInlineSnapshot(`
+      "CS_ID_001__SERVICE_ACCOUNT=service-account-data
+      "
+    `)
+  })
+
+  it('updates the name and service account', async () => {
+    const filePath = join(tempDir, 'integrations.yaml')
+    const envFilePath = join(tempDir, '.env')
+
+    await writeFile(filePath, EXISTING_YAML)
+    await writeFile(envFilePath, 'CS_ID_001__SERVICE_ACCOUNT=service-account-data\n')
+
+    const promise = editIntegration({ file: filePath, envFile: envFilePath, id: 'cs-id-001' })
+
+    await screen.next()
+    expect(screen.getScreen()).toContain('Integration name: (Production Cloud SQL)')
+    screen.type('Updated Cloud SQL')
+    screen.keypress('enter')
+
+    await screen.next()
+    expect(screen.getScreen()).toContain('Service Account (JSON):')
+    screen.type('new-service-account-data')
+    screen.keypress('enter')
+
+    await promise
+
+    const yamlContent = await readFile(filePath, 'utf-8')
+    expect(yamlContent).toMatchInlineSnapshot(`
+      "#yaml-language-server: $schema=https://example.com/schema.json
+
+      integrations:
+        - id: cs-id-001
+          name: Updated Cloud SQL
+          type: cloud-sql
+          federated_auth_method: null
+          metadata:
+            service_account: env:CS_ID_001__SERVICE_ACCOUNT
+      "
+    `)
+  })
+})

--- a/packages/database-integrations/src/database-integration-config.ts
+++ b/packages/database-integrations/src/database-integration-config.ts
@@ -41,6 +41,11 @@ export const databaseIntegrationConfigSchema = z.discriminatedUnion('type', [
     federated_auth_method: z.null().optional(),
   }),
   commonIntegrationConfig.extend({
+    type: z.literal('cloud-sql'),
+    metadata: databaseMetadataSchemasByType['cloud-sql'],
+    federated_auth_method: z.null().optional(),
+  }),
+  commonIntegrationConfig.extend({
     type: z.literal('databricks'),
     metadata: databaseMetadataSchemasByType.databricks,
     federated_auth_method: z.null().optional(),

--- a/packages/database-integrations/src/database-integration-env-vars.test.ts
+++ b/packages/database-integrations/src/database-integration-env-vars.test.ts
@@ -2314,6 +2314,27 @@ describe('Database integration env variables', () => {
       })
     })
 
+    describe('Cloud SQL', () => {
+      it('should not generate a SQL Alchemy env var (connects via the Cloud SQL Python connector)', () => {
+        const { envVars, errors } = getEnvironmentVariablesForIntegrations(
+          [
+            {
+              type: 'cloud-sql',
+              id: 'my-cloud-sql',
+              name: 'My Cloud SQL Connection',
+              metadata: {
+                service_account: '{"project_id": "my-project-id"}',
+              },
+            },
+          ],
+          { projectRootDirectory: '/path/to/project' }
+        )
+
+        expect(errors).toHaveLength(0)
+        expect(getSqlAlchemyInputVar(envVars, 'my-cloud-sql')).toBeUndefined()
+      })
+    })
+
     describe('Snowflake', () => {
       it('should generate a SQL Alchemy env var with snowflake URL for password auth', () => {
         const { envVars, errors } = getEnvironmentVariablesForIntegrations(

--- a/packages/database-integrations/src/database-integration-env-vars.ts
+++ b/packages/database-integrations/src/database-integration-env-vars.ts
@@ -155,6 +155,11 @@ export function getSqlAlchemyInput(
     case 'clickhouse':
       return getClickHouseSqlAlchemyInput(integration.id, params.projectRootDirectory, integration.metadata)
 
+    case 'cloud-sql':
+      // Cloud SQL connects via the Cloud SQL Python connector rather than a plain SQLAlchemy URL,
+      // so there is no SQLAlchemy input to generate here yet.
+      return null
+
     case 'databricks':
       return getDatabricksSqlAlchemyInput(integration.metadata)
 

--- a/packages/database-integrations/src/database-integration-metadata-schemas.test.ts
+++ b/packages/database-integrations/src/database-integration-metadata-schemas.test.ts
@@ -179,6 +179,25 @@ describe('SQL integration metadata schemas', () => {
     })
   })
 
+  describe('Cloud SQL', () => {
+    it('should validate valid metadata', () => {
+      const result = databaseMetadataSchemasByType['cloud-sql'].safeParse({
+        service_account: '{ "type": "service_account", "project_id": "example" }',
+      })
+
+      expect(result.success).toBe(true)
+      expect(result.data).toStrictEqual({
+        service_account: '{ "type": "service_account", "project_id": "example" }',
+      })
+    })
+
+    it('should fail on metadata with missing service account', () => {
+      const result = databaseMetadataSchemasByType['cloud-sql'].safeParse({})
+
+      expect(result.success).toBe(false)
+    })
+  })
+
   describe('Databricks', () => {
     it('should validate valid metadata', () => {
       const result = databaseMetadataSchemasByType.databricks.safeParse({

--- a/packages/database-integrations/src/database-integration-metadata-schemas.ts
+++ b/packages/database-integrations/src/database-integration-metadata-schemas.ts
@@ -47,6 +47,10 @@ const clickhouseMetadataSchema = z.object({
   caCertificateText: z.string().optional(),
 })
 
+const cloudSqlMetadataSchema = z.object({
+  service_account: z.string(),
+})
+
 const databricksMetadataSchema = z.object({
   host: z.string(),
   httpPath: z.string(),
@@ -301,6 +305,7 @@ export const databaseMetadataSchemasByType = {
   'athena': athenaMetadataSchema,
   'big-query': bigqueryMetadataSchema,
   'clickhouse': clickhouseMetadataSchema,
+  'cloud-sql': cloudSqlMetadataSchema,
   'databricks': databricksMetadataSchema,
   'dremio': dremioMetadataSchema,
   'mariadb': mariadbMetadataSchema,

--- a/packages/database-integrations/src/database-integration-types.ts
+++ b/packages/database-integrations/src/database-integration-types.ts
@@ -3,6 +3,7 @@ export const sqlIntegrationTypes = [
   'athena',
   'big-query',
   'clickhouse',
+  'cloud-sql',
   'databricks',
   'dremio',
   'mariadb',

--- a/packages/database-integrations/src/secret-field-paths.ts
+++ b/packages/database-integrations/src/secret-field-paths.ts
@@ -43,6 +43,7 @@ const SECRET_PATHS: { [K in DatabaseIntegrationType]: readonly MetadataKey<K>[] 
 
   // Service account based
   spanner: ['service_account'],
+  'cloud-sql': ['service_account'],
 
   // MongoDB - connection string may contain password
   mongodb: ['password', 'connection_string', 'rawConnectionString', 'caCertificateText'],


### PR DESCRIPTION
## What / Why

Adds `cloud-sql` as a supported `DatabaseIntegrationType` in the `@deepnote/database-integrations` package.

This is the upstream schema extraction for the Cloud SQL integration — `vscode-deepnote#406` added a local shim with the comment *"Pending addition to @deepnote/database-integrations; remove once the package includes 'cloud-sql'."* This PR fulfils that.

## Changes

- `database-integration-types.ts` — `'cloud-sql'` added to `sqlIntegrationTypes`
- `database-integration-metadata-schemas.ts` — `cloudSqlMetadataSchema` (`service_account: z.string()`, consistent with Spanner/BigQuery convention)
- `database-integration-config.ts` — config union member added
- `secret-field-paths.ts` — `'cloud-sql': ['service_account']` (service account JSON is a secret)
- `database-integration-env-vars.ts` — `case 'cloud-sql': return null` (Cloud SQL connects via the cloud-sql-python-connector, not a plain SQLAlchemy URL — satisfies the exhaustiveness check)
- `integrations-prompts/cloud-sql.ts` — new CLI prompt (single `service_account` field, modelled on Spanner)
- `add-integration.ts` + `edit-integration.ts` — import + switch case wired in
- `database-integration-metadata-schemas.test.ts` — 2 new test cases

## Why `cloud-sql` produces no SQLAlchemy input

**How integrations normally reach the runtime.** For a SQL integration, `getEnvVarForSqlCells` (`database-integration-env-vars.ts`) calls `getSqlAlchemyInput` and, only if it returns a non-null `{ url, params, param_style }`, emits an env var. The [deepnote-toolkit](https://github.com/deepnote/deepnote-toolkit) runtime reads that env var and feeds the triple straight into SQLAlchemy: `execute_sql` → `_query_data_source` → `create_engine(url, **params, pool_pre_ping=True)` (`deepnote_toolkit/sql/sql_execution.py:506`). So `url` has to be a DSN that `create_engine` can dial directly, e.g. `postgresql://user:pass@host:port/db`.

**Cloud SQL has no such DSN.** A Cloud SQL instance isn't addressable by a static host:port URL — you connect through the [Cloud SQL Python Connector](https://github.com/GoogleCloudPlatform/cloud-sql-python-connector) (`from google.cloud.sql.connector import Connector`), which resolves the instance (`project:region:instance`), performs the IAM/TLS handshake using the **service account**, and hands SQLAlchemy a `creator` callable instead of a URL (see `docs/google-cloud-sql.md`). There is no `url` + `params` pair that captures that flow, so there is nothing valid for `getSqlAlchemyInput` to emit — hence `return null`.

**Why `null` specifically (not a placeholder URL).** Returning `null` makes `getEnvVarForSqlCells` skip the env var entirely (the new test asserts `getSqlAlchemyInputVar(envVars, 'my-cloud-sql')` is `undefined`). Emitting a half-formed URL would instead make the toolkit call `create_engine` on a DSN it can't dial and fail at query time. `null` cleanly means "no platform-injected engine; the connection is established in-notebook via the connector," which matches the documented Cloud SQL workflow today.

**The toolkit gates this too.** The toolkit bundles `sqlalchemy-spanner` and `sqlalchemy-bigquery` (`pyproject.toml`), so those can build engines from a Google-specific URL — Spanner emits `spanner+spanner:///projects/<id>/instances/<instance>/databases/<db>`, BigQuery emits `bigquery://` with `credentials_info` in `params`. The toolkit does **not** ship `cloud-sql-python-connector` and has no `google.cloud.sql` import, so even a correct URL would have no driver to consume it. The closest existing precedent in this same file is BigQuery **federated auth**, which already `return null`s when the platform can't construct a URL (`database-integration-env-vars.ts:611`, plus the federated-auth guard at `:140`). `cloud-sql` follows that shape; a full connector-backed implementation (toolkit + env-var) is a follow-up.

## How to review

Start with `database-integration-types.ts` (one-liner), then `database-integration-metadata-schemas.ts`, then `secret-field-paths.ts`, then `database-integration-env-vars.ts`. The CLI files (`add-integration.ts`, `edit-integration.ts`, `cloud-sql.ts`) follow the exact same pattern as Spanner.

## Testing

- Typecheck: clean (`tsc --noEmit` across all packages)
- Unit tests: 227/227 pass in `@deepnote/database-integrations`; all pass in `@deepnote/cli` when run in isolation
- Build: succeeds (ESM + CJS + types)
- CLI prompt (`promptForFieldsCloudSql`): not manually run, but covered by typecheck — follows the Spanner pattern exactly
- Note: some pre-existing `add-integration` tests are intermittently flaky under parallel local execution (unrelated to this diff); CI is unaffected

## Risks

- Safe: purely additive, no existing behaviour changed
- The `return null` in env-vars is intentional — Cloud SQL connects via the Cloud SQL Python Connector rather than a SQLAlchemy URL, mirroring how BigQuery federated auth already returns `null` (see *Why `cloud-sql` produces no SQLAlchemy input* above). A full connector-backed implementation (toolkit + env-var) is a follow-up.

## Next step

Once this merges and `@deepnote/database-integrations` publishes a new version, `vscode-deepnote#406` can be updated to remove the local shim and consume the package directly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Cloud SQL database integration support, allowing users to create and manage Cloud SQL connections through the CLI with service account-based authentication.
  * CLI now supports adding and editing Cloud SQL integrations with streamlined configuration workflows for service account credentials.
  * Added comprehensive validation and environment variable handling for Cloud SQL integration configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

