### PR TITLE
fix(database-integrations): redact Snowflake dbtServiceToken in integrations file

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -44,6 +44,7 @@
     "daed",
     "dataframe",
     "dateutil",
+    "DBTSERVICETOKEN",
     "deepnote",
     "defu",
     "dntk",

--- a/packages/cli/src/commands/integrations.test.ts
+++ b/packages/cli/src/commands/integrations.test.ts
@@ -187,12 +187,13 @@ describe('integrations command', () => {
       expect(paths).toContain('password')
     })
 
-    it('handles snowflake secrets (password, privateKey, privateKeyPassphrase)', async () => {
+    it('handles snowflake secrets (password, privateKey, privateKeyPassphrase, dbtServiceToken)', async () => {
       const { getSecretFieldPaths } = await import('@deepnote/database-integrations')
       const paths = getSecretFieldPaths('snowflake')
       expect(paths).toContain('password')
       expect(paths).toContain('privateKey')
       expect(paths).toContain('privateKeyPassphrase')
+      expect(paths).toContain('dbtServiceToken')
     })
 
     it('handles bigquery service account', async () => {

--- a/packages/database-integrations/src/loading/merge-integrations.test.ts
+++ b/packages/database-integrations/src/loading/merge-integrations.test.ts
@@ -343,8 +343,8 @@ describe('merge-integrations', () => {
       const content = await readFile(filePath, 'utf-8')
 
       expect(content).not.toContain(serviceToken)
-      expect(content).toContain('dbtServiceToken: env:')
-      expect(Object.values(secrets)).toContain(serviceToken)
+      expect(content).toContain('dbtServiceToken: env:SNOWFLAKE_DBT_ID__DBTSERVICETOKEN')
+      expect(secrets).toMatchObject({ 'SNOWFLAKE_DBT_ID__DBTSERVICETOKEN': serviceToken })
 
       // The remaining dbt fields are not credentials and stay in the file
       expect(content).toContain('dbtPrimaryJobId: "12345"')

--- a/packages/database-integrations/src/loading/merge-integrations.test.ts
+++ b/packages/database-integrations/src/loading/merge-integrations.test.ts
@@ -316,6 +316,7 @@ describe('merge-integrations', () => {
 
     it('extracts the snowflake dbt service token, which is shared by every auth method', async () => {
       const filePath = join(tempDir, 'snowflake-dbt.yaml')
+      const serviceToken = 'my-secret-service-token'
 
       const apiIntegrations = [
         createMockApiIntegration({
@@ -328,7 +329,7 @@ describe('merge-integrations', () => {
             username: 'my-user',
             password: 'my-password',
             dbt: true,
-            dbtServiceToken: 'dbtc_super-secret-token',
+            dbtServiceToken: serviceToken,
             dbtPrimaryJobId: '12345',
             dbtProxyServerUrl: 'https://proxy.example.com',
           },
@@ -341,8 +342,9 @@ describe('merge-integrations', () => {
       await writeIntegrationsFile(filePath, doc)
       const content = await readFile(filePath, 'utf-8')
 
-      expect(content).not.toContain('dbtc_super-secret-token')
-      expect(secrets).toMatchObject({ 'SNOWFLAKE_DBT_ID__DBTSERVICETOKEN': 'dbtc_super-secret-token' })
+      expect(content).not.toContain(serviceToken)
+      expect(content).toContain('dbtServiceToken: env:')
+      expect(Object.values(secrets)).toContain(serviceToken)
 
       // The remaining dbt fields are not credentials and stay in the file
       expect(content).toContain('dbtPrimaryJobId: "12345"')

--- a/packages/database-integrations/src/loading/merge-integrations.test.ts
+++ b/packages/database-integrations/src/loading/merge-integrations.test.ts
@@ -12,6 +12,7 @@ import {
   mergeApiIntegrationsIntoDocument,
   mergeProcessedIntegrations,
 } from './merge-integrations'
+import { parseIntegrations } from './parse-integrations'
 
 async function readIntegrationsDocument(filePath: string): Promise<Document | null> {
   const content = await readFile(filePath, 'utf-8')
@@ -342,9 +343,22 @@ describe('merge-integrations', () => {
       await writeIntegrationsFile(filePath, doc)
       const content = await readFile(filePath, 'utf-8')
 
+      // The token must not reach the file, and the reference left behind must name
+      // the env var the user is expected to define.
       expect(content).not.toContain(serviceToken)
       expect(content).toContain('dbtServiceToken: env:SNOWFLAKE_DBT_ID__DBTSERVICETOKEN')
       expect(secrets).toMatchObject({ 'SNOWFLAKE_DBT_ID__DBTSERVICETOKEN': serviceToken })
+
+      // Reading the file back through the parser that consumes it must resolve the
+      // reference to the original token — a reference that does not match the key in
+      // `secrets` would surface here as an env_var_not_defined issue.
+      const { integrations, issues } = parseIntegrations({ yaml: content, env: secrets })
+      expect(issues).toEqual([])
+      const integration = integrations[0]
+      if (integration?.type !== 'snowflake') {
+        throw new Error('Expected a snowflake integration')
+      }
+      expect(integration.metadata.dbtServiceToken).toBe(serviceToken)
 
       // The remaining dbt fields are not credentials and stay in the file
       expect(content).toContain('dbtPrimaryJobId: "12345"')

--- a/packages/database-integrations/src/loading/merge-integrations.test.ts
+++ b/packages/database-integrations/src/loading/merge-integrations.test.ts
@@ -314,6 +314,41 @@ describe('merge-integrations', () => {
       expect(Object.values(secrets)).toContain('some-passphrase')
     })
 
+    it('extracts the snowflake dbt service token, which is shared by every auth method', async () => {
+      const filePath = join(tempDir, 'snowflake-dbt.yaml')
+
+      const apiIntegrations = [
+        createMockApiIntegration({
+          id: 'snowflake-dbt-id',
+          name: 'Snowflake with dbt',
+          type: 'snowflake',
+          metadata: {
+            accountName: 'my-account',
+            authMethod: 'password',
+            username: 'my-user',
+            password: 'my-password',
+            dbt: true,
+            dbtServiceToken: 'dbtc_super-secret-token',
+            dbtPrimaryJobId: '12345',
+            dbtProxyServerUrl: 'https://proxy.example.com',
+          },
+        }),
+      ]
+
+      const doc = createNewDocument()
+      const { secrets } = mergeApiIntegrationsIntoDocument(doc, apiIntegrations)
+
+      await writeIntegrationsFile(filePath, doc)
+      const content = await readFile(filePath, 'utf-8')
+
+      expect(content).not.toContain('dbtc_super-secret-token')
+      expect(secrets).toMatchObject({ 'SNOWFLAKE_DBT_ID__DBTSERVICETOKEN': 'dbtc_super-secret-token' })
+
+      // The remaining dbt fields are not credentials and stay in the file
+      expect(content).toContain('dbtPrimaryJobId: "12345"')
+      expect(content).toContain('dbtProxyServerUrl: https://proxy.example.com')
+    })
+
     it('handles integrations with no secrets', async () => {
       const filePath = join(tempDir, 'no-secrets.yaml')
 

--- a/packages/database-integrations/src/secret-field-paths.ts
+++ b/packages/database-integrations/src/secret-field-paths.ts
@@ -54,8 +54,8 @@ const SECRET_PATHS: { [K in DatabaseIntegrationType]: readonly MetadataKey<K>[] 
   // BigQuery - service account or OAuth
   'big-query': ['service_account', 'clientSecret'],
 
-  // Snowflake - various auth methods
-  snowflake: ['password', 'clientSecret', 'privateKey', 'privateKeyPassphrase'],
+  // Snowflake - various auth methods. `dbtServiceToken` is shared by all of them.
+  snowflake: ['password', 'clientSecret', 'privateKey', 'privateKeyPassphrase', 'dbtServiceToken'],
 
   // Redshift - password or IAM
   redshift: ['password', 'caCertificateText'],
@@ -76,7 +76,7 @@ const SECRET_PATHS: { [K in DatabaseIntegrationType]: readonly MetadataKey<K>[] 
  *
  * @example
  * getSecretFieldPaths('pgsql') // => ['password', 'caCertificateText']
- * getSecretFieldPaths('snowflake') // => ['password', 'clientSecret', 'privateKey', 'privateKeyPassphrase']
+ * getSecretFieldPaths('snowflake') // => ['password', 'clientSecret', 'privateKey', 'privateKeyPassphrase', 'dbtServiceToken']
  */
 export function getSecretFieldPaths(type: DatabaseIntegrationType): readonly string[] {
   return SECRET_PATHS[type] ?? []


### PR DESCRIPTION
## Summary

`dbtServiceToken` — a [dbt Cloud service token](https://docs.getdbt.com/docs/dbt-cloud-apis/service-tokens) — was written into `integrations.yaml` in **cleartext** instead of being extracted into an env var reference. Since that file is meant to be committed, the token could reach version control.

This was an oversight in the original redaction implementation.

## Root cause

`dbtServiceToken` is declared on `commonSnowflakeMetadataSchema`, so it is inherited by **all six** Snowflake auth variants. But `SECRET_PATHS.snowflake` only listed the credentials belonging to individual auth variants:

```ts
snowflake: ['password', 'clientSecret', 'privateKey', 'privateKeyPassphrase'],
```

`updateIntegrationMetadataMap` treats that list as an allowlist and writes everything else through untouched:

```ts
if (!secretPaths.includes(key)) { metadataMap.set(key, value); continue }
```

So the field on the *shared base* was missed while every field on the *variants* was covered — the token fell straight through to disk.

## Impact

Reachable via `deepnote integrations pull` for any Snowflake integration with dbt enabled. The dbt fields are `Omit`ted from the interactive prompts (`integrations-prompts/snowflake.ts`), so the API sync path was the only way to populate it — which is why the regression test targets `mergeApiIntegrationsIntoDocument` rather than the prompts.

> [!IMPORTANT]
> Anyone whose `integrations.yaml` already contains a literal `dbtServiceToken` should **rotate that token** in dbt Cloud and scrub it from git history. The fix prevents new writes; it cannot retract tokens already committed.

## Changes

- `secret-field-paths.ts` — add `dbtServiceToken` to `SECRET_PATHS.snowflake` (+ update the doc example).
- `merge-integrations.test.ts` — regression test on the API sync path.
- `integrations.test.ts` — extend the Snowflake secret-paths assertion.

`dbt`, `dbtPrimaryJobId` and `dbtProxyServerUrl` are not credentials and deliberately remain in the file.

## Verification

The test fails without the fix, with the token visible in the emitted YAML:

```
AssertionError: expected '#yaml-language-server: $schema=https:…' not to contain 'dbtc_super-secret-token'
```

After the fix:

```yaml
metadata:
  dbtServiceToken: env:SNOWFLAKE_DBT_ID__DBTSERVICETOKEN   # extracted
  dbtPrimaryJobId: "12345"                                 # unchanged
  dbtProxyServerUrl: https://proxy.example.com             # unchanged
```

`packages/database-integrations` + `packages/cli/src/commands/integrations.test.ts` pass (326 tests); biome clean.

<details>
<summary>Pre-existing unrelated failures on <code>main</code></summary>

Six `packages/cli` test files fail to collect with `Cannot find package 'zod' imported from packages/cloud/src/cloud-runs.ts`, and `tsc` reports two errors in the same file. Both reproduce on a clean checkout of `main` (`c6fcb8c`) and are untouched by this PR.
</details>

## Audit of the other integrations

All 18 remaining integration types were swept for the same bug class — every field across every union variant, cross-checked against vendor documentation. **No other cleartext credential leaks were found.** Two candidates were investigated and rejected:

| Field | Verdict |
|---|---|
| `redshift.roleNonce` | Not a credential. AWS explicitly documents the sibling External ID as non-secret, and `roleNonce` is prompted as a plain string and never read by any code. |
| `mongodb.options` | Not a credential field by design — see below. |

### Follow-up worth a maintainer decision (not addressed here)

`mongodb.options` is concatenated into `connection_string` (`integrations-prompts/mongodb.ts:74`), and `connection_string` **is** redacted — so the same bytes are treated differently depending on which field they land in:

```yaml
options: tlsCertificateKeyFilePassword=SUPERSECRET&retryWrites=true   # cleartext
connection_string: env:MONGO_1__CONNECTION_STRING                     # redacted
```

Left alone deliberately: MongoDB documents `options` as connection tuning (`retryWrites`, `w`, `readPreference`), the prompt code classifies it as non-secret, and adding it to `SECRET_PATHS` would push benign config into env vars. But `tlsCertificateKeyFilePassword`, `proxyPassword` and `authMechanismProperties=AWS_SESSION_TOKEN:…` are real options that would leak. If worth closing, selective key-level redaction inside `options` seems better than redacting the whole field.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J1kuzoQrpYv35P7hkNKGHa


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Snowflake integration handling so DBT service tokens are securely extracted into the secrets configuration.
  * Ensured Snowflake DBT metadata is preserved in generated configuration files without exposing the raw token.
* **Documentation**
  * Updated Snowflake secret-field documentation to include the DBT service token.
* **Tests**
  * Expanded Snowflake test coverage to verify secret extraction and correct YAML/env references, including `dbtServiceToken`.
* **Chores**
  * Updated spelling configuration to recognize `DBTSERVICETOKEN`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->