### PR TITLE
refactor(examples): one Run button against one configurable endpoint

### DIFF
--- a/examples/local-runner/cloud-app/README.md
+++ b/examples/local-runner/cloud-app/README.md
@@ -1,32 +1,29 @@
-# Cloud app
+# Deepnote app
 
-A self-contained dynamic app that calls the Deepnote API directly from the browser — no server required for cloud execution.
+A self-contained dynamic app that runs notebooks via the Deepnote `/v2/runs` API directly from the browser — no server required.
 
 ## How it works
 
+One configurable `baseUrl` determines where runs execute. Point it at `api.deepnote.com` for cloud execution, or at a local Deepnote server (`localhost:8080`) for local kernel execution. Same API surface either way — `/v2/runs`, `/v2/runs/{id}`, `/v2/notebooks/{id}/runs`. It cannot be both; the app runs against one target at a time.
+
 The HTML page embeds all the JS needed to:
 
-1. **Trigger cloud runs** via `POST /v2/runs`
-2. **Poll for results** via `GET /v2/runs/{runId}?snapshotDelivery=inline`
+1. **Trigger runs** via `POST {baseUrl}/v2/runs`
+2. **Poll for results** via `GET {baseUrl}/v2/runs/{runId}?snapshotDelivery=inline`
 3. **Parse snapshot YAML** using the `snapshot-reader.iife.js` bundle
 4. **Render outputs** (tables, charts, text) in the browser
 
-### Token acquisition
+### Configuration
 
-| Environment                                         | How the token is obtained                                            |
-| --------------------------------------------------- | -------------------------------------------------------------------- |
-| **deepnote.com** (published via `deepnote publish`) | postMessage to the Deepnote shell — automatic, no user action needed |
-| **Localhost**                                       | `?token=<DEEPNOTE_TOKEN>` query parameter                            |
+Everything is configurable via query params or by editing `APP_CONFIG` in the HTML:
 
-### Optional local server
+| Parameter    | Default                    | Description                                                                      |
+| ------------ | -------------------------- | -------------------------------------------------------------------------------- |
+| `baseUrl`    | `https://api.deepnote.com` | API server — cloud or local                                                      |
+| `notebookId` | —                          | Notebook to run                                                                  |
+| `token`      | —                          | Bearer token (not needed on deepnote.com or against a local server without auth) |
 
-For local development, `serve.mjs` provides:
-
-- `/api/info` — notebook name + input metadata from the `.deepnote` file
-- `/api/run` — local Python execution (needs a Python env + `OPENAI_API_KEY` for the demo notebook)
-- `/snapshot-reader.js` — the built YAML parser, resolved from `packages/local-runner/dist`
-
-When the page detects a local server at `/api/info`, it shows the **Run locally** button alongside **Run in cloud**.
+On deepnote.com, the token is acquired automatically via postMessage — no configuration needed.
 
 ## Quick start
 
@@ -34,17 +31,20 @@ When the page detects a local server at `/api/info`, it shows the **Run locally*
 # Build the snapshot reader (once)
 pnpm --filter @deepnote/local-runner build
 
-# Start the local dev server
+# Start the dev server (just serves static files + snapshot-reader.js)
 node examples/local-runner/cloud-app/serve.mjs
 
-# Open in browser — pass a token for cloud runs
-# http://127.0.0.1:<port>?token=<your-deepnote-token>
+# Cloud execution
+# http://127.0.0.1:<port>?notebookId=<id>&token=<your-deepnote-token>
+
+# Local Deepnote server
+# http://127.0.0.1:<port>?notebookId=<id>&baseUrl=http://localhost:8080
 ```
 
 ## Publishing to deepnote.com
 
 ```bash
-# 1. Set your notebook id in APP_CONFIG inside index.html
+# 1. Set notebookId in APP_CONFIG inside index.html
 # 2. Copy the snapshot reader into this directory
 cp packages/local-runner/dist/snapshot-reader.iife.js examples/local-runner/cloud-app/snapshot-reader.js
 

--- a/examples/local-runner/cloud-app/index.html
+++ b/examples/local-runner/cloud-app/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>Deepnote cloud app</title>
+    <title>Deepnote app</title>
     <style>
       :root {
         color-scheme: light dark;
@@ -107,8 +107,6 @@
       .btn:disabled { opacity: 0.5; cursor: default; }
       .btn.primary { background: var(--accent); color: #fff; box-shadow: 0 1px 2px rgba(91,61,245,.3); flex: 1; justify-content: center; }
       .btn.primary:hover:not(:disabled) { filter: brightness(1.06); }
-      .btn.ghost { background: transparent; color: var(--ink-2); border-color: var(--line); }
-      .btn.ghost:hover:not(:disabled) { border-color: var(--ink-3); color: var(--ink); }
       .status { font-size: 0.8rem; color: var(--ink-3); margin-top: 13px; min-height: 1.2em; display: flex; align-items: center; gap: 7px; }
       .status.ok { color: var(--pos); } .status.err { color: var(--neg); } .status a { color: var(--accent); }
       .spin { width: 12px; height: 12px; border: 2px solid currentColor; border-right-color: transparent; border-radius: 50%; animation: sp 0.7s linear infinite; }
@@ -117,8 +115,6 @@
       .runs { margin-top: auto; padding-top: 18px; border-top: 1px solid var(--line); }
       .runs-head { display: flex; align-items: baseline; justify-content: space-between; gap: 8px; margin-bottom: 8px; }
       .runs-head h2 { font-size: 0.72rem; letter-spacing: 0.12em; text-transform: uppercase; color: var(--ink-3); margin: 0; font-weight: 650; }
-      .runs-head a { font-size: 0.72rem; color: var(--accent); text-decoration: none; }
-      .runs-head a:hover { text-decoration: underline; }
       .runs ul { list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 1px; }
       .run { display: flex; align-items: center; gap: 8px; padding: 5px 6px; border-radius: 6px; font-size: 0.78rem; color: var(--ink-2); width: 100%; font-family: inherit; background: none; border: 0; cursor: pointer; text-align: left; }
       .run:hover { background: var(--surface-2); }
@@ -152,8 +148,8 @@
   </head>
   <body>
     <div class="topbar">
-      <div class="brand"><span class="mark"></span>Deepnote <span class="dim">cloud app</span></div>
-      <div class="badge" id="env-badge"><span class="dot"></span><span id="env-label">Connecting…</span></div>
+      <div class="brand"><span class="mark"></span>Deepnote <span class="dim">app</span></div>
+      <div class="badge"><span class="dot"></span><span id="env-label">Connecting…</span></div>
     </div>
 
     <div class="layout">
@@ -164,14 +160,13 @@
         </div>
         <div id="inputs"></div>
         <div class="actions">
-          <button id="run-cloud" class="btn primary"><span id="spin-cloud"></span>Run in cloud</button>
-          <button id="run-local" class="btn ghost" hidden><span id="spin-local"></span>Run locally</button>
+          <button id="run-btn" class="btn primary" disabled><span id="spin"></span>Run</button>
         </div>
         <div class="status" id="status"></div>
 
         <div class="runs" id="runs-panel" hidden>
           <div class="runs-head">
-            <h2>Cloud runs</h2>
+            <h2>Runs</h2>
           </div>
           <ul id="runs-list"></ul>
         </div>
@@ -185,27 +180,31 @@
         <div id="output">
           <div class="empty">
             <div class="glyph">▷</div>
-            <b>Edit the inputs, then Run in cloud.</b>
-            <div>The notebook executes in Deepnote Cloud and its output appears here.</div>
+            <b>Edit the inputs, then press Run.</b>
+            <div>The notebook executes via the Deepnote API and its output appears here.</div>
           </div>
         </div>
       </section>
     </div>
 
     <!--
-      The snapshot reader bundles a YAML parser and the Deepnote block schema so cloud-run snapshots
-      can be parsed client-side. Loaded from the built package; `serve.mjs` wires the path for local
-      development. For publishing, copy the file into this directory or inline it.
+      The snapshot reader bundles a YAML parser and the Deepnote block schema so run snapshots
+      can be parsed client-side. Loaded from the built package; `serve.mjs` wires the path for
+      local development. For publishing, copy the file into this directory.
     -->
     <script src="./snapshot-reader.js"></script>
     <script type="module">
       // ── App config ─────────────────────────────────────────────────────────────
-      // When published to deepnote.com these are baked in. For local development
-      // the optional serve.mjs fills them from the .deepnote file via /api/info.
+      // The single `baseUrl` determines where runs execute. Point it at
+      // api.deepnote.com for cloud execution, or at a local Deepnote server
+      // (e.g. localhost:8080) for local kernel execution. One API surface either
+      // way — /v2/runs, /v2/runs/{id}, /v2/notebooks/{id}/runs.
+      //
+      // Query-param overrides: ?baseUrl=…  ?token=…  ?notebookId=…
       const APP_CONFIG = {
         notebookId: null,
         notebookName: 'Dashboard',
-        apiUrl: 'https://api.deepnote.com',
+        baseUrl: 'https://api.deepnote.com',
         inputs: [],
       }
 
@@ -215,18 +214,21 @@
       const state = {}
 
       // ── Environment detection ──────────────────────────────────────────────────
-      // Three modes:
-      //   1. deepnote.com — inside an iframe, token via postMessage
-      //   2. localhost with server — /api/info available, token from server
-      //   3. standalone — token from ?token= query param or prompt
       const isDeepnote = window !== window.parent && location.hostname.includes('deepnoteworkspace.com')
-      const isLocalhost = location.hostname === '127.0.0.1' || location.hostname === 'localhost'
+      const params = new URLSearchParams(location.search)
+
+      // Query params override baked-in config
+      if (params.get('baseUrl')) APP_CONFIG.baseUrl = params.get('baseUrl')
+      if (params.get('notebookId')) APP_CONFIG.notebookId = params.get('notebookId')
 
       let apiToken = null
-      let localServerAvailable = false
       let lastRuns = null
       let shownRunId = null
       let displayGen = 0
+
+      function isLocal() {
+        try { return new URL(APP_CONFIG.baseUrl).hostname === 'localhost' || new URL(APP_CONFIG.baseUrl).hostname === '127.0.0.1' } catch { return false }
+      }
 
       // ── Token acquisition ──────────────────────────────────────────────────────
       function requestDeepnoteToken() {
@@ -247,11 +249,13 @@
 
       // ── API helpers ────────────────────────────────────────────────────────────
       function apiHeaders() {
-        return { Authorization: `Bearer ${apiToken}`, 'Content-Type': 'application/json' }
+        const h = { 'Content-Type': 'application/json' }
+        if (apiToken) h.Authorization = `Bearer ${apiToken}`
+        return h
       }
 
-      async function triggerCloudRun(notebookId, inputs) {
-        const res = await fetch(`${APP_CONFIG.apiUrl}/v2/runs`, {
+      async function triggerRun(notebookId, inputs) {
+        const res = await fetch(`${APP_CONFIG.baseUrl}/v2/runs`, {
           method: 'POST',
           headers: apiHeaders(),
           body: JSON.stringify({ notebookId, inputs }),
@@ -267,14 +271,13 @@
 
       async function pollRun(runId) {
         const terminal = new Set(['success', 'error', 'internal_error', 'stopped'])
-        const failed = new Set(['error', 'internal_error', 'stopped'])
         const maxPolls = 300
         let interval = 2000
 
         for (let i = 0; i < maxPolls; i++) {
           await sleep(interval)
           const res = await fetch(
-            `${APP_CONFIG.apiUrl}/v2/runs/${encodeURIComponent(runId)}?snapshotDelivery=inline`,
+            `${APP_CONFIG.baseUrl}/v2/runs/${encodeURIComponent(runId)}?snapshotDelivery=inline`,
             { headers: apiHeaders() }
           )
           if (!res.ok) {
@@ -288,13 +291,12 @@
 
           if (terminal.has(run.status)) {
             const snapshot = run.snapshot ?? {}
-            const snapshotContent = snapshot.snapshotContent ?? run.snapshotContent ?? null
             return {
               runId: run.runId ?? run.id,
               status: run.status,
               success: run.status === 'success',
               error: describeError(run),
-              snapshotContent,
+              snapshotContent: snapshot.snapshotContent ?? run.snapshotContent ?? null,
             }
           }
           interval = Math.min(interval * 1.2, 10000)
@@ -302,39 +304,9 @@
         throw new Error('Timed out waiting for run to complete')
       }
 
-      function describeError(run) {
-        if (run.error == null) return undefined
-        if (typeof run.error === 'string') return run.error
-        if (typeof run.error === 'object' && run.error.message) return run.error.message
-        return JSON.stringify(run.error)
-      }
-
-      function extractApiMessage(body, fallback) {
-        try {
-          const json = JSON.parse(body)
-          return json.message || json.error || json.detail || fallback
-        } catch {
-          return fallback
-        }
-      }
-
-      async function listCloudRuns(notebookId) {
-        try {
-          const res = await fetch(
-            `${APP_CONFIG.apiUrl}/v2/notebooks/${encodeURIComponent(notebookId)}/runs`,
-            { headers: apiHeaders() }
-          )
-          if (!res.ok) return { runs: [] }
-          const json = await res.json()
-          return { runs: json.runs ?? [] }
-        } catch {
-          return { runs: [] }
-        }
-      }
-
-      async function getCloudRun(runId) {
+      async function fetchRun(runId) {
         const res = await fetch(
-          `${APP_CONFIG.apiUrl}/v2/runs/${encodeURIComponent(runId)}?snapshotDelivery=inline`,
+          `${APP_CONFIG.baseUrl}/v2/runs/${encodeURIComponent(runId)}?snapshotDelivery=inline`,
           { headers: apiHeaders() }
         )
         if (!res.ok) {
@@ -350,6 +322,36 @@
           success: run.status === 'success',
           error: describeError(run),
           snapshotContent: snapshot.snapshotContent ?? run.snapshotContent ?? null,
+        }
+      }
+
+      async function listRuns(notebookId) {
+        try {
+          const res = await fetch(
+            `${APP_CONFIG.baseUrl}/v2/notebooks/${encodeURIComponent(notebookId)}/runs`,
+            { headers: apiHeaders() }
+          )
+          if (!res.ok) return { runs: [] }
+          const json = await res.json()
+          return { runs: json.runs ?? [] }
+        } catch {
+          return { runs: [] }
+        }
+      }
+
+      function describeError(run) {
+        if (run.error == null) return undefined
+        if (typeof run.error === 'string') return run.error
+        if (typeof run.error === 'object' && run.error.message) return run.error.message
+        return JSON.stringify(run.error)
+      }
+
+      function extractApiMessage(body, fallback) {
+        try {
+          const json = JSON.parse(body)
+          return json.message || json.error || json.detail || fallback
+        } catch {
+          return fallback
         }
       }
 
@@ -376,62 +378,45 @@
 
       // ── Initialize ─────────────────────────────────────────────────────────────
       async function init() {
-        // 1. Try local server first (provides config + local run capability)
-        if (isLocalhost) {
-          try {
-            const res = await fetch('/api/info')
-            if (res.ok) {
-              const info = await res.json()
-              localServerAvailable = true
-              APP_CONFIG.notebookName = info.notebook
-              APP_CONFIG.inputs = info.inputs ?? []
-              $('#run-local').hidden = false
-              $('#env-label').textContent = 'Local + Cloud'
-            }
-          } catch {}
-        }
-
-        // 2. Acquire token
+        // Acquire token
         if (isDeepnote) {
           apiToken = await requestDeepnoteToken()
-          $('#env-label').textContent = apiToken ? 'Deepnote' : 'No token'
         } else {
-          const params = new URLSearchParams(location.search)
           apiToken = params.get('token') || null
-          if (!apiToken && !localServerAvailable) {
-            // Read from /api/info is already attempted above
-            $('#env-label').textContent = 'No token'
-          } else if (!apiToken && localServerAvailable) {
-            $('#env-label').textContent = 'Local only'
-          } else if (!localServerAvailable) {
-            $('#env-label').textContent = 'Cloud'
-          }
         }
 
-        // 3. Render UI
+        // Badge shows where runs go
+        const host = (() => {
+          try { return new URL(APP_CONFIG.baseUrl).host } catch { return APP_CONFIG.baseUrl }
+        })()
+        if (isLocal()) {
+          $('#env-label').textContent = `Local · ${host}`
+        } else if (isDeepnote) {
+          $('#env-label').textContent = apiToken ? 'Deepnote' : 'No token'
+        } else {
+          $('#env-label').textContent = apiToken ? host : 'No token'
+        }
+
+        // Render UI
         $('#nb-name').textContent = APP_CONFIG.notebookName
         $('#r-title').textContent = APP_CONFIG.notebookName
         renderInputs(APP_CONFIG.inputs)
 
-        // 4. Cloud run button — only enabled with a token and notebook id
-        const canCloud = apiToken && APP_CONFIG.notebookId
-        if (!canCloud) {
-          $('#run-cloud').disabled = true
-          if (!apiToken) {
-            setStatus('No API token — pass ?token=… or run on deepnote.com', 'err')
-          } else if (!APP_CONFIG.notebookId) {
-            setStatus('No notebook id configured — set APP_CONFIG.notebookId', 'err')
-          }
+        // Enable run button if we have what we need
+        const ready = APP_CONFIG.notebookId && (apiToken || isLocal())
+        const btn = $('#run-btn')
+        if (ready) {
+          btn.disabled = false
+        } else if (!APP_CONFIG.notebookId) {
+          setStatus('No notebook id — set APP_CONFIG.notebookId or pass ?notebookId=…', 'err')
+        } else if (!apiToken && !isLocal()) {
+          setStatus('No API token — pass ?token=… or run on deepnote.com', 'err')
         }
 
-        // 5. Wire up buttons
-        $('#run-cloud').onclick = () => runInCloud()
-        if (localServerAvailable) {
-          $('#run-local').onclick = () => runLocally()
-        }
+        btn.onclick = () => doRun()
 
-        // 6. Load run history
-        if (canCloud) loadCloudRuns()
+        // Load run history
+        if (ready) loadRuns()
       }
 
       // ── Input rendering ────────────────────────────────────────────────────────
@@ -499,21 +484,20 @@
         text.oninput = () => { state[inp.variableName] = text.value }; return text
       }
 
-      // ── Run in cloud (direct API) ──────────────────────────────────────────────
-      async function runInCloud() {
+      // ── Run ────────────────────────────────────────────────────────────────────
+      async function doRun() {
         const gen = ++displayGen
-        disableButtons(true)
-        $('#spin-cloud').className = 'spin'
-        setStatus('Starting cloud run…')
+        $('#run-btn').disabled = true
+        $('#spin').className = 'spin'
+        setStatus('Starting run…')
 
         try {
-          // On deepnote.com, the postMessage token expires after 15 minutes. Refresh it per run.
           if (isDeepnote) {
             apiToken = await requestDeepnoteToken()
             if (!apiToken) throw new Error('Could not acquire API token from Deepnote')
           }
 
-          const started = await triggerCloudRun(APP_CONFIG.notebookId, state)
+          const started = await triggerRun(APP_CONFIG.notebookId, state)
           setStatus(`Running… (${started.status})`)
 
           const result = await pollRun(started.runId)
@@ -526,48 +510,23 @@
           if (!result.success) {
             setStatus(cap(result.error || `The run failed (${result.status})`), 'err')
           } else {
-            setStatus(`Ran ${outputs.length} block${outputs.length === 1 ? '' : 's'} in cloud`, 'ok')
+            const where = isLocal() ? 'locally' : 'in cloud'
+            setStatus(`Ran ${outputs.length} block${outputs.length === 1 ? '' : 's'} ${where}`, 'ok')
           }
         } catch (e) {
           if (gen === displayGen) setStatus(cap(e.message), 'err')
         } finally {
-          disableButtons(false)
-          $('#spin-cloud').className = ''
-          loadCloudRuns()
+          $('#run-btn').disabled = false
+          $('#spin').className = ''
+          loadRuns()
         }
       }
 
-      // ── Run locally (via serveStatic server) ───────────────────────────────────
-      async function runLocally() {
-        const gen = ++displayGen
-        disableButtons(true)
-        $('#spin-local').className = 'spin'
-        setStatus('Running in a local kernel…')
-
-        try {
-          const res = await fetch('/api/run', {
-            method: 'POST',
-            headers: { 'content-type': 'application/json' },
-            body: JSON.stringify({ inputs: state }),
-          })
-          const data = await res.json()
-          if (gen !== displayGen) return
-          if (!res.ok) throw new Error(data.error || `HTTP ${res.status}`)
-          render(data)
-          shownRunId = null
-          setStatus(`Ran ${data.summary?.executedBlocks ?? ''} blocks locally`.replace(/\s+/g, ' ').trim(), 'ok')
-        } catch (e) {
-          if (gen === displayGen) setStatus(cap(e.message), 'err')
-        } finally {
-          disableButtons(false)
-          $('#spin-local').className = ''
-        }
-      }
-
-      // ── Cloud run history ──────────────────────────────────────────────────────
-      async function loadCloudRuns() {
-        if (!apiToken || !APP_CONFIG.notebookId) return
-        const data = await listCloudRuns(APP_CONFIG.notebookId)
+      // ── Run history ────────────────────────────────────────────────────────────
+      async function loadRuns() {
+        if (!apiToken && !isLocal()) return
+        if (!APP_CONFIG.notebookId) return
+        const data = await listRuns(APP_CONFIG.notebookId)
         renderRuns(data)
       }
 
@@ -603,7 +562,7 @@
       async function showRun(runId) {
         const gen = ++displayGen
         try {
-          const result = await getCloudRun(runId)
+          const result = await fetchRun(runId)
           if (gen !== displayGen) return
           shownRunId = runId
           const outputs = parseOutputsFromSnapshot(result.snapshotContent)
@@ -613,7 +572,7 @@
           if (!result.success) {
             setStatus(`That run ${label(result.status).toLowerCase()} ${when}${result.error ? ': ' + result.error : ''}`, 'err')
           } else {
-            setStatus(`Showing a cloud run from ${when}`, 'ok')
+            setStatus(`Showing a run from ${when}`, 'ok')
           }
         } catch (e) {
           if (gen === displayGen) setStatus(cap(e.message), 'err')
@@ -663,8 +622,6 @@
         return frame
       }
       window.addEventListener('message', (e) => {
-        // Accept height reports from sandboxed iframes (null origin), and also from the Deepnote
-        // shell's token response (different origin). Only the height reports touch the DOM.
         if (e.data?.type === 'deepnote-static-files-api-token-response') return
         if (e.origin !== 'null' || !e.data || typeof e.data.h !== 'number') return
         const f = document.querySelector(`iframe[data-id=${JSON.stringify(e.data.id)}]`)
@@ -694,12 +651,6 @@
       }
 
       function setStatus(text, cls = '') { const s = $('#status'); s.textContent = text; s.className = 'status ' + cls }
-
-      function disableButtons(disabled) {
-        $('#run-cloud').disabled = disabled
-        const local = $('#run-local')
-        if (!local.hidden) local.disabled = disabled
-      }
 
       // ── Boot ────────────────────────────────────────────────────────────────────
       init()

--- a/examples/local-runner/cloud-app/serve.mjs
+++ b/examples/local-runner/cloud-app/serve.mjs
@@ -1,152 +1,45 @@
-// Optional local dev server for the cloud app. Provides:
-//   - Static files from this directory + /snapshot-reader.js from the built package
-//   - /api/info — notebook name + inputs
-//   - /api/run — local Python execution
-//
-// The cloud app works without this server (on deepnote.com it acquires a token via postMessage
-// and calls the Deepnote API directly). This server lets you develop locally with the "Run
-// locally" button enabled.
-//
-// Deliberately simpler than serveStatic — cloud runs go straight from the browser to the API,
-// the only server-side route is local Python execution.
+// Serves the cloud app for local development. Zero API routes — the page talks directly to
+// whatever baseUrl it's configured with (api.deepnote.com or a local Deepnote server).
+// This only exists to wire /snapshot-reader.js from the built package without a copy step.
 
-import { readFile, realpath, stat } from 'node:fs/promises'
+import { readFile } from 'node:fs/promises'
 import { createServer } from 'node:http'
-import { dirname, extname, join, resolve, sep } from 'node:path'
+import { dirname, join } from 'node:path'
 import { fileURLToPath } from 'node:url'
 
 const here = dirname(fileURLToPath(import.meta.url))
-const notebookPath = join(here, '..', '..', 'local-runner-showcase.deepnote')
 
-try {
-  process.loadEnvFile()
-} catch {}
-
-// Dynamic imports: the built package, not the TypeScript source.
-const { loadDeepnoteFile, runWithInputs } = await import('../../../packages/local-runner/dist/index.js')
-
-const SNAPSHOT_READER_PATH = join(here, '..', '..', '..', 'packages', 'local-runner', 'dist', 'snapshot-reader.iife.js')
-
-const CONTENT_TYPES = {
-  '.html': 'text/html; charset=utf-8',
-  '.js': 'text/javascript; charset=utf-8',
-  '.mjs': 'text/javascript; charset=utf-8',
-  '.css': 'text/css; charset=utf-8',
-  '.json': 'application/json; charset=utf-8',
-  '.svg': 'image/svg+xml',
-  '.png': 'image/png',
-  '.jpg': 'image/jpeg',
-  '.ico': 'image/x-icon',
-}
-
-const MAX_BODY = 5_000_000
-
-function sendJson(res, status, body) {
-  res.writeHead(status, { 'Content-Type': 'application/json; charset=utf-8' })
-  res.end(JSON.stringify(body))
-}
-
-function readBody(req) {
-  return new Promise((resolve, reject) => {
-    const chunks = []
-    let size = 0
-    req.on('data', chunk => {
-      size += chunk.length
-      if (size > MAX_BODY) {
-        reject(new Error('Payload too large'))
-        return
-      }
-      chunks.push(chunk)
-    })
-    req.on('end', () => resolve(Buffer.concat(chunks).toString('utf-8')))
-    req.on('error', reject)
-  })
+const routes = {
+  '/': [join(here, 'index.html'), 'text/html; charset=utf-8'],
+  '/snapshot-reader.js': [
+    join(here, '..', '..', '..', 'packages', 'local-runner', 'dist', 'snapshot-reader.iife.js'),
+    'text/javascript; charset=utf-8',
+  ],
 }
 
 const server = createServer(async (req, res) => {
+  const route = routes[(req.url ?? '/').split('?')[0]]
+  if (!route) {
+    res.writeHead(404).end('Not found')
+    return
+  }
   try {
-    await handle(req, res)
+    const body = await readFile(route[0])
+    res.writeHead(200, { 'content-type': route[1] }).end(body)
   } catch (err) {
-    sendJson(res, 500, { error: err.message ?? String(err) })
+    const missingReader = route[0].endsWith('snapshot-reader.iife.js')
+    res
+      .writeHead(500)
+      .end(
+        missingReader
+          ? 'snapshot-reader not built. Run: pnpm --filter @deepnote/local-runner build'
+          : `Failed to read ${route[0]}: ${err instanceof Error ? err.message : String(err)}`
+      )
   }
 })
 
-async function handle(req, res) {
-  const { pathname } = new URL(req.url ?? '/', 'http://localhost')
-
-  // /snapshot-reader.js → the built IIFE from packages/local-runner/dist
-  if (req.method === 'GET' && pathname === '/snapshot-reader.js') {
-    try {
-      const body = await readFile(SNAPSHOT_READER_PATH)
-      res.writeHead(200, { 'Content-Type': 'text/javascript; charset=utf-8' })
-      res.end(body)
-    } catch {
-      res.writeHead(500).end('snapshot-reader not built. Run: pnpm --filter @deepnote/local-runner build')
-    }
-    return
-  }
-
-  // /api/info → notebook name + input blocks
-  if (req.method === 'GET' && pathname === '/api/info') {
-    const { listInputBlocks } = await import('../../../packages/local-runner/dist/index.js')
-    const { file } = loadDeepnoteFile(notebookPath)
-    sendJson(res, 200, { notebook: file.project.name, inputs: listInputBlocks(file) })
-    return
-  }
-
-  // /api/run → local Python execution
-  if (req.method === 'POST' && pathname === '/api/run') {
-    let body
-    try {
-      body = JSON.parse(await readBody(req))
-    } catch {
-      sendJson(res, 400, { error: 'Invalid JSON body' })
-      return
-    }
-    const inputs = body?.inputs ?? {}
-    if (typeof inputs !== 'object' || Array.isArray(inputs)) {
-      sendJson(res, 400, { error: 'inputs must be an object' })
-      return
-    }
-    const result = await runWithInputs(notebookPath, inputs, { persistSnapshot: false })
-    sendJson(res, 200, {
-      outputs: result.outputs,
-      summary: result.summary,
-      snapshotYaml: result.snapshotYaml,
-    })
-    return
-  }
-
-  // Static files from this directory
-  if (req.method === 'GET') {
-    const decoded = decodeURIComponent(pathname === '/' ? '/index.html' : pathname)
-    const target = resolve(here, `.${decoded.startsWith('/') ? decoded : `/${decoded}`}`)
-    if (target !== here && !target.startsWith(here + sep)) {
-      sendJson(res, 403, { error: 'Forbidden' })
-      return
-    }
-    try {
-      const real = await realpath(target)
-      if (!(await stat(real)).isFile()) {
-        sendJson(res, 404, { error: 'Not found' })
-        return
-      }
-      const bytes = await readFile(real)
-      res.writeHead(200, { 'Content-Type': CONTENT_TYPES[extname(real)] ?? 'application/octet-stream' })
-      res.end(bytes)
-    } catch {
-      sendJson(res, 404, { error: 'Not found' })
-    }
-    return
-  }
-
-  sendJson(res, 404, { error: 'Not found' })
-}
-
 server.listen(0, '127.0.0.1', () => {
   const { port } = server.address()
-  const has = k => (process.env[k] ? '✓' : '—')
-  console.log(`\n  Deepnote cloud app (local dev) → http://127.0.0.1:${port}`)
-  console.log(`  Local run: OPENAI_API_KEY ${has('OPENAI_API_KEY')}`)
-  console.log(`  Cloud run: open the page and pass ?token=<DEEPNOTE_TOKEN>\n`)
+  console.log(`\n  Deepnote app (local dev) → http://127.0.0.1:${port}`)
+  console.log(`  Pass ?baseUrl=http://localhost:8080 for a local server, or ?token=… for cloud\n`)
 })


### PR DESCRIPTION
## Summary

The app had **two run paths and two buttons**. This collapses them into one, pointed at a single configurable endpoint that defaults to `https://api.deepnote.com` — so the common case needs no configuration at all.

Before, the page carried two independent execution paths:

| | "Run in cloud" | "Run locally" |
| --- | --- | --- |
| Endpoint | `POST /v2/runs` on `api.deepnote.com` | `POST /api/run` on the `serve.mjs` Node process |
| Executor | Deepnote Cloud | a local Python kernel, shelled out from Node |
| Result shape | run id → poll → snapshot YAML | synchronous outputs + summary |
| Visibility | always | appeared/vanished depending on whether `/api/info` answered |

Two request paths, two result shapes to render, and a button whose presence depended on a probe — for what is the same operation from the user's point of view.

## After

One `baseUrl`, defaulting to `https://api.deepnote.com`:

```js
const APP_CONFIG = {
  notebookId: null,
  notebookName: 'Dashboard',
  baseUrl: 'https://api.deepnote.com',
  inputs: [],
}
```

Point it elsewhere with `?baseUrl=` and the *same* `/v2/runs` surface serves local execution:

```bash
# Cloud — the default, nothing to configure
http://127.0.0.1:<port>?notebookId=<id>&token=<token>

# A local Deepnote server, same endpoints
http://127.0.0.1:<port>?notebookId=<id>&baseUrl=http://localhost:8080
```

The app runs against one target at a time — it is no longer both at once — so there is one button, one request path, and one result shape to render.

`serve.mjs` loses its API routes along with the `/api/run` path. It is now a static file server whose only remaining job is mapping `/snapshot-reader.js` to the built IIFE, so local development needs no copy step. That's what takes it from 152 lines to 45.

## Why it's a separate PR

Split out of #456 on request, so the demo and the simplification can be reviewed independently. #456 now lands the app as originally built; this PR is the refactor on top, which is why the diff reads as a large deletion.

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm test` — 2999 passed, 1 skipped
- [x] `pnpm spell-check` clean
- [ ] `node examples/local-runner/cloud-app/serve.mjs` serves the page and `/snapshot-reader.js`
- [ ] Cloud run against `api.deepnote.com` with `?token=` renders outputs
- [ ] Local run against `?baseUrl=http://localhost:8080` hits the same code path
- [ ] On deepnote.com, the postMessage token flow still works with no `baseUrl` set

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a unified Deepnote app experience for running notebooks against either cloud or local servers.
  * Added configurable `baseUrl` and token parameters for selecting the execution environment.
  * Added unified run status polling, result retrieval, history loading, and status messaging.
  * Simplified the interface to use a single Run button.

* **Documentation**
  * Updated setup instructions with cloud and local startup URLs, configuration options, and API usage details.

* **Bug Fixes**
  * Improved local execution compatibility through consistent authorization and API handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->