### PR TITLE
fix(blocks): sanitize notebook-function export variable names

### DIFF
--- a/packages/blocks/src/blocks/notebook-function-blocks.test.ts
+++ b/packages/blocks/src/blocks/notebook-function-blocks.test.ts
@@ -285,6 +285,160 @@ describe('createPythonCodeForNotebookFunctionBlock', () => {
     `)
   })
 
+  it('sanitizes invalid Python identifiers in single export variable name', () => {
+    const block: NotebookFunctionBlock = {
+      id: '123',
+      type: 'notebook-function',
+      content: '',
+      blockGroup: 'abc',
+      sortingKey: 'a0',
+      metadata: {
+        function_notebook_id: 'notebook-mno',
+        function_notebook_inputs: {},
+        function_notebook_export_mappings: {
+          output: {
+            enabled: true,
+            variable_name: 'data-frame',
+          },
+        },
+      },
+    }
+
+    const result = createPythonCodeForNotebookFunctionBlock(block)
+
+    // The assignment target is sanitized; the export_mappings payload keeps the original name
+    expect(result).toEqual(dedent`
+      # Notebook Function: notebook-mno
+      # Inputs: {}
+      # Exports: output -> data-frame
+      dataframe = _dntk.run_notebook_function(
+          'notebook-mno',
+          inputs={},
+          export_mappings={"output":"data-frame"}
+      )
+    `)
+  })
+
+  it('sanitizes invalid Python identifiers in multiple export variable names', () => {
+    const block: NotebookFunctionBlock = {
+      id: '123',
+      type: 'notebook-function',
+      content: '',
+      blockGroup: 'abc',
+      sortingKey: 'a0',
+      metadata: {
+        function_notebook_id: 'notebook-pqr',
+        function_notebook_inputs: {},
+        function_notebook_export_mappings: {
+          data: {
+            enabled: true,
+            variable_name: 'data-frame',
+          },
+          totals: {
+            enabled: true,
+            variable_name: 'total sales',
+          },
+        },
+      },
+    }
+
+    const result = createPythonCodeForNotebookFunctionBlock(block)
+
+    expect(result).toEqual(dedent`
+      # Notebook Function: notebook-pqr
+      # Inputs: {}
+      # Exports: data -> data-frame, totals -> total sales
+      dataframe, total_sales = _dntk.run_notebook_function(
+          'notebook-pqr',
+          inputs={},
+          export_mappings={"data":"data-frame","totals":"total sales"}
+      )
+    `)
+  })
+
+  it('strips invalid leading characters from export variable names', () => {
+    const block: NotebookFunctionBlock = {
+      id: '123',
+      type: 'notebook-function',
+      content: '',
+      blockGroup: 'abc',
+      sortingKey: 'a0',
+      metadata: {
+        function_notebook_id: 'notebook-stu',
+        function_notebook_inputs: {},
+        function_notebook_export_mappings: {
+          first: {
+            enabled: true,
+            variable_name: '1st_result',
+          },
+        },
+      },
+    }
+
+    const result = createPythonCodeForNotebookFunctionBlock(block)
+
+    expect(result).toEqual(dedent`
+      # Notebook Function: notebook-stu
+      # Inputs: {}
+      # Exports: first -> 1st_result
+      st_result = _dntk.run_notebook_function(
+          'notebook-stu',
+          inputs={},
+          export_mappings={"first":"1st_result"}
+      )
+    `)
+  })
+
+  it('falls back to a default variable name when single export variable_name is missing', () => {
+    const block: NotebookFunctionBlock = {
+      id: '123',
+      type: 'notebook-function',
+      content: '',
+      blockGroup: 'abc',
+      sortingKey: 'a0',
+      metadata: {
+        function_notebook_id: 'notebook-vwx',
+        function_notebook_inputs: {},
+        function_notebook_export_mappings: {
+          output: {
+            enabled: true,
+          },
+        },
+      },
+    }
+
+    const result = createPythonCodeForNotebookFunctionBlock(block)
+
+    expect(result).toContain('input_1 = _dntk.run_notebook_function(')
+  })
+
+  it('falls back to a default variable name when a multiple export variable_name is missing', () => {
+    const block: NotebookFunctionBlock = {
+      id: '123',
+      type: 'notebook-function',
+      content: '',
+      blockGroup: 'abc',
+      sortingKey: 'a0',
+      metadata: {
+        function_notebook_id: 'notebook-vwx',
+        function_notebook_inputs: {},
+        function_notebook_export_mappings: {
+          data: {
+            enabled: true,
+            variable_name: 'data-frame',
+          },
+          second: {
+            enabled: true,
+          },
+        },
+      },
+    }
+
+    const result = createPythonCodeForNotebookFunctionBlock(block)
+
+    expect(result).toContain('dataframe, input_1 = _dntk.run_notebook_function(')
+  })
+
   it('escapes special characters in notebook_id', () => {
     const block: NotebookFunctionBlock = {
       id: '123',

--- a/packages/blocks/src/blocks/notebook-function-blocks.ts
+++ b/packages/blocks/src/blocks/notebook-function-blocks.ts
@@ -1,7 +1,7 @@
 import { dedent } from 'ts-dedent'
 
 import type { DeepnoteBlock, NotebookFunctionBlock } from '../deepnote-file/deepnote-file-schema'
-import { escapePythonString } from './python-utils'
+import { escapePythonString, sanitizePythonVariableName } from './python-utils'
 
 export function isNotebookFunctionBlock(block: DeepnoteBlock): block is NotebookFunctionBlock {
   return block.type === 'notebook-function'
@@ -64,7 +64,7 @@ export function createPythonCodeForNotebookFunctionBlock(block: NotebookFunction
   }
 
   if (enabledExports.length === 1) {
-    const variableName = enabledExports[0][1]?.variable_name
+    const variableName = sanitizePythonVariableName(enabledExports[0][1]?.variable_name ?? '')
 
     return dedent`
       # Notebook Function: ${notebookId}
@@ -75,7 +75,9 @@ export function createPythonCodeForNotebookFunctionBlock(block: NotebookFunction
   }
 
   // Multiple exports: use tuple unpacking
-  const variableNames = enabledExports.map(([, mapping]) => mapping.variable_name).join(', ')
+  const variableNames = enabledExports
+    .map(([, mapping]) => sanitizePythonVariableName(mapping.variable_name ?? ''))
+    .join(', ')
 
   return dedent`
     # Notebook Function: ${notebookId}


### PR DESCRIPTION
Supersedes #413 (original head repo was deleted; PR head could not be re-associated).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved notebook function code generation so exported variable names are turned into valid Python identifiers.
  * Added safer fallback naming when export names are missing or incomplete, including multi-output cases.  

* **Tests**
  * Expanded coverage for valid Python naming, sanitization, and default variable assignment behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->