### PR TITLE
feat(examples): browser app with one Run button and one configurable endpoint

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -46,6 +46,7 @@
     "dateutil",
     "DBTSERVICETOKEN",
     "deepnote",
+    "deepnoteworkspace",
     "defu",
     "desync",
     "desyncing",

--- a/examples/local-runner/cloud-app/README.md
+++ b/examples/local-runner/cloud-app/README.md
@@ -1,0 +1,55 @@
+# Deepnote app
+
+A self-contained dynamic app that runs notebooks via the Deepnote `/v2/runs` API directly from the browser — no server required.
+
+## How it works
+
+One configurable `baseUrl` determines where runs execute. Point it at `api.deepnote.com` for cloud execution, or at a local Deepnote server (`localhost:8080`) for local kernel execution. Same API surface either way — `/v2/runs`, `/v2/runs/{id}`, `/v2/notebooks/{id}/runs`. It cannot be both; the app runs against one target at a time.
+
+The HTML page embeds all the JS needed to:
+
+1. **Trigger runs** via `POST {baseUrl}/v2/runs`
+2. **Poll for results** via `GET {baseUrl}/v2/runs/{runId}?snapshotDelivery=inline`
+3. **Parse snapshot YAML** using the `snapshot-reader.iife.js` bundle
+4. **Render outputs** (tables, charts, text) in the browser
+
+### Configuration
+
+Everything is configurable via query params or by editing `APP_CONFIG` in the HTML:
+
+| Parameter    | Default                    | Description                                                                      |
+| ------------ | -------------------------- | -------------------------------------------------------------------------------- |
+| `baseUrl`    | `https://api.deepnote.com` | API server — cloud or local                                                      |
+| `notebookId` | —                          | Notebook to run                                                                  |
+| `token`      | —                          | Bearer token (not needed on deepnote.com or against a local server without auth) |
+
+On deepnote.com, the token is acquired automatically via postMessage — no configuration needed.
+
+## Quick start
+
+```bash
+# Build the snapshot reader (once)
+pnpm --filter @deepnote/local-runner build
+
+# Start the dev server (just serves static files + snapshot-reader.js)
+node examples/local-runner/cloud-app/serve.mjs
+
+# Cloud execution
+# http://127.0.0.1:<port>?notebookId=<id>&token=<your-deepnote-token>
+
+# Local Deepnote server
+# http://127.0.0.1:<port>?notebookId=<id>&baseUrl=http://localhost:8080
+```
+
+## Publishing to deepnote.com
+
+```bash
+# 1. Set notebookId in APP_CONFIG inside index.html
+# 2. Copy the snapshot reader into this directory
+cp packages/local-runner/dist/snapshot-reader.iife.js examples/local-runner/cloud-app/snapshot-reader.js
+
+# 3. Publish
+deepnote publish examples/local-runner/cloud-app --project-id <your-project-id>
+```
+
+Once published, the app runs on `static-<projectId>.outputs.deepnoteworkspace.com` and acquires a token automatically via postMessage — no server, no manual token configuration.

--- a/examples/local-runner/cloud-app/index.html
+++ b/examples/local-runner/cloud-app/index.html
@@ -1,0 +1,659 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Deepnote app</title>
+    <style>
+      :root {
+        color-scheme: light dark;
+        --bg: #fbfbfd;
+        --surface: #ffffff;
+        --surface-2: #f5f5f9;
+        --ink: #17151f;
+        --ink-2: #57546a;
+        --ink-3: #8b889b;
+        --line: #e9e8f1;
+        --line-2: #f1f0f7;
+        --accent: #5b3df5;
+        --accent-soft: #efecff;
+        --pos: #0f8f7f;
+        --neg: #d6425f;
+        --shadow: 0 1px 2px rgba(20, 18, 40, 0.04), 0 10px 30px -16px rgba(20, 18, 40, 0.16);
+        --r: 8px;
+        --r-lg: 12px;
+        --sans: ui-sans-serif, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+        --mono: ui-monospace, "SF Mono", "JetBrains Mono", Menlo, Consolas, monospace;
+      }
+      @media (prefers-color-scheme: dark) {
+        :root {
+          --bg: #0c0b12;
+          --surface: #141220;
+          --surface-2: #1b1828;
+          --ink: #ece9f7;
+          --ink-2: #a9a6bd;
+          --ink-3: #726f86;
+          --line: #262233;
+          --line-2: #1d1a29;
+          --accent: #a78bfa;
+          --accent-soft: #211b3b;
+          --pos: #35d0b6;
+          --neg: #ff6b86;
+          --shadow: 0 1px 2px rgba(0, 0, 0, 0.3), 0 14px 34px -18px rgba(0, 0, 0, 0.7);
+        }
+      }
+      * { box-sizing: border-box; }
+      html, body { height: 100%; }
+      body {
+        margin: 0; background: var(--bg); color: var(--ink);
+        font-family: var(--sans); line-height: 1.5; -webkit-font-smoothing: antialiased;
+        font-variant-numeric: tabular-nums;
+      }
+      .topbar {
+        display: flex; align-items: center; justify-content: space-between;
+        padding: 0 20px; height: 52px; border-bottom: 1px solid var(--line);
+        background: color-mix(in srgb, var(--surface) 82%, transparent);
+        backdrop-filter: saturate(1.2) blur(8px); position: sticky; top: 0; z-index: 5;
+      }
+      .brand { display: flex; align-items: center; gap: 9px; font-weight: 640; letter-spacing: -0.01em; font-size: 0.95rem; }
+      .brand .mark { width: 15px; height: 15px; border-radius: 4px; background: var(--accent); rotate: 45deg; }
+      .brand .dim { color: var(--ink-3); font-weight: 500; }
+      .badge {
+        font-size: 0.72rem; font-weight: 600; letter-spacing: 0.02em; color: var(--accent);
+        background: var(--accent-soft); padding: 4px 10px; border-radius: 999px;
+        display: inline-flex; align-items: center; gap: 6px;
+      }
+      .badge .dot { width: 6px; height: 6px; border-radius: 50%; background: var(--accent); }
+      .layout { display: grid; grid-template-columns: 340px minmax(0, 1fr); min-height: calc(100% - 52px); }
+      @media (max-width: 820px) { .layout { grid-template-columns: 1fr; } }
+      .inputs-panel {
+        border-right: 1px solid var(--line); padding: 22px 20px 28px; background: var(--surface);
+        display: flex; flex-direction: column;
+      }
+      @media (max-width: 820px) { .inputs-panel { border-right: 0; border-bottom: 1px solid var(--line); } }
+      .panel-head { margin-bottom: 16px; }
+      .panel-head h2 { font-size: 0.72rem; letter-spacing: 0.12em; text-transform: uppercase; color: var(--ink-3); margin: 0; font-weight: 650; }
+      .nb-name { display: block; font-size: 1.05rem; font-weight: 620; letter-spacing: -0.01em; color: var(--ink); margin-top: 5px; }
+
+      .field { margin-bottom: 15px; animation: rise 0.45s both; }
+      .field label { display: flex; align-items: baseline; gap: 8px; font-size: 0.82rem; font-weight: 560; margin-bottom: 7px; color: var(--ink-2); }
+      .field .var { font-family: var(--mono); font-size: 0.68rem; color: var(--accent); font-weight: 500; margin-left: auto; opacity: 0.85; }
+      input[type="text"], input[type="date"], textarea, select {
+        width: 100%; font: inherit; font-size: 0.88rem; color: var(--ink); background: var(--bg);
+        border: 1px solid var(--line); border-radius: var(--r); padding: 8px 10px; transition: border-color 0.15s, box-shadow 0.15s;
+      }
+      textarea { resize: vertical; min-height: 62px; line-height: 1.45; }
+      input:focus, textarea:focus, select:focus {
+        outline: none; border-color: var(--accent);
+        box-shadow: 0 0 0 3px color-mix(in srgb, var(--accent) 18%, transparent);
+      }
+      .dates { display: flex; align-items: center; gap: 8px; }
+      .dates span { color: var(--ink-3); font-size: 0.8rem; }
+      .range { display: flex; align-items: center; gap: 12px; }
+      input[type="range"] { flex: 1; accent-color: var(--accent); height: 4px; }
+      .range .val { font-family: var(--mono); font-weight: 600; color: var(--accent); min-width: 3.5ch; text-align: right; font-size: 0.85rem; }
+      .switch { display: inline-flex; align-items: center; gap: 10px; cursor: pointer; user-select: none; }
+      .switch input { position: absolute; opacity: 0; }
+      .track { width: 38px; height: 22px; border-radius: 999px; background: var(--line); position: relative; transition: background 0.18s; flex: none; }
+      .track::after { content: ""; position: absolute; top: 2px; left: 2px; width: 18px; height: 18px; border-radius: 50%; background: #fff; box-shadow: 0 1px 2px rgba(0,0,0,.25); transition: transform 0.18s; }
+      .switch input:checked + .track { background: var(--accent); }
+      .switch input:checked + .track::after { transform: translateX(16px); }
+      .switch input:focus-visible + .track { box-shadow: 0 0 0 3px color-mix(in srgb, var(--accent) 22%, transparent); }
+      .switch .txt { font-size: 0.84rem; color: var(--ink-2); }
+
+      .actions { display: flex; gap: 8px; margin-top: 6px; }
+      .btn { font: inherit; font-weight: 600; font-size: 0.86rem; border-radius: var(--r); padding: 9px 16px; cursor: pointer; border: 1px solid transparent; display: inline-flex; align-items: center; gap: 7px; transition: transform 0.08s, filter 0.15s, background 0.15s, border-color 0.15s; }
+      .btn:active { transform: translateY(1px); }
+      .btn:disabled { opacity: 0.5; cursor: default; }
+      .btn.primary { background: var(--accent); color: #fff; box-shadow: 0 1px 2px rgba(91,61,245,.3); flex: 1; justify-content: center; }
+      .btn.primary:hover:not(:disabled) { filter: brightness(1.06); }
+      .status { font-size: 0.8rem; color: var(--ink-3); margin-top: 13px; min-height: 1.2em; display: flex; align-items: center; gap: 7px; }
+      .status.ok { color: var(--pos); } .status.err { color: var(--neg); } .status a { color: var(--accent); }
+      .spin { width: 12px; height: 12px; border: 2px solid currentColor; border-right-color: transparent; border-radius: 50%; animation: sp 0.7s linear infinite; }
+      @keyframes sp { to { transform: rotate(360deg); } }
+
+      .runs { margin-top: auto; padding-top: 18px; border-top: 1px solid var(--line); }
+      .runs-head { display: flex; align-items: baseline; justify-content: space-between; gap: 8px; margin-bottom: 8px; }
+      .runs-head h2 { font-size: 0.72rem; letter-spacing: 0.12em; text-transform: uppercase; color: var(--ink-3); margin: 0; font-weight: 650; }
+      .runs ul { list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 1px; }
+      .run { display: flex; align-items: center; gap: 8px; padding: 5px 6px; border-radius: 6px; font-size: 0.78rem; color: var(--ink-2); width: 100%; font-family: inherit; background: none; border: 0; cursor: pointer; text-align: left; }
+      .run:hover { background: var(--surface-2); }
+      .run.on { background: var(--accent-soft); color: var(--ink); }
+      .run:focus-visible { outline: 2px solid var(--accent); outline-offset: -2px; }
+      .run .dot { width: 6px; height: 6px; border-radius: 50%; flex: none; background: var(--ink-3); }
+      .run .dot.success { background: var(--pos); }
+      .run .dot.failed { background: var(--neg); }
+      .run .dot.live { background: var(--accent); animation: pulse 1.3s ease-in-out infinite; }
+      .run .when { color: var(--ink-3); }
+      .run .dur { margin-left: auto; font-family: var(--mono); font-size: 0.7rem; color: var(--ink-3); }
+      @keyframes pulse { 50% { opacity: 0.3; } }
+
+      .results { padding: 26px clamp(18px, 4vw, 44px) 60px; overflow: auto; }
+      .results-head { display: flex; align-items: baseline; justify-content: space-between; gap: 12px; flex-wrap: wrap; }
+      .results-head h1 { font-size: 1.35rem; letter-spacing: -0.02em; margin: 0; font-weight: 660; }
+      .caption { color: var(--ink-3); font-size: 0.85rem; font-family: var(--mono); }
+      .grid { display: grid; gap: 16px; margin-top: 22px; }
+      .card { background: var(--surface); border: 1px solid var(--line); border-radius: var(--r-lg); box-shadow: var(--shadow); padding: 16px 18px; animation: rise 0.5s both; }
+      .card.flush { padding: 14px; }
+      pre { font-family: var(--mono); font-size: 0.82rem; white-space: pre-wrap; margin: 0; color: var(--ink-2); }
+      pre.err { color: var(--neg); }
+      img.out { max-width: 100%; border-radius: var(--r); display: block; }
+      iframe.htmlout { width: 100%; border: 0; background: transparent; display: block; }
+      .empty { display: flex; min-height: 55vh; align-items: center; justify-content: center; flex-direction: column; text-align: center; color: var(--ink-3); gap: 6px; }
+      .empty .glyph { width: 42px; height: 42px; border-radius: 10px; border: 1.5px dashed var(--line); display: grid; place-items: center; color: var(--accent); margin-bottom: 6px; font-size: 1.1rem; }
+      .empty b { color: var(--ink-2); font-weight: 600; }
+
+      @keyframes rise { from { opacity: 0; transform: translateY(8px); } to { opacity: 1; transform: none; } }
+    </style>
+  </head>
+  <body>
+    <div class="topbar">
+      <div class="brand"><span class="mark"></span>Deepnote <span class="dim">app</span></div>
+      <div class="badge"><span class="dot"></span><span id="env-label">Connecting…</span></div>
+    </div>
+
+    <div class="layout">
+      <aside class="inputs-panel">
+        <div class="panel-head">
+          <h2>Inputs</h2>
+          <span class="nb-name" id="nb-name">Loading…</span>
+        </div>
+        <div id="inputs"></div>
+        <div class="actions">
+          <button id="run-btn" class="btn primary" disabled><span id="spin"></span>Run</button>
+        </div>
+        <div class="status" id="status"></div>
+
+        <div class="runs" id="runs-panel" hidden>
+          <div class="runs-head">
+            <h2>Runs</h2>
+          </div>
+          <ul id="runs-list"></ul>
+        </div>
+      </aside>
+
+      <section class="results">
+        <div class="results-head">
+          <h1 id="r-title">Dashboard</h1>
+          <span class="caption" id="r-caption"></span>
+        </div>
+        <div id="output">
+          <div class="empty">
+            <div class="glyph">▷</div>
+            <b>Edit the inputs, then press Run.</b>
+            <div>The notebook executes via the Deepnote API and its output appears here.</div>
+          </div>
+        </div>
+      </section>
+    </div>
+
+    <!--
+      The snapshot reader bundles a YAML parser and the Deepnote block schema so run snapshots
+      can be parsed client-side. Loaded from the built package; `serve.mjs` wires the path for
+      local development. For publishing, copy the file into this directory.
+    -->
+    <script src="./snapshot-reader.js"></script>
+    <script type="module">
+      // ── App config ─────────────────────────────────────────────────────────────
+      // The single `baseUrl` determines where runs execute. Point it at
+      // api.deepnote.com for cloud execution, or at a local Deepnote server
+      // (e.g. localhost:8080) for local kernel execution. One API surface either
+      // way — /v2/runs, /v2/runs/{id}, /v2/notebooks/{id}/runs.
+      //
+      // Query-param overrides: ?baseUrl=…  ?token=…  ?notebookId=…
+      const APP_CONFIG = {
+        notebookId: null,
+        notebookName: 'Dashboard',
+        baseUrl: 'https://api.deepnote.com',
+        inputs: [],
+      }
+
+      // ── DOM helpers ────────────────────────────────────────────────────────────
+      const $ = (s) => document.querySelector(s)
+      const el = (t, c) => { const n = document.createElement(t); if (c) n.className = c; return n }
+      const state = {}
+
+      // ── Environment detection ──────────────────────────────────────────────────
+      const isDeepnote = window !== window.parent && location.hostname.includes('deepnoteworkspace.com')
+      const params = new URLSearchParams(location.search)
+
+      // Query params override baked-in config
+      if (params.get('baseUrl')) APP_CONFIG.baseUrl = params.get('baseUrl')
+      if (params.get('notebookId')) APP_CONFIG.notebookId = params.get('notebookId')
+
+      let apiToken = null
+      let lastRuns = null
+      let shownRunId = null
+      let displayGen = 0
+
+      function isLocal() {
+        try { return new URL(APP_CONFIG.baseUrl).hostname === 'localhost' || new URL(APP_CONFIG.baseUrl).hostname === '127.0.0.1' } catch { return false }
+      }
+
+      // ── Token acquisition ──────────────────────────────────────────────────────
+      function requestDeepnoteToken() {
+        return new Promise((resolve) => {
+          function onMessage(e) {
+            if (e.data?.type !== 'deepnote-static-files-api-token-response') return
+            window.removeEventListener('message', onMessage)
+            resolve(e.data.token || null)
+          }
+          window.addEventListener('message', onMessage)
+          window.parent.postMessage({ type: 'deepnote-static-files-api-token-request' }, '*')
+          setTimeout(() => {
+            window.removeEventListener('message', onMessage)
+            resolve(null)
+          }, 5000)
+        })
+      }
+
+      // ── API helpers ────────────────────────────────────────────────────────────
+      function apiHeaders() {
+        const h = { 'Content-Type': 'application/json' }
+        if (apiToken) h.Authorization = `Bearer ${apiToken}`
+        return h
+      }
+
+      async function triggerRun(notebookId, inputs) {
+        const res = await fetch(`${APP_CONFIG.baseUrl}/v2/runs`, {
+          method: 'POST',
+          headers: apiHeaders(),
+          body: JSON.stringify({ notebookId, inputs }),
+        })
+        if (!res.ok) {
+          const body = await res.text().catch(() => '')
+          throw new Error(extractApiMessage(body, `HTTP ${res.status} ${res.statusText}`))
+        }
+        const json = await res.json()
+        const run = json.run ?? json
+        return { runId: run.runId ?? run.id, status: run.status }
+      }
+
+      async function pollRun(runId) {
+        const terminal = new Set(['success', 'error', 'internal_error', 'stopped'])
+        const maxPolls = 300
+        let interval = 2000
+
+        for (let i = 0; i < maxPolls; i++) {
+          await sleep(interval)
+          const res = await fetch(
+            `${APP_CONFIG.baseUrl}/v2/runs/${encodeURIComponent(runId)}?snapshotDelivery=inline`,
+            { headers: apiHeaders() }
+          )
+          if (!res.ok) {
+            const body = await res.text().catch(() => '')
+            throw new Error(extractApiMessage(body, `HTTP ${res.status}`))
+          }
+          const json = await res.json()
+          const run = json.run ?? json
+
+          setStatus(`Running… (${run.status})`)
+
+          if (terminal.has(run.status)) {
+            const snapshot = run.snapshot ?? {}
+            return {
+              runId: run.runId ?? run.id,
+              status: run.status,
+              success: run.status === 'success',
+              error: describeError(run),
+              snapshotContent: snapshot.snapshotContent ?? run.snapshotContent ?? null,
+            }
+          }
+          interval = Math.min(interval * 1.2, 10000)
+        }
+        throw new Error('Timed out waiting for run to complete')
+      }
+
+      async function fetchRun(runId) {
+        const res = await fetch(
+          `${APP_CONFIG.baseUrl}/v2/runs/${encodeURIComponent(runId)}?snapshotDelivery=inline`,
+          { headers: apiHeaders() }
+        )
+        if (!res.ok) {
+          const body = await res.text().catch(() => '')
+          throw new Error(extractApiMessage(body, `HTTP ${res.status}`))
+        }
+        const json = await res.json()
+        const run = json.run ?? json
+        const snapshot = run.snapshot ?? {}
+        return {
+          runId: run.runId ?? run.id,
+          status: run.status,
+          success: run.status === 'success',
+          error: describeError(run),
+          snapshotContent: snapshot.snapshotContent ?? run.snapshotContent ?? null,
+        }
+      }
+
+      async function listRuns(notebookId) {
+        try {
+          const res = await fetch(
+            `${APP_CONFIG.baseUrl}/v2/notebooks/${encodeURIComponent(notebookId)}/runs`,
+            { headers: apiHeaders() }
+          )
+          if (!res.ok) return { runs: [] }
+          const json = await res.json()
+          return { runs: json.runs ?? [] }
+        } catch {
+          return { runs: [] }
+        }
+      }
+
+      function describeError(run) {
+        if (run.error == null) return undefined
+        if (typeof run.error === 'string') return run.error
+        if (typeof run.error === 'object' && run.error.message) return run.error.message
+        return JSON.stringify(run.error)
+      }
+
+      function extractApiMessage(body, fallback) {
+        try {
+          const json = JSON.parse(body)
+          return json.message || json.error || json.detail || fallback
+        } catch {
+          return fallback
+        }
+      }
+
+      function sleep(ms) { return new Promise(r => setTimeout(r, ms)) }
+
+      // ── Snapshot → outputs ─────────────────────────────────────────────────────
+      function parseOutputsFromSnapshot(snapshotContent) {
+        if (!snapshotContent || typeof DeepnoteSnapshot === 'undefined') return []
+        try {
+          const view = DeepnoteSnapshot.parseSnapshot(snapshotContent)
+          const outputs = []
+          for (const nb of view.notebooks) {
+            for (const block of nb.blocks) {
+              if (block.outputs.length > 0) {
+                outputs.push({ blockId: block.id, outputs: block.outputs })
+              }
+            }
+          }
+          return outputs
+        } catch {
+          return []
+        }
+      }
+
+      // ── Initialize ─────────────────────────────────────────────────────────────
+      async function init() {
+        // Acquire token
+        if (isDeepnote) {
+          apiToken = await requestDeepnoteToken()
+        } else {
+          apiToken = params.get('token') || null
+        }
+
+        // Badge shows where runs go
+        const host = (() => {
+          try { return new URL(APP_CONFIG.baseUrl).host } catch { return APP_CONFIG.baseUrl }
+        })()
+        if (isLocal()) {
+          $('#env-label').textContent = `Local · ${host}`
+        } else if (isDeepnote) {
+          $('#env-label').textContent = apiToken ? 'Deepnote' : 'No token'
+        } else {
+          $('#env-label').textContent = apiToken ? host : 'No token'
+        }
+
+        // Render UI
+        $('#nb-name').textContent = APP_CONFIG.notebookName
+        $('#r-title').textContent = APP_CONFIG.notebookName
+        renderInputs(APP_CONFIG.inputs)
+
+        // Enable run button if we have what we need
+        const ready = APP_CONFIG.notebookId && (apiToken || isLocal())
+        const btn = $('#run-btn')
+        if (ready) {
+          btn.disabled = false
+        } else if (!APP_CONFIG.notebookId) {
+          setStatus('No notebook id — set APP_CONFIG.notebookId or pass ?notebookId=…', 'err')
+        } else if (!apiToken && !isLocal()) {
+          setStatus('No API token — pass ?token=… or run on deepnote.com', 'err')
+        }
+
+        btn.onclick = () => doRun()
+
+        // Load run history
+        if (ready) loadRuns()
+      }
+
+      // ── Input rendering ────────────────────────────────────────────────────────
+      function renderInputs(inputs) {
+        const container = $('#inputs')
+        container.innerHTML = ''
+        inputs.forEach((inp, i) => {
+          state[inp.variableName] = inp.value
+          const field = el('div', 'field')
+          field.style.animationDelay = `${i * 40}ms`
+          const label = el('label')
+          label.append(document.createTextNode(inp.label || inp.variableName))
+          const chip = el('span', 'var'); chip.textContent = inp.variableName; label.append(chip)
+          field.append(label, control(inp))
+          container.append(field)
+        })
+      }
+
+      function control(inp) {
+        if (inp.type === 'input-slider') {
+          state[inp.variableName] = Number(inp.value)
+          const row = el('div', 'range')
+          const range = el('input'); range.type = 'range'
+          range.min = inp.min ?? 0; range.max = inp.max ?? 100; range.step = inp.step ?? 1; range.value = inp.value
+          const out = el('span', 'val'); out.textContent = inp.value
+          range.oninput = () => { state[inp.variableName] = Number(range.value); out.textContent = range.value }
+          row.append(range, out); return row
+        }
+        if (inp.type === 'input-checkbox') {
+          const wrap = el('label', 'switch')
+          const box = el('input'); box.type = 'checkbox'; box.checked = inp.value === true
+          const track = el('span', 'track'); const txt = el('span', 'txt'); txt.textContent = box.checked ? 'On' : 'Off'
+          box.onchange = () => { state[inp.variableName] = box.checked; txt.textContent = box.checked ? 'On' : 'Off' }
+          wrap.append(box, track, txt); return wrap
+        }
+        if (inp.type === 'input-select') {
+          const sel = el('select'); sel.multiple = !!inp.multiple
+          for (const opt of inp.options ?? []) {
+            const o = el('option'); o.value = opt; o.textContent = opt
+            o.selected = Array.isArray(inp.value) ? inp.value.includes(opt) : inp.value === opt
+            sel.append(o)
+          }
+          sel.onchange = () => { state[inp.variableName] = inp.multiple ? [...sel.selectedOptions].map(o => o.value) : sel.value }
+          return sel
+        }
+        if (inp.type === 'input-textarea') {
+          const ta = el('textarea'); ta.rows = 3; ta.value = inp.value ?? ''
+          ta.oninput = () => { state[inp.variableName] = ta.value }; return ta
+        }
+        if (inp.type === 'input-date') {
+          const d = el('input'); d.type = 'date'; d.value = inp.value ?? ''
+          d.oninput = () => { state[inp.variableName] = d.value }; return d
+        }
+        if (inp.type === 'input-date-range') {
+          const wrap = el('div', 'dates')
+          const v = Array.isArray(inp.value) ? inp.value : ['', '']
+          const a = el('input'); a.type = 'date'; a.value = v[0] ?? ''
+          const arrow = el('span'); arrow.textContent = '→'
+          const b = el('input'); b.type = 'date'; b.value = v[1] ?? ''
+          const sync = () => { state[inp.variableName] = [a.value, b.value] }
+          a.oninput = sync; b.oninput = sync
+          wrap.append(a, arrow, b); return wrap
+        }
+        const text = el('input'); text.type = 'text'; text.value = inp.value ?? ''
+        text.oninput = () => { state[inp.variableName] = text.value }; return text
+      }
+
+      // ── Run ────────────────────────────────────────────────────────────────────
+      async function doRun() {
+        const gen = ++displayGen
+        $('#run-btn').disabled = true
+        $('#spin').className = 'spin'
+        setStatus('Starting run…')
+
+        try {
+          if (isDeepnote) {
+            apiToken = await requestDeepnoteToken()
+            if (!apiToken) throw new Error('Could not acquire API token from Deepnote')
+          }
+
+          const started = await triggerRun(APP_CONFIG.notebookId, state)
+          setStatus(`Running… (${started.status})`)
+
+          const result = await pollRun(started.runId)
+          if (gen !== displayGen) return
+
+          const outputs = parseOutputsFromSnapshot(result.snapshotContent)
+          render({ outputs: outputs.map(b => ({ blockId: b.blockId, outputs: b.outputs })) })
+          shownRunId = null
+
+          if (!result.success) {
+            setStatus(cap(result.error || `The run failed (${result.status})`), 'err')
+          } else {
+            const where = isLocal() ? 'locally' : 'in cloud'
+            setStatus(`Ran ${outputs.length} block${outputs.length === 1 ? '' : 's'} ${where}`, 'ok')
+          }
+        } catch (e) {
+          if (gen === displayGen) setStatus(cap(e.message), 'err')
+        } finally {
+          $('#run-btn').disabled = false
+          $('#spin').className = ''
+          loadRuns()
+        }
+      }
+
+      // ── Run history ────────────────────────────────────────────────────────────
+      async function loadRuns() {
+        if (!apiToken && !isLocal()) return
+        if (!APP_CONFIG.notebookId) return
+        const data = await listRuns(APP_CONFIG.notebookId)
+        renderRuns(data)
+      }
+
+      function renderRuns(data) {
+        lastRuns = data
+        const { runs } = data
+        const panel = $('#runs-panel')
+        if (!runs?.length) { panel.hidden = true; return }
+        panel.hidden = false
+
+        const list = $('#runs-list')
+        list.innerHTML = ''
+        for (const run of runs.slice(0, 8)) {
+          const row = el('button', `run${run.runId === shownRunId ? ' on' : ''}`)
+          row.type = 'button'
+          const dot = el('span', `dot ${dotClass(run.status)}`)
+          const name = el('span'); name.textContent = label(run.status)
+          const when = el('span', 'when'); when.textContent = ago(run.createdAt)
+          const dur = el('span', 'dur'); dur.textContent = took(run)
+          row.append(dot, name, when, dur)
+          row.onclick = () => showRun(run.runId)
+          const li = el('li')
+          li.append(row)
+          list.append(li)
+        }
+
+        if (displayGen === 0) {
+          const latest = runs.find(r => r.status === 'success')
+          if (latest) showRun(latest.runId)
+        }
+      }
+
+      async function showRun(runId) {
+        const gen = ++displayGen
+        try {
+          const result = await fetchRun(runId)
+          if (gen !== displayGen) return
+          shownRunId = runId
+          const outputs = parseOutputsFromSnapshot(result.snapshotContent)
+          render({ outputs: outputs.map(b => ({ blockId: b.blockId, outputs: b.outputs })) })
+          if (lastRuns) renderRuns(lastRuns)
+          const when = ago(lastRuns?.runs?.find(r => r.runId === runId)?.createdAt)
+          if (!result.success) {
+            setStatus(`That run ${label(result.status).toLowerCase()} ${when}${result.error ? ': ' + result.error : ''}`, 'err')
+          } else {
+            setStatus(`Showing a run from ${when}`, 'ok')
+          }
+        } catch (e) {
+          if (gen === displayGen) setStatus(cap(e.message), 'err')
+        }
+      }
+
+      // ── Rendering ──────────────────────────────────────────────────────────────
+      function render(data) {
+        const root = $('#output'); root.innerHTML = ''
+        const withOut = data.outputs.filter(b => b.outputs.length)
+        if (!withOut.length) { root.innerHTML = '<div class="empty"><b>No output.</b></div>'; return }
+        const grid = el('div', 'grid')
+        withOut.forEach((block, i) => {
+          const card = el('div', 'card'); card.style.animationDelay = `${i * 60}ms`
+          let onlyMedia = true
+          for (const o of block.outputs) {
+            const node = renderOutput(o)
+            if (!node) continue
+            card.append(node)
+            if (node.tagName !== 'IMG' && !node.classList.contains('htmlout')) onlyMedia = false
+          }
+          if (onlyMedia) card.classList.add('flush')
+          grid.append(card)
+        })
+        root.append(grid)
+      }
+
+      function renderOutput(o) {
+        if (o.output_type === 'stream') { const pre = el('pre', o.name === 'stderr' ? 'err' : ''); pre.textContent = join(o.text); return pre }
+        if (o.output_type === 'error') { const pre = el('pre', 'err'); pre.textContent = (o.traceback ? o.traceback.join('\n') : `${o.ename}: ${o.evalue}`).replace(/\x1b\[[0-9;]*m/g, ''); return pre }
+        const d = o.data || {}
+        if (d['image/png']) { const img = el('img', 'out'); img.alt = 'Chart output'; img.src = 'data:image/png;base64,' + join(d['image/png']).replace(/\s+/g, ''); return img }
+        if (d['text/html']) return sandbox(join(d['text/html']))
+        const pre = el('pre'); pre.textContent = join(d['text/plain'] ?? ''); return pre
+      }
+
+      function sandbox(html) {
+        const frame = el('iframe', 'htmlout'); frame.setAttribute('sandbox', 'allow-scripts'); frame.title = 'HTML output'; frame.style.height = '60px'
+        const id = 'f' + Math.random().toString(36).slice(2); frame.dataset.id = id
+        frame.srcdoc =
+          '<!doctype html><meta charset="utf-8"><style>:root{color-scheme:light dark}' +
+          'html,body{margin:0}body{font:14px/1.5 ui-sans-serif,-apple-system,"Segoe UI",sans-serif;color:#17151f;padding:2px}' +
+          'table{border-collapse:collapse;font-size:13px}th,td{border:1px solid #e3e2ec;padding:5px 11px;text-align:right}th{color:#57546a;font-weight:600}td:first-child,th:first-child{text-align:left}' +
+          '@media(prefers-color-scheme:dark){body{color:#ece9f7}th,td{border-color:#2a2638}th{color:#a9a6bd}}</style>' +
+          html +
+          '<script>const post=()=>parent.postMessage({h:document.documentElement.scrollHeight,id:' + JSON.stringify(id) + '},"*");new ResizeObserver(post).observe(document.documentElement);addEventListener("load",post)<\/script>'
+        return frame
+      }
+      window.addEventListener('message', (e) => {
+        if (e.data?.type === 'deepnote-static-files-api-token-response') return
+        if (e.origin !== 'null' || !e.data || typeof e.data.h !== 'number') return
+        const f = document.querySelector(`iframe[data-id=${JSON.stringify(e.data.id)}]`)
+        if (f && e.source === f.contentWindow) f.style.height = e.data.h + 2 + 'px'
+      })
+
+      // ── Utilities ──────────────────────────────────────────────────────────────
+      const join = (t) => (Array.isArray(t) ? t.join('') : t ?? '')
+      const cap = (s) => (s ? String(s)[0].toUpperCase() + String(s).slice(1) : s)
+      const dotClass = (s) =>
+        s === 'success' ? 'success' : ['error', 'internal_error', 'stopped'].includes(s) ? 'failed' : 'live'
+      const label = (s) => cap(String(s).replace(/_/g, ' '))
+
+      function ago(iso) {
+        if (!iso) return ''
+        const secs = Math.max(0, (Date.now() - new Date(iso).getTime()) / 1000)
+        if (secs < 60) return 'just now'
+        if (secs < 3600) return `${Math.floor(secs / 60)}m ago`
+        if (secs < 86400) return `${Math.floor(secs / 3600)}h ago`
+        return `${Math.floor(secs / 86400)}d ago`
+      }
+
+      function took({ createdAt, completedAt }) {
+        if (!completedAt || !createdAt) return ''
+        const secs = Math.round((new Date(completedAt) - new Date(createdAt)) / 1000)
+        return secs >= 60 ? `${Math.floor(secs / 60)}m ${secs % 60}s` : `${secs}s`
+      }
+
+      function setStatus(text, cls = '') { const s = $('#status'); s.textContent = text; s.className = 'status ' + cls }
+
+      // ── Boot ────────────────────────────────────────────────────────────────────
+      init()
+    </script>
+  </body>
+</html>

--- a/examples/local-runner/cloud-app/serve.mjs
+++ b/examples/local-runner/cloud-app/serve.mjs
@@ -1,0 +1,45 @@
+// Serves the cloud app for local development. Zero API routes — the page talks directly to
+// whatever baseUrl it's configured with (api.deepnote.com or a local Deepnote server).
+// This only exists to wire /snapshot-reader.js from the built package without a copy step.
+
+import { readFile } from 'node:fs/promises'
+import { createServer } from 'node:http'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const here = dirname(fileURLToPath(import.meta.url))
+
+const routes = {
+  '/': [join(here, 'index.html'), 'text/html; charset=utf-8'],
+  '/snapshot-reader.js': [
+    join(here, '..', '..', '..', 'packages', 'local-runner', 'dist', 'snapshot-reader.iife.js'),
+    'text/javascript; charset=utf-8',
+  ],
+}
+
+const server = createServer(async (req, res) => {
+  const route = routes[(req.url ?? '/').split('?')[0]]
+  if (!route) {
+    res.writeHead(404).end('Not found')
+    return
+  }
+  try {
+    const body = await readFile(route[0])
+    res.writeHead(200, { 'content-type': route[1] }).end(body)
+  } catch (err) {
+    const missingReader = route[0].endsWith('snapshot-reader.iife.js')
+    res
+      .writeHead(500)
+      .end(
+        missingReader
+          ? 'snapshot-reader not built. Run: pnpm --filter @deepnote/local-runner build'
+          : `Failed to read ${route[0]}: ${err instanceof Error ? err.message : String(err)}`
+      )
+  }
+})
+
+server.listen(0, '127.0.0.1', () => {
+  const { port } = server.address()
+  console.log(`\n  Deepnote app (local dev) → http://127.0.0.1:${port}`)
+  console.log(`  Pass ?baseUrl=http://localhost:8080 for a local server, or ?token=… for cloud\n`)
+})


### PR DESCRIPTION
## Summary

A self-contained HTML page that runs a Deepnote notebook and renders its outputs, driven by **one Run button** pointed at **one configurable endpoint** that defaults to `https://api.deepnote.com` — so the common case needs no configuration at all.

```js
const APP_CONFIG = {
  notebookId: null,
  notebookName: 'Dashboard',
  baseUrl: 'https://api.deepnote.com',
  inputs: [],
}
```

Point `baseUrl` elsewhere and the *same* `/v2/runs` surface serves a local Deepnote server:

```bash
# Cloud — the default, nothing to configure
http://127.0.0.1:<port>?notebookId=<id>&token=<token>

# A local Deepnote server, same endpoints
http://127.0.0.1:<port>?notebookId=<id>&baseUrl=http://localhost:8080
```

The app targets one at a time, so there is a single request path and a single result shape to render — rather than separate cloud and local buttons whose visibility depends on probing for a local server.

## How it works

1. `POST {baseUrl}/v2/runs` to trigger
2. `GET {baseUrl}/v2/runs/{runId}?snapshotDelivery=inline` to poll
3. Parse the returned snapshot YAML client-side with the existing `snapshot-reader.iife.js` bundle
4. Render outputs — tables, charts, text, HTML

Token acquisition: on deepnote.com the page asks the shell via `postMessage` (`deepnote-static-files-api-token-request`) and gets a short-lived project-scoped token; elsewhere it accepts `?token=`.

`serve.mjs` is for local development only and has **no API routes** — runs never pass through it. Its only job is mapping `/snapshot-reader.js` to the built bundle so there's no copy step. That's why it's 45 lines.

## Dependencies — none

This branches directly off `main` and depends on no other open PR. `main` already builds `snapshot-reader.iife.js` (`packages/local-runner/tsdown.config.ts`) and already hosts sibling examples under `examples/local-runner/`. Nothing outside `examples/local-runner/cloud-app/` changes except a one-word `cspell.json` entry for `deepnoteworkspace`, the domain the README documents.

One forward reference to flag: the README's "Publishing to deepnote.com" section uses `deepnote publish`, which ships in #455. It is documentation only — nothing in the app calls it — but if this merges first, that section describes a command not yet on `main`.

## Test plan

- [x] `pnpm test` — 2894 passed, 1 skipped
- [x] `pnpm spell-check` — 0 issues
- [x] `pnpm biome:check` — clean (the two `noConsole` warnings in `serve.mjs` match `gallery/`, `run-app/`, and `snapshot-viewer/` on `main`)
- [ ] `node examples/local-runner/cloud-app/serve.mjs` serves the page and `/snapshot-reader.js`
- [ ] Cloud run against the default `api.deepnote.com` with `?token=` renders outputs
- [ ] `?baseUrl=http://localhost:8080` drives the same code path against a local server
- [ ] On deepnote.com, the postMessage token flow works with no `baseUrl` set

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a standalone browser app for running Deepnote notebooks, viewing run history, and rendering outputs.
  * Added support for cloud and local API execution, including run status, errors, streams, images, HTML, and text results.
  * Added a local development server with configurable app and snapshot-reader URLs.

* **Documentation**
  * Added setup, configuration, execution, snapshot rendering, and publishing instructions for the browser app.

* **Chores**
  * Added the app name to the spell-check dictionary.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->