### PR TITLE
docs: correct dark mode documentation

### DIFF
--- a/docs/dark-mode.md
+++ b/docs/dark-mode.md
@@ -4,6 +4,4 @@ noIndex: false
 noContent: false
 ---
 
-Deepnote supports dark mode. You can find the settings under “Preferences” > “Theme.”
-
-Alternatively, you can switch to dark mode by opening the command palette and searching for the “Switch to dark mode” command.
+Deepnote supports dark mode. In Settings & members, select Account, then choose Dark under Appearance > Interface theme.


### PR DESCRIPTION
## What this changes

- Updates the dark mode settings route to match Settings & members > Account > Appearance > Interface theme.
- Removes the unavailable command palette search instruction.

Linear ticket is not filed yet. See the local run artifact for the prepared ticket text and add `Closes <ID>` after filing it.

## Why

The documentation audit executed https://deepnote.com/docs/dark-mode against the real product and found reproducible differences.

### Finding 1: cosmetic

> Deepnote supports dark mode. You can find the settings under “Preferences” > “Theme.”

- **Documented:** The settings are under Preferences > Theme.
- **Actual:** The route is Settings & members > Account > Appearance > Interface theme, and Dark changes the interface to dark mode.
- **Reproduced:** Yes. The route and Dark selection were confirmed twice.
- **Correction:** Replaced the sentence with the current product route.

### Finding 2: blocking

> Alternatively, you can switch to dark mode by opening the command palette and searching for the “Switch to dark mode” command.

- **Documented:** The command palette contains a Switch to dark mode command.
- **Actual:** Search returned 0 results for the exact query on two attempts.
- **Reproduced:** Yes.
- **Correction:** Removed the unsupported paragraph.

## How this was verified

Every documented step was performed through the real Chrome UI using the throwaway audit account in the dedicated audit workspace. No production workspace was touched. The account theme was restored to Light. No project was created.

Opened automatically by the `doc-verify` skill from the approved GitHub account. Not reviewed by a human.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated dark-mode instructions to reflect the current navigation path in Settings.
  * Removed outdated command-palette instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->