### PR TITLE
feat(local-runner): run an agent block in the run-app demo

### DIFF
--- a/examples/local-runner-showcase.deepnote
+++ b/examples/local-runner-showcase.deepnote
@@ -22,7 +22,11 @@ project:
           content: |-
             Edit the inputs, then **Run** — the notebook recomputes a small revenue
             dashboard (a KPI, a table, and a chart) from deterministic synthetic data.
-            No API keys, no network.
+
+            The dashboard needs no API keys and no network. The **agent block** at the
+            end does: **Run** reads `OPENAI_API_KEY` from the environment, while **Run
+            in cloud** needs only `DEEPNOTE_TOKEN` — Deepnote supplies the model there.
+            With no key the dashboard still renders and only the agent block errors.
           metadata: {}
         - blockGroup: g0000000-0000-0000-0000-000000000003
           id: b0000000000000000000000000000003
@@ -290,4 +294,24 @@ project:
             </div>
             ''')
           metadata: {}
+        - blockGroup: g0000000-0000-0000-0000-000000000010
+          id: b0000000000000000000000000000010
+          sortingKey: b5
+          type: agent
+          content: |-
+            Write a short executive readout of this quarter for the sales lead.
+
+            Work from what the notebook already computed — the `view` dataframe (the
+            selected regions and months), `by_region`, and the `total`, `target_total`,
+            `pct` and `delta` values. Do not reload or regenerate the data.
+
+            1. Add one code block that ranks each region in `view` by month-over-month
+               growth and prints the strongest and weakest with their rates.
+            2. Add one markdown block: three bullets on what stands out this period,
+               then one recommendation line.
+
+            Stop after those two blocks. Quote the actual numbers you computed, and
+            take the analyst notes above into account.
+          metadata:
+            deepnote_agent_model: auto
 version: 1.0.0

--- a/examples/local-runner/README.md
+++ b/examples/local-runner/README.md
@@ -14,8 +14,10 @@ hosting.** Both scripts build the package first, so a clean checkout works with 
 Both examples draw on two committed artifacts at the `examples/` root:
 
 - [`local-runner-showcase.deepnote`](../local-runner-showcase.deepnote) — an input-rich sales
-  dashboard (a KPI, a table, a chart, and a written summary). Deterministic and key-free, so the
-  run-app can execute it live.
+  dashboard (a KPI, a table, a chart, and a written summary), closing with an **agent block** that
+  writes an executive readout. The dashboard is deterministic and key-free; only the agent block
+  needs a key, and it runs last, so a keyless run still renders the whole dashboard and reports the
+  error on that block alone.
 - [`snapshot-showcase.snapshot.deepnote`](../snapshot-showcase.snapshot.deepnote) — that dashboard,
   already run, plus an **agent block with precomputed output**. The snapshot viewer renders it with
   zero setup, showing agent-block support without anyone needing an API key.

--- a/examples/local-runner/run-app/README.md
+++ b/examples/local-runner/run-app/README.md
@@ -1,8 +1,9 @@
 # run-app
 
 A page that runs [`../../local-runner-showcase.deepnote`](../../local-runner-showcase.deepnote)
-locally: edit the inputs, click **Run**, and real Python output — a KPI, a table, a chart — comes
-back, powered entirely by [`@deepnote/local-runner`](../../../packages/local-runner)'s `serveStatic`.
+locally: edit the inputs, click **Run**, and real Python output — a KPI, a table, a chart, and an
+agent-written readout — comes back, powered entirely by
+[`@deepnote/local-runner`](../../../packages/local-runner)'s `serveStatic`.
 
 It's an app shell, not a document: an inputs panel on the left, a results canvas on the right. Two
 files do the work — [`serve.mjs`](./serve.mjs) (`serveStatic({ dir, notebookPath })`) and
@@ -22,13 +23,26 @@ pnpm example:local-runner
 That builds the package and starts the server. Edit the inputs and hit **Run** — the notebook
 executes in a local kernel and the dashboard updates.
 
+The notebook's last block is an **agent block**, which needs an OpenAI key to run locally:
+
+```bash
+OPENAI_API_KEY=sk-... pnpm example:local-runner
+```
+
+`serve.mjs` also reads a `.env` in the working directory (like `deepnote run`), so the key can live
+there instead — the startup banner prints which keys it found. Without one, the dashboard still
+renders in full and only the agent block reports the missing key: it runs last, and the engine stops
+at the first failing block. `deepnote_agent_model: auto` resolves to `$OPENAI_MODEL` (default
+`gpt-5`) locally; in the cloud Deepnote picks the model.
+
 ## Run in Deepnote Cloud
 
 The page also has a **Run in cloud** button, wired to `POST /api/run-cloud` → `runInCloud` → the
 shared `@deepnote/cloud` client (the same one behind `deepnote run --cloud`). It runs the notebook in
 Deepnote Cloud and renders the returned snapshot.
 
-It needs a `DEEPNOTE_TOKEN`:
+It needs a `DEEPNOTE_TOKEN` — and only that: the agent block runs on Deepnote's side there, so no
+`OPENAI_API_KEY` is involved in a cloud run.
 
 ```bash
 DEEPNOTE_TOKEN=... pnpm example:local-runner

--- a/examples/local-runner/run-app/serve.mjs
+++ b/examples/local-runner/run-app/serve.mjs
@@ -7,10 +7,20 @@ import { serveStatic } from '../../../packages/local-runner/dist/index.js'
 
 const here = dirname(fileURLToPath(import.meta.url))
 
+// Read `.env` from the working directory, like `deepnote run` does, so the keys the notebook's
+// agent block needs can live in a file rather than your shell: OPENAI_API_KEY for `Run` (local
+// kernel), DEEPNOTE_TOKEN for `Run in cloud`. Absent `.env` is fine — the environment may carry
+// them already, and the dashboard blocks need neither.
+try {
+  process.loadEnvFile()
+} catch {}
+
 const { port } = await serveStatic({
   dir: here, // serve index.html from this folder
   notebookPath: join(here, '..', '..', 'local-runner-showcase.deepnote'), // the notebook to run
   persistSnapshot: false, // this is an interactive demo — don't litter the repo with snapshot files
 })
 
-console.log(`\n  Deepnote local-runner · run app → http://127.0.0.1:${port}\n`)
+const has = k => (process.env[k] ? '✓' : '—')
+console.log(`\n  Deepnote local-runner · run app → http://127.0.0.1:${port}`)
+console.log(`  Run: OPENAI_API_KEY ${has('OPENAI_API_KEY')}   Run in cloud: DEEPNOTE_TOKEN ${has('DEEPNOTE_TOKEN')}\n`)


### PR DESCRIPTION
Chained on #419 — review that first; this diff is only the agent block on top of it.

## What and why

The run-app executed Python live but contained **zero agent blocks**, so the only agent block a reader could actually see was the snapshot-viewer's precomputed one. You could read the agent support, but never watch it run.

This adds a real agent block to `local-runner-showcase.deepnote`. It writes an executive readout from what the dashboard already computed, and **both** Run paths execute it for real.

## The one non-obvious design point

The agent block runs **last**, and that ordering is load-bearing rather than cosmetic. The engine `break`s at the first failing block (`execution-engine.ts:425`), so placed anywhere earlier a missing key would take the whole dashboard down with it. At the end, a keyless run still renders every dashboard block and reports the error on the agent block alone — the demo degrades to exactly one error card.

`deepnote_agent_model: auto` is what lets one notebook serve both paths: locally it resolves to `$OPENAI_MODEL` (default `gpt-5`); in the cloud Deepnote picks the model.

## Verified end-to-end (not just typechecked)

| Path | Credential | Result |
| --- | --- | --- |
| `Run` (local kernel) | `OPENAI_API_KEY` | `failedBlocks: 0`; agent called `add_code_block` + `add_markdown_block` |
| `Run in cloud` | `DEEPNOTE_TOKEN` **only** | run `4005cab5` `success`; no OpenAI key involved |

The cloud agent inserted a code block computing real month-over-month growth (`North America +11.2%`, `Asia Pacific -2.2%`) and a readout citing both the computed figures and the `analyst_notes` input — so notebook inputs reach the agent, not just the Python blocks.

## Also here

`serve.mjs` now reads `.env` like `deepnote run` does (it previously did not — only the CLI loaded it), and prints which keys it found, so a missing key shows up at startup instead of mid-run:

```
Run: OPENAI_API_KEY ✓   Run in cloud: DEEPNOTE_TOKEN ✓
```

READMEs updated: the showcase was documented as "deterministic and key-free", which is now true only of the dashboard, not the agent block.

## Two findings for reviewers (not fixed here)

1. **A unit test is environment-dependent.** `packages/cli/src/utils/run-in-cloud.test.ts > requires a token (missing)` assumes the developer has no real token. `run-in-cloud.ts:297` calls `dotenv.config()` on the cwd, so once you put a `DEEPNOTE_TOKEN` in `.env` — which this PR's README now tells you to do — the test fails **and makes a live call to api.deepnote.com**. Green in CI (no `.env` there); fails locally for anyone set up to use the cloud button. Worth a hermetic fix in its own PR.
2. **Local and cloud produce different artifacts for the same notebook.** The agent block emits `stream` locally but `display_data` in the cloud, and the inserted block is `markdown` locally vs `text-cell-p` in the cloud. Both render fine in run-app, so nothing is broken — but anything that diffs a local snapshot against a cloud one would see it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an AI-generated executive readout to the showcase notebook, including regional growth rankings, key observations, and a recommendation based on computed dashboard values.
  - Local app startup now loads environment settings from a working-directory `.env` file and reports credential availability.

- **Documentation**
  - Clarified execution order and credential requirements for local and cloud runs.
  - Documented that the dashboard renders without credentials, while the final AI readout requires appropriate configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->