### PR TITLE
fix(blocks): sanitize notebook-function export variable names

### DIFF
--- a/packages/blocks/src/blocks/notebook-function-blocks.test.ts
+++ b/packages/blocks/src/blocks/notebook-function-blocks.test.ts
@@ -285,6 +285,160 @@ describe('createPythonCodeForNotebookFunctionBlock', () => {
     `)
   })
 
+  it('sanitizes invalid Python identifiers in single export variable name', () => {
+    const block: NotebookFunctionBlock = {
+      id: '123',
+      type: 'notebook-function',
+      content: '',
+      blockGroup: 'abc',
+      sortingKey: 'a0',
+      metadata: {
+        function_notebook_id: 'notebook-mno',
+        function_notebook_inputs: {},
+        function_notebook_export_mappings: {
+          output: {
+            enabled: true,
+            variable_name: 'data-frame',
+          },
+        },
+      },
+    }
+
+    const result = createPythonCodeForNotebookFunctionBlock(block)
+
+    // The assignment target is sanitized; the export_mappings payload keeps the original name
+    expect(result).toEqual(dedent`
+      # Notebook Function: notebook-mno
+      # Inputs: {}
+      # Exports: output -> data-frame
+      dataframe = _dntk.run_notebook_function(
+          'notebook-mno',
+          inputs={},
+          export_mappings={"output":"data-frame"}
+      )
+    `)
+  })
+
+  it('sanitizes invalid Python identifiers in multiple export variable names', () => {
+    const block: NotebookFunctionBlock = {
+      id: '123',
+      type: 'notebook-function',
+      content: '',
+      blockGroup: 'abc',
+      sortingKey: 'a0',
+      metadata: {
+        function_notebook_id: 'notebook-pqr',
+        function_notebook_inputs: {},
+        function_notebook_export_mappings: {
+          data: {
+            enabled: true,
+            variable_name: 'data-frame',
+          },
+          totals: {
+            enabled: true,
+            variable_name: 'total sales',
+          },
+        },
+      },
+    }
+
+    const result = createPythonCodeForNotebookFunctionBlock(block)
+
+    expect(result).toEqual(dedent`
+      # Notebook Function: notebook-pqr
+      # Inputs: {}
+      # Exports: data -> data-frame, totals -> total sales
+      dataframe, total_sales = _dntk.run_notebook_function(
+          'notebook-pqr',
+          inputs={},
+          export_mappings={"data":"data-frame","totals":"total sales"}
+      )
+    `)
+  })
+
+  it('strips invalid leading characters from export variable names', () => {
+    const block: NotebookFunctionBlock = {
+      id: '123',
+      type: 'notebook-function',
+      content: '',
+      blockGroup: 'abc',
+      sortingKey: 'a0',
+      metadata: {
+        function_notebook_id: 'notebook-stu',
+        function_notebook_inputs: {},
+        function_notebook_export_mappings: {
+          first: {
+            enabled: true,
+            variable_name: '1st_result',
+          },
+        },
+      },
+    }
+
+    const result = createPythonCodeForNotebookFunctionBlock(block)
+
+    expect(result).toEqual(dedent`
+      # Notebook Function: notebook-stu
+      # Inputs: {}
+      # Exports: first -> 1st_result
+      st_result = _dntk.run_notebook_function(
+          'notebook-stu',
+          inputs={},
+          export_mappings={"first":"1st_result"}
+      )
+    `)
+  })
+
+  it('falls back to a default variable name when single export variable_name is missing', () => {
+    const block: NotebookFunctionBlock = {
+      id: '123',
+      type: 'notebook-function',
+      content: '',
+      blockGroup: 'abc',
+      sortingKey: 'a0',
+      metadata: {
+        function_notebook_id: 'notebook-vwx',
+        function_notebook_inputs: {},
+        function_notebook_export_mappings: {
+          output: {
+            enabled: true,
+          },
+        },
+      },
+    }
+
+    const result = createPythonCodeForNotebookFunctionBlock(block)
+
+    expect(result).toContain('input_1 = _dntk.run_notebook_function(')
+  })
+
+  it('falls back to a default variable name when a multiple export variable_name is missing', () => {
+    const block: NotebookFunctionBlock = {
+      id: '123',
+      type: 'notebook-function',
+      content: '',
+      blockGroup: 'abc',
+      sortingKey: 'a0',
+      metadata: {
+        function_notebook_id: 'notebook-vwx',
+        function_notebook_inputs: {},
+        function_notebook_export_mappings: {
+          data: {
+            enabled: true,
+            variable_name: 'data-frame',
+          },
+          second: {
+            enabled: true,
+          },
+        },
+      },
+    }
+
+    const result = createPythonCodeForNotebookFunctionBlock(block)
+
+    expect(result).toContain('dataframe, input_1 = _dntk.run_notebook_function(')
+  })
+
   it('escapes special characters in notebook_id', () => {
     const block: NotebookFunctionBlock = {
       id: '123',

--- a/packages/blocks/src/blocks/notebook-function-blocks.ts
+++ b/packages/blocks/src/blocks/notebook-function-blocks.ts
@@ -1,7 +1,7 @@
 import { dedent } from 'ts-dedent'
 
 import type { DeepnoteBlock, NotebookFunctionBlock } from '../deepnote-file/deepnote-file-schema'
-import { escapePythonString } from './python-utils'
+import { escapePythonString, sanitizePythonVariableName } from './python-utils'
 
 export function isNotebookFunctionBlock(block: DeepnoteBlock): block is NotebookFunctionBlock {
   return block.type === 'notebook-function'
@@ -64,7 +64,7 @@ export function createPythonCodeForNotebookFunctionBlock(block: NotebookFunction
   }
 
   if (enabledExports.length === 1) {
-    const variableName = enabledExports[0][1]?.variable_name
+    const variableName = sanitizePythonVariableName(enabledExports[0][1]?.variable_name ?? '')
 
     return dedent`
       # Notebook Function: ${notebookId}
@@ -75,7 +75,9 @@ export function createPythonCodeForNotebookFunctionBlock(block: NotebookFunction
   }
 
   // Multiple exports: use tuple unpacking
-  const variableNames = enabledExports.map(([, mapping]) => mapping.variable_name).join(', ')
+  const variableNames = enabledExports
+    .map(([, mapping]) => sanitizePythonVariableName(mapping.variable_name ?? ''))
+    .join(', ')
 
   return dedent`
     # Notebook Function: ${notebookId}


### PR DESCRIPTION
## What

`notebook-function` blocks generated invalid Python when an export mapping's
`variable_name` was not a valid Python identifier, e.g.
`data-frame = _dntk.run_notebook_function(...)` (a `SyntaxError`).

## Why

`variable_name` is user-controllable (`function_notebook_export_mappings` is
`z.record(z.any())`) and used as the assignment target in generated code. Every other
codegen path (`input-blocks`, `button-blocks`, `sql-blocks`, `visualization-blocks`,
`python-snippets`) already routes variable names through `sanitizePythonVariableName`;
`notebook-function-blocks` was the only one that didn't.

## How

Apply `sanitizePythonVariableName` to the single- and multi-export assignment targets,
with a `?? ''` guard so a missing `variable_name` falls back to the helper's default
(`input_1`) instead of emitting `undefined = ...`. The `export_mappings` payload and the
human-readable `# Exports:` comment keep the original names (string data, not
identifiers), so this is a pure syntax-correctness fix.

Known limitations, deliberately out of scope for this minimal fix:

- Two names that sanitize to the same identifier produce `x, x = ...` in the
  tuple-unpacking path — valid Python where the last binding wins. Deduplication needs a
  naming policy, so it is left to a follow-up if desired.
- For a missing `variable_name`, the pre-existing `# Exports: name -> undefined` comment
  and the key being dropped from the `export_mappings` payload are unchanged and not
  pinned by tests; only the new sanitized fallback target is.
- Python keywords (e.g. `class`) pass through `sanitizePythonVariableName` unchanged —
  a pre-existing limitation of the shared helper affecting all call sites equally.

## Testing

Added regression tests for invalid identifiers (single export, tuple unpacking,
leading-digit) and the missing-name fallback (single + tuple). `pnpm build`, `pnpm test`
(2444 passed), `pnpm test:coverage`, `pnpm typecheck`, `pnpm lintAndFormat`,
`pnpm spell-check` all green locally.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved generated notebook code so export variable names are made valid for Python, including names that start with invalid characters.
  * Added sensible default names when an export name is missing, preventing malformed assignment code.
  * Preserved the original export names in the exported metadata while still generating valid Python assignments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->