### PR TITLE
docs: fix numbering, embed sizing, and integration links

### DIFF
--- a/docs/airtable.md
+++ b/docs/airtable.md
@@ -103,7 +103,7 @@ df = fetch_airtable_data(AIRTABLE_BASE_ID, AIRTABLE_TABLE_NAME, AIRTABLE_TOKEN)
 df
 ```
 
-<iframe title="Embedded cell output" src="https://embed.deepnote.com/89226e1d-380f-447a-924e-79271fc232ae/f0abc3c611164a2fbcb56b8cabaab7b5/edd266a97ca54f93b823779115fc2973?height=431"/>
+<Embed url="https://embed.deepnote.com/89226e1d-380f-447a-924e-79271fc232ae/f0abc3c611164a2fbcb56b8cabaab7b5/edd266a97ca54f93b823779115fc2973?height=577" />
 
 ### Analyze your data with SQL
 
@@ -120,7 +120,7 @@ WHERE
   NOT ("Status" = 'Closed' OR "Status" = 'Lost')
 ```
 
-<iframe title="Embedded cell output" src="https://embed.deepnote.com/89226e1d-380f-447a-924e-79271fc232ae/f0abc3c611164a2fbcb56b8cabaab7b5/a9e9543ce04d4cc88020a943d6382455?"  />
+<Embed url="https://embed.deepnote.com/89226e1d-380f-447a-924e-79271fc232ae/f0abc3c611164a2fbcb56b8cabaab7b5/a9e9543ce04d4cc88020a943d6382455?height=577" />
 
 ### Visualize data
 

--- a/docs/auto-grading-solutions.md
+++ b/docs/auto-grading-solutions.md
@@ -53,7 +53,7 @@ Doc tests are a way to embed test cases within the documentation for a piece of 
 Check out our [Deepnote notebook with doc tests](https://deepnote.com/workspace/Deepnote-classroom-template-ef3ec34d-be29-481f-a95d-9384fc1dd07e/project/4-Doc-tests-1e6f63a1-039d-493c-8d96-9b2ef1053a84) template to learn more. You can duplicate it and use it for your own purposes.
 </Callout>
 
-### 5.) Unit tests
+## 5. Unit tests
 
 ![Screenshot 2022-12-22 at 14.32.21.png](../assets/docs/BdWLwJfySTCH1ymnKQGJ.webp)
 

--- a/docs/dbt.md
+++ b/docs/dbt.md
@@ -13,12 +13,12 @@ dbt specializes in the Transform step of the ELT (Extract, Load, Transform) proc
 
 In Deepnote, you can use the following adapters for your dbt development workflow:
 
-- Snowflake
-- BigQuery
-- Redshift
-- Postgres
-- Databricks
-- Clickhouse
+- [Snowflake](/docs/snowflake)
+- [BigQuery](/docs/google-bigquery)
+- [Redshift](/docs/amazon-redshift)
+- [Postgres](/docs/postgresql)
+- [Databricks](/docs/databricks)
+- [Clickhouse](/docs/clickhouse)
 
 <Callout status="info">
 If you wish to use dbt for its Semantic Layer (MetricFlow) capabilities, please see your options [here](https://deepnote.com/docs/semantic-layer).

--- a/docs/vscode-extension.md
+++ b/docs/vscode-extension.md
@@ -92,23 +92,23 @@ Integrations allow you to connect to data sources and other tools. To manage int
 
 **Supported data sources:**
 
-- ClickHouse
-- Amazon Redshift
-- Amazon Athena
-- Google BigQuery
-- Snowflake
-- Databricks
-- Dremio
-- Trino
-- MongoDB
-- PostgreSQL
-- MySQL
-- MariaDB
-- Microsoft SQL Server
-- Google AlloyDB
-- Google Cloud Spanner
-- Materialize
-- MindsDB
+- [ClickHouse](/docs/clickhouse)
+- [Amazon Redshift](/docs/amazon-redshift)
+- [Amazon Athena](/docs/amazon-athena)
+- [Google BigQuery](/docs/google-bigquery)
+- [Snowflake](/docs/snowflake)
+- [Databricks](/docs/databricks)
+- [Dremio](/docs/dremio)
+- [Trino](/docs/trino)
+- [MongoDB](/docs/mongodb)
+- [PostgreSQL](/docs/postgresql)
+- [MySQL](/docs/mysql)
+- [MariaDB](/docs/mysql)
+- [Microsoft SQL Server](/docs/sql-server)
+- [Google AlloyDB](/docs/google-alloydb)
+- [Google Cloud Spanner](/docs/google-spanner)
+- [Materialize](/docs/materialize)
+- [MindsDB](/docs/mindsdb)
 
 Your credentials are stored encrypted. We also support enforcing SSL connections and SSH tunnels for secure access.
 


### PR DESCRIPTION
The VS Code and dbt integration lists left readers searching for setup guides, and the Airtable embeds gave their output too little space. The unit tests heading broke the auto-grading page’s section hierarchy. Prettier and the pre-push checks pass.