### PR TITLE
feat(cli): add GCF as --output gcf format option

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -42,6 +42,7 @@
     "watch": "tsdown --watch"
   },
   "dependencies": {
+    "@blackwell-systems/gcf": "^2.1.2",
     "@deepnote/blocks": "workspace:*",
     "@deepnote/convert": "workspace:*",
     "@deepnote/database-integrations": "workspace:*",

--- a/packages/cli/src/commands/analyze.ts
+++ b/packages/cli/src/commands/analyze.ts
@@ -3,7 +3,16 @@ import { decodeUtf8NoBom, deserializeDeepnoteFile } from '@deepnote/blocks'
 import { resolvePythonExecutable } from '@deepnote/runtime-core'
 import type { Command } from 'commander'
 import { ExitCode } from '../exit-codes'
-import { debug, getChalk, error as logError, type OutputFormat, output, outputJson, outputToon } from '../output'
+import {
+  debug,
+  getChalk,
+  error as logError,
+  type OutputFormat,
+  output,
+  outputGcf,
+  outputJson,
+  outputToon,
+} from '../output'
 import { type AnalysisResult, analyzeProject, type BlockInfo, buildBlockMap } from '../utils/analysis'
 import { FileResolutionError, resolvePathToDeepnoteFile } from '../utils/file-resolver'
 
@@ -293,6 +302,11 @@ function outputAnalysis(result: AnalyzeResult, options: AnalyzeOptions): void {
     return
   }
 
+  if (options.output === 'gcf') {
+    outputGcf(result)
+    return
+  }
+
   // Human-readable text output
   const c = getChalk()
 
@@ -374,6 +388,8 @@ function handleError(error: unknown, options: AnalyzeOptions): never {
     outputJson({ success: false, error: message })
   } else if (options.output === 'toon') {
     outputToon({ success: false, error: message })
+  } else if (options.output === 'gcf') {
+    outputGcf({ success: false, error: message })
   } else {
     logError(message)
   }

--- a/packages/cli/src/commands/inspect.ts
+++ b/packages/cli/src/commands/inspect.ts
@@ -2,7 +2,16 @@ import fs from 'node:fs/promises'
 import { decodeUtf8NoBom, deserializeDeepnoteFile, ParseError } from '@deepnote/blocks'
 import type { Command } from 'commander'
 import { ExitCode } from '../exit-codes'
-import { debug, getChalk, error as logError, type OutputFormat, output, outputJson, outputToon } from '../output'
+import {
+  debug,
+  getChalk,
+  error as logError,
+  type OutputFormat,
+  output,
+  outputGcf,
+  outputJson,
+  outputToon,
+} from '../output'
 import { FileResolutionError, resolvePathToDeepnoteFile } from '../utils/file-resolver'
 
 export interface InspectOptions {
@@ -26,6 +35,8 @@ export function createInspectAction(
         outputJson({ success: false, error: message })
       } else if (options.output === 'toon') {
         outputToon({ success: false, error: message })
+      } else if (options.output === 'gcf') {
+        outputGcf({ success: false, error: message })
       } else {
         logError(message)
       }
@@ -48,6 +59,8 @@ async function inspectDeepnoteFile(path: string | undefined, options: InspectOpt
     outputInspectJson(absolutePath, deepnoteFile)
   } else if (options.output === 'toon') {
     outputInspectToon(absolutePath, deepnoteFile)
+  } else if (options.output === 'gcf') {
+    outputGcf(buildInspectResult(absolutePath, deepnoteFile))
   } else {
     printDeepnoteFileMetadata(absolutePath, deepnoteFile)
   }

--- a/packages/cli/src/commands/run.ts
+++ b/packages/cli/src/commands/run.ts
@@ -36,7 +36,17 @@ import { collectRequiredIntegrationIds } from '../integrations/collect-integrati
 import { fetchAndMergeApiIntegrations } from '../integrations/fetch-and-merge-integrations'
 import { injectIntegrationEnvVars } from '../integrations/inject-integration-env-vars'
 import { getDefaultIntegrationsFilePath, parseIntegrationsFile } from '../integrations/parse-integrations'
-import { debug, getChalk, log, error as logError, type OutputFormat, output, outputJson, outputToon } from '../output'
+import {
+  debug,
+  getChalk,
+  log,
+  error as logError,
+  type OutputFormat,
+  output,
+  outputGcf,
+  outputJson,
+  outputToon,
+} from '../output'
 import { renderOutput } from '../output-renderer'
 import { analyzeProject, buildBlockMap, diagnoseBlockFailure, type ProjectStats } from '../utils/analysis'
 import { getBlockLabel } from '../utils/block-label'
@@ -533,6 +543,11 @@ export function createRunAction(program: Command): (path: string | undefined, op
         process.exitCode = exitCode
         return
       }
+      if (options.output === 'gcf') {
+        outputGcf({ success: false, error: message })
+        process.exitCode = exitCode
+        return
+      }
       program.error(getChalk().red(message), { exitCode })
     }
   }
@@ -712,6 +727,8 @@ async function dryRunDeepnoteProject(path: string, options: RunOptions): Promise
     }
     if (options.output === 'toon') {
       outputToon(result)
+    } else if (options.output === 'gcf') {
+      outputGcf(result)
     } else {
       outputJson(result)
     }
@@ -904,6 +921,8 @@ async function runDeepnoteProject(path: string | undefined, options: RunOptions)
 
       if (options.output === 'toon') {
         outputToon(result, { showEfficiencyHint: true })
+      } else if (options.output === 'gcf') {
+        outputGcf(result)
       } else {
         outputJson(result)
       }

--- a/packages/cli/src/output.ts
+++ b/packages/cli/src/output.ts
@@ -1,3 +1,4 @@
+import { encodeGeneric as gcfEncode } from '@blackwell-systems/gcf'
 import { encode as toonEncode } from '@toon-format/toon'
 import { Chalk, type ChalkInstance } from 'chalk'
 import { analyzeToonEfficiency } from './utils/toon-analysis'
@@ -6,13 +7,14 @@ import { analyzeToonEfficiency } from './utils/toon-analysis'
  * Available output formats for CLI commands.
  * - json: Machine-readable JSON format for scripting
  * - toon: Token-Oriented Object Notation, optimized for LLM consumption
+ * - gcf: Graph Compact Format, optimized for LLM consumption with higher comprehension accuracy
  */
-export type OutputFormat = 'json' | 'toon'
+export type OutputFormat = 'json' | 'toon' | 'gcf'
 
 /**
  * Valid output format values for validation.
  */
-export const OUTPUT_FORMATS: readonly OutputFormat[] = ['json', 'toon'] as const
+export const OUTPUT_FORMATS: readonly OutputFormat[] = ['json', 'toon', 'gcf'] as const
 
 /**
  * Global output configuration for the CLI.
@@ -174,4 +176,16 @@ export function outputToon(data: unknown, options?: { showEfficiencyHint?: boole
       console.error(cliChalk.dim(hint))
     }
   }
+}
+
+/**
+ * Output data as GCF (Graph Compact Format).
+ * GCF is an LLM-optimized wire format with 90.7% comprehension accuracy
+ * across frontier models (vs 68.5% TOON, 53.6% JSON on adversarial data).
+ * Verified lossless across 33 billion+ round-trips.
+ *
+ * @see https://gcformat.com
+ */
+export function outputGcf(data: unknown): void {
+  console.log(gcfEncode(data))
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -97,6 +97,9 @@ importers:
 
   packages/cli:
     dependencies:
+      '@blackwell-systems/gcf':
+        specifier: ^2.1.2
+        version: 2.1.2
       '@deepnote/blocks':
         specifier: workspace:*
         version: link:../blocks
@@ -410,6 +413,10 @@ packages:
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [win32]
+
+  '@blackwell-systems/gcf@2.1.2':
+    resolution: {integrity: sha512-IKSqfNwXX2O0Xn+c1mTKZW261n5Cruj66y/M2CgfxvPqNRNJhwP0CGokkzA/mLUSgnus4FO3a00m4WHSKJD8pA==}
+    hasBin: true
 
   '@colors/colors@1.5.0':
     resolution: {integrity: sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==}
@@ -3272,6 +3279,8 @@ snapshots:
 
   '@biomejs/cli-win32-x64@2.2.7':
     optional: true
+
+  '@blackwell-systems/gcf@2.1.2': {}
 
   '@colors/colors@1.5.0':
     optional: true


### PR DESCRIPTION
## Summary

- Add `--output gcf` as a new output format option alongside existing `json` and `toon`
- GCF (Graph Compact Format) is an LLM-optimized wire format with higher comprehension accuracy than both JSON and TOON
- No changes to existing TOON or JSON behavior

## Why

### LLM comprehension

When CLI output is consumed by LLMs (agents, pipelines, automation), format comprehension accuracy matters. Across 1,700+ evaluations on GPT-4o, GPT-5.5, Claude, and Gemini:

- GCF: 100% on general data, 90.7% on adversarial payloads
- TOON: 68.5% on the same adversarial data
- JSON: 53.6%

Full eval methodology: [GCF benchmarks](https://gcformat.com/guide/benchmarks)

### Data integrity

GCF verified lossless across 33 billion+ round-trips in 5 formats and 6 languages. Zero failures.

Full verification data: [Lossless verification](https://gcformat.com/guide/lossless-verification)

### Zero runtime dependencies

`@blackwell-systems/gcf` has zero runtime dependencies.

## Changes

| File | Change |
|------|--------|
| `packages/cli/src/output.ts` | Add `gcfEncode` import, `'gcf'` to `OutputFormat`, `outputGcf()` function |
| `packages/cli/src/commands/inspect.ts` | Wire `--output gcf` |
| `packages/cli/src/commands/run.ts` | Wire `--output gcf` |
| `packages/cli/src/commands/analyze.ts` | Wire `--output gcf` |
| `packages/cli/package.json` | Add `@blackwell-systems/gcf` dependency |

## Links

- GCF spec and docs: https://gcformat.com
- GCF TypeScript SDK: https://www.npmjs.com/package/@blackwell-systems/gcf
- SDKs in 6 languages: https://gcformat.com/guide/getting-started
- Eval results: https://gcformat.com/guide/eval-results
- Lossless verification: https://gcformat.com/guide/lossless-verification
- Whitepaper: https://gcformat.com/whitepaper

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced support for the new GCF output format across CLI commands. The analyze, inspect, and run commands now accept `--output gcf` to generate structured output in GCF format. This enables seamless integration with external tools, automated processing systems, and platforms that support standardized structured output formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->