### PR TITLE
docs: update Projects sidebar and environment instructions

### DIFF
--- a/docs/projects.md
+++ b/docs/projects.md
@@ -26,7 +26,7 @@ Let's move to the newly created Project panel now. Notice that the left panel ha
 
 ### Learning the most important bits
 
-The Project sidebar on the left contains sections for your notebooks, integrations, files, the environment, and more. Let's learn about each of these in detail.
+The project interface includes a **Notebooks** section in the left sidebar. Integrations, files, and machine settings are available in the right sidebar. Let's learn about each of these in detail.
 
 ![Important Bits.jpg](../assets/docs/h9lkwiibTeSNaquQx2If.jpg)
 <br></br><br></br>
@@ -53,7 +53,7 @@ Got a `requirements.txt` file? We create one for you when you `pip` install a pa
 
 Time to get serious. You probably want to know how to configure your environment. Let's dive into what you can do in the **Environment** section.
 
-First, click on the ⚙️ icon. You should now see your environment configuration options (shown below). Follow me.
+In the right sidebar, click the current Python environment to view the available environment configuration options.
 
 ![Environment.jpg](../assets/docs/PSMiDJAtRlFgQrhOIsVA.jpg)
 


### PR DESCRIPTION
Updates the Projects page to match the current product UI. The approved Docchecking workspace showed notebooks in the left sidebar, with integrations, files, machine settings, and the Python environment control in the right sidebar. The current Python control opens Environment selection. The temporary project, terminal, and duplicate project were created only for verification and were deleted afterward. Screenshot replacement remains a separate blocked lead because the available Chrome capture did not meet the required native source size.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated project navigation guidance to clarify sidebar placement for Notebooks, integrations, files, and machine settings.
  * Revised environment instructions to direct users to select the current Python environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->