### PR TITLE
docs: correct Snowflake integration instructions

### DIFF
--- a/docs/snowflake-with-azure-ad.md
+++ b/docs/snowflake-with-azure-ad.md
@@ -102,7 +102,7 @@ There are a number of steps to follow which will be described in the following s
 
 1.  After heading back to Deepnote, create a Snowflake integration as described in our main [Snowflake docs](snowflake).
 
-2.  Select Azure AD as the authentication method and fill in **Client ID** and **Client Secret** based on `<OAUTH_CLIENT_ID>` and `<OAUTH_CLIENT_SECRET>` defined in [the section above](snowflake-with-azure-ad#create-snowflake-oauth-client-application).
+2.  Select **AzureAD** as the authentication method and fill in **Client ID** and **Client Secret** based on `<OAUTH_CLIENT_ID>` and `<OAUTH_CLIENT_SECRET>` defined in [the section above](snowflake-with-azure-ad#create-snowflake-oauth-client-application).
 
 3.  Fill in **Resource** as the `<RESOURCE_ID>` of your Snowflake OAuth Resource application from step 7 of [the first section](snowflake-with-azure-ad#create-snowflake-oauth-resource-application).
 

--- a/docs/snowflake-with-key-pair-authentication.md
+++ b/docs/snowflake-with-key-pair-authentication.md
@@ -24,8 +24,10 @@ You have two options when generating your private key - unencrypted or encrypted
 
 For an unencrypted private key:
 
+<!-- cspell:ignore nocrypt -->
+
 ```sh
-openssl genrsa 2048 | openssl pkcs8 -topk8 -v2 des3 -inform PEM -out snowflake_key.p8 --no-crypt
+openssl genrsa 2048 | openssl pkcs8 -topk8 -inform PEM -out snowflake_key.p8 -nocrypt
 ```
 
 If you prefer an encrypted private key:
@@ -55,10 +57,10 @@ This command reads the public key file and copies its content to your clipboard,
 After generating both keys, you'll need to register the public key with Snowflake. Open your public key file, copy its contents, and run this SQL command in Snowflake:
 
 ```sql
-ALTER USER [USERNAME] SET RSA_PUBLIC_KEY='-----BEGIN PRIVATE KEY----- MIIEvg...';
+ALTER USER [USERNAME] SET RSA_PUBLIC_KEY='MIIEvg...';
 ```
 
-Remember to replace `[USERNAME]` with your actual Snowflake username and insert your full public key. The public key should begin with `-----BEGIN PRIVATE KEY-----`.
+Remember to replace `[USERNAME]` with your actual Snowflake username and insert the contents of your public key. Remove the `-----BEGIN PUBLIC KEY-----` and `-----END PUBLIC KEY-----` delimiters before inserting the key into the SQL statement.
 
 ## Setting up Snowflake integration in Deepnote
 

--- a/docs/snowflake-with-okta.md
+++ b/docs/snowflake-with-okta.md
@@ -109,7 +109,7 @@ Snowflake account URL can be copied from the Snowflake UI, as shown on a screens
        external_oauth_type = okta
        external_oauth_issuer = '<OKTA_ISSUER>'
        external_oauth_jws_keys_url = '<OKTA_JWS_KEY_ENDPOINT>'
-       external_oauth_audience_list = ('<snowflake_account_url')
+       external_oauth_audience_list = ('<snowflake_account_url>')
        external_oauth_token_user_mapping_claim = 'sub'
        external_oauth_snowflake_user_mapping_attribute = 'login_name';
    ```
@@ -124,7 +124,7 @@ Snowflake account URL can be copied from the Snowflake UI, as shown on a screens
 
 4.  Fill in Identity Provider as `<OKTA_IDENTITY_PROVIDER_ID>` .
 
-5.  Fill in Authorization Server as the `<OKTA_AUTHORIZATION_SERVER_ID>`.
+5.  Fill in **Authorization server ID** as the `<OKTA_AUTHORIZATION_SERVER_ID>`.
 
 6.  **Optional:** If you didn’t set `external_oauth_any_role_mode = 'ENABLE'` when creating a security integration in Snowflake, you must fill in Role [as defined by the Okta scope](snowflake-with-azure-ad#Create-Security-integration-in-Snowflake) (just add the role name and not the `session:role` prefix).
 

--- a/docs/snowflake.md
+++ b/docs/snowflake.md
@@ -45,7 +45,7 @@ This authentication method is straightforward and works well for individual use 
 
 For enhanced security, Deepnote supports [Snowflake's Key-pair authentication](/docs/snowflake-with-key-pair-authentication), allowing you to authenticate users with private keys instead of passwords.
 
-When creating a Snowflake integration, select **Key-pair (individual credentials)** or **Key-pair (service account)** as the authentication method. After creating the integration and connecting it to your project, users will be prompted to provide their username and private key when they first access Snowflake resources through the schema browser or when running queries.
+When creating a Snowflake integration, select **Key-pair (individual credentials)** or **Key-pair (service account)** as the authentication method. For **Key-pair (individual credentials)**, after creating the integration and connecting it to your project, users will be prompted to provide their username and private key when they first access Snowflake resources through the schema browser or when running queries. For **Key-pair (service account)**, provide the service-account username and private key during integration setup.
 
 Key-pair authentication provides a more secure alternative to password-based access while maintaining a seamless experience when working with Snowflake data in Deepnote.
 

--- a/docs/snowflake.md
+++ b/docs/snowflake.md
@@ -45,7 +45,7 @@ This authentication method is straightforward and works well for individual use 
 
 For enhanced security, Deepnote supports [Snowflake's Key-pair authentication](/docs/snowflake-with-key-pair-authentication), allowing you to authenticate users with private keys instead of passwords.
 
-When creating a Snowflake integration, select "Key-pair" as the authentication type. After creating the integration and connecting it to your project, users will be prompted to provide their username and private key when they first access Snowflake resources through the schema browser or when running queries.
+When creating a Snowflake integration, select **Key-pair (individual credentials)** or **Key-pair (service account)** as the authentication method. After creating the integration and connecting it to your project, users will be prompted to provide their username and private key when they first access Snowflake resources through the schema browser or when running queries.
 
 Key-pair authentication provides a more secure alternative to password-based access while maintaining a seamless experience when working with Snowflake data in Deepnote.
 

--- a/docs/snowpark.md
+++ b/docs/snowpark.md
@@ -15,9 +15,9 @@ With the new Snowpark integration in Deepnote you can perform database transform
 
 The Snowpark + Deepnote integration makes the warehouse feel like an in-memory object. Simply write your code in Deepnote and manipulate your tables as if you were using Pandas. All compute occurs directly in the warehouse so there’s no need to constantly move your data around.
 
-### How to connect
+## How to connect
 
-Begin by `pip` installing Snowpark inside of Deepnote. Note that **Snowpark requires Python 3.10 or later**. Select a compatible Python environment from the dropdown in the right sidebar. For more information, see [custom environments](/docs/custom-environments).
+Begin by `pip` installing Snowpark inside of Deepnote. Note that **Deepnote supports Python versions 3.10 through 3.13 for Snowpark**. Select a compatible Python environment from the dropdown in the right sidebar. For more information, see [custom environments](/docs/custom-environments).
 
 ```python
 !pip install snowflake-snowpark-python

--- a/docs/snowpark.md
+++ b/docs/snowpark.md
@@ -13,11 +13,11 @@ noContent: false
 
 With the new Snowpark integration in Deepnote you can perform database transformations with Python and deploy machine learning models to Snowflake—**without moving your data or changing the Python code you already use**.
 
-The Snowpark + Deepnote integration makes the warehouse feels like an in-memory object. Simply write your code in Deepnote and manipulate your tables as if you were using Pandas. All compute occurs directly in the warehouse so there’s no need to constantly move your data around.
+The Snowpark + Deepnote integration makes the warehouse feel like an in-memory object. Simply write your code in Deepnote and manipulate your tables as if you were using Pandas. All compute occurs directly in the warehouse so there’s no need to constantly move your data around.
 
 ### How to connect
 
-Begin by `pip` installing Snowpark inside of Deepnote. Note that **Snowpark requires Python 3.10 or later** (this can be selected from the [environments tab in Deepnote](/docs/custom-environments)).
+Begin by `pip` installing Snowpark inside of Deepnote. Note that **Snowpark requires Python 3.10 or later**. Select a compatible Python environment from the dropdown in the right sidebar. For more information, see [custom environments](/docs/custom-environments).
 
 ```python
 !pip install snowflake-snowpark-python


### PR DESCRIPTION
## What this changes

- Corrects the Snowflake key-pair OpenSSL command and public-key SQL instructions.
- Updates the Snowflake key-pair authentication labels to match the current UI.
- Separates individual-credential prompts from service-account setup instructions.
- Updates the AzureAD and Okta authentication field labels.
- Fixes the Okta Snowflake account URL placeholder.
- Fixes the Snowpark heading hierarchy, introduction, and Python environment guidance.

## Why

The documentation audit compared these Snowflake integration and Snowpark instructions with the current product UI and provider documentation. The changes correct reproducible wording, command, placeholder, and navigation drift.

### Finding 1: misleading

> When creating a Snowflake integration, select "Key-pair" as the authentication type.

- **Documented:** The authentication method is labeled Key-pair.
- **Actual:** The current choices are Key-pair (individual credentials) and Key-pair (service account).
- **Reproduced:** Yes.
- **Correction:** Names both current authentication choices.

### Finding 2: blocking

> For an unencrypted private key:

- **Documented:** The command uses `--no-crypt`.
- **Actual:** The tested OpenSSL command accepts `-nocrypt`.
- **Reproduced:** Yes.
- **Correction:** Uses the current unencrypted PKCS#8 command.

### Finding 3: blocking

> The public key should begin with `-----BEGIN PRIVATE KEY-----`.

- **Documented:** The public-key example uses a private-key header.
- **Actual:** The public-key command produces a public-key header, and Snowflake SQL uses the key contents without PEM delimiters.
- **Reproduced:** Yes.
- **Correction:** Uses the public-key contents without PEM delimiters.

### Finding 4: misleading

> Select Azure AD as the authentication method and fill in **Client ID** and **Client Secret** based on `<OAUTH_CLIENT_ID>` and `<OAUTH_CLIENT_SECRET>` defined in [the section above](snowflake-with-azure-ad#create-snowflake-oauth-client-application).

- **Documented:** The method is labeled Azure AD.
- **Actual:** The current Deepnote method is labeled AzureAD.
- **Reproduced:** Yes.
- **Correction:** Uses the current AzureAD label.

### Finding 5: misleading

> Fill in Authorization Server as the `<OKTA_AUTHORIZATION_SERVER_ID>`.

- **Documented:** The field is named Authorization Server.
- **Actual:** The current field is named Authorization server ID.
- **Reproduced:** Yes.
- **Correction:** Uses the current field label.

### Finding 6: blocking

> external_oauth_audience_list = ('<snowflake_account_url')

- **Documented:** The placeholder is incomplete.
- **Actual:** The placeholder needs a closing angle bracket.
- **Reproduced:** Yes.
- **Correction:** Uses `<snowflake_account_url>`.

### Finding 7: misleading

> The Snowpark + Deepnote integration makes the warehouse feels like an in-memory object.

- **Documented:** The introduction uses “makes ... feels”.
- **Actual:** The sentence requires “makes ... feel”.
- **Reproduced:** Yes.
- **Correction:** Fixes the grammar.

### Finding 8: misleading

> Note that **Snowpark requires Python 3.10 or later** (this can be selected from the [environments tab in Deepnote](/docs/custom-environments)).

- **Documented:** The environment is selected from an environments tab.
- **Actual:** The current product exposes a Python environment dropdown in the right sidebar.
- **Reproduced:** Yes.
- **Correction:** Describes the current dropdown and links to custom environments.

### Follow-up review fixes

- Limits the Snowpark Python guidance to versions 3.10 through 3.13 in Deepnote.
- Changes the Snowpark **How to connect** heading to the correct document level.
- Explains that individual-credential users enter their username and private key on first resource access, while service-account credentials are entered during integration setup.

## How this was verified

The documented workflows were checked through the approved Chrome-based audit workflow. Independent UI, command, syntax, package, and navigation checks were completed where they did not require provider credentials. No credentials or sensitive values are included in this change.

## Unverified by human

This draft uses a user-authorized incomplete-verification exception. The following items remain for human validation:

### https://deepnote.com/docs/snowflake

Safe credential-free replacement screenshot for the illustrated Snowflake authentication form; the new and existing forms auto-populate stored connection values.

Human follow-up: capture and review the current authentication-form state with a safe test connection, without exposing credentials.

### https://deepnote.com/docs/snowflake-with-key-pair-authentication

First-use key-pair authentication through the schema browser or query, including the required username and private key prompt and its screenshot.

Human follow-up: use a test Snowflake account, register the public key, complete first-use authentication, and verify a schema or query result.

### https://deepnote.com/docs/snowflake-oauth

Snowflake OAuth authorization through the external provider, including the resulting first-use sign-in state and required screenshot.

Human follow-up: complete the provider consent and sign-in flow with a test OAuth application, then verify the resulting authenticated integration.

### https://deepnote.com/docs/snowflake-with-azure-ad

Azure AD authorization through the external identity provider, including the resulting first-use sign-in state and required screenshot.

Human follow-up: complete the Azure client and consent configuration, enter the secret interactively, finish the Snowflake security integration, and verify Deepnote authentication.

### https://deepnote.com/docs/snowflake-with-okta

Okta authorization through the external identity provider, including the resulting first-use sign-in state and required screenshot.

Human follow-up: complete the Okta client and authorization-server configuration, finish the Snowflake security integration, and verify Deepnote authentication.

### https://deepnote.com/docs/snowpark

Creating a real Snowpark Session and running table or DataFrame operations against Snowflake, which requires a Snowflake credentialed connection.

Human follow-up: use a test Snowflake connection, create a real Session, read a test table, run a DataFrame operation, and confirm the result.

User explicitly authorized this incomplete-verification draft exception for the `snowflake-and-snowpark` batch on 2026-08-19.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified Snowflake Azure AD, key-pair, and Okta authentication setup instructions.
  - Corrected key-generation commands, SQL examples, and OAuth configuration details.
  - Distinguished individual-credential and service-account authentication methods.
  - Improved Snowpark integration wording and clarified support for Python 3.10–3.13 environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->