### PR TITLE
feat(cli): wire --push into deepnote run --cloud

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -161,6 +161,8 @@ deepnote run my-project.deepnote
 | `--out <path>`          | Write the downloaded cloud snapshot to this exact path                    |                            |
 | `--storage-mode <mode>` | Project-storage access for a detached cloud run: `read-write`, `readonly` | `read-write`               |
 | `--timeout <seconds>`   | Max seconds to wait for a cloud run (with `--cloud`)                      | `600`                      |
+| `--push`                | Push the local `.deepnote` blocks to the Deepnote notebook before running | `false`                    |
+| `--yes`                 | Skip the `--push` confirmation prompt                                     | `false`                    |
 | `--url <url>`           | API base URL                                                              | `https://api.deepnote.com` |
 | `--token <token>`       | Bearer token (or `DEEPNOTE_TOKEN` env var)                                |                            |
 
@@ -220,6 +222,14 @@ persistent project storage read-only for that run; temporary files and reads sti
 databases, integrations, external APIs, and other systems remain live. Block-scoped cloud runs are
 the exception: the API runs them in live mode, so they update live-editor outputs and cannot be
 combined with `--storage-mode`.
+
+`--push` sends the local file's blocks to the Deepnote notebook before the run, so the run executes
+what is on disk rather than what was last saved in Deepnote. The sync is destructive — a cloud
+block the file does not have is deleted, and a block whose type or metadata changed is recreated
+under a new id (a `--block` selection is remapped automatically) — so the CLI prints the plan and
+asks first. `--yes` confirms non-interactively and is required when output is piped or
+machine-readable; `--dry-run` prints the plan and exits without sending or running anything (with
+`-o json`/`-o toon` the plan itself is emitted); a declined confirmation exits `0` without running.
 
 Cloud execution status and snapshot delivery are reported separately. The CLI briefly polls after
 terminal status because snapshot attachment can lag; empty snapshot content is treated as no

--- a/packages/cli/src/cli.test.ts
+++ b/packages/cli/src/cli.test.ts
@@ -68,10 +68,11 @@ describe('CLI', () => {
       expect(optionFlags).toContain('--out <path>')
       expect(optionFlags).toContain('--storage-mode <mode>')
       expect(optionFlags).toContain('--timeout <seconds>')
-      // --push is registered but hidden until the push-to-cloud flow ships
+      // --push is wired into the cloud run flow and visible, with --yes to confirm it in CI
       const pushOption = runCmd?.options.find(o => o.flags === '--push')
       expect(pushOption).toBeDefined()
-      expect(pushOption?.hidden).toBe(true)
+      expect(pushOption?.hidden).toBe(false)
+      expect(optionFlags).toContain('--yes')
     })
 
     it('completion command is properly configured', () => {
@@ -174,6 +175,7 @@ describe('CLI', () => {
         COMPREPLY=( $(compgen -W "read-write readonly" -- "\${cur}") )
         return 0
     fi`)
+      expect(output).toContain('--storage-mode --timeout --push --yes --url')
       consoleSpy.mockRestore()
     })
 
@@ -192,6 +194,8 @@ describe('CLI', () => {
       expect(output).toContain(
         "'--storage-mode[Project-storage access for a detached cloud run]:mode:(read-write readonly)'"
       )
+      expect(output).toContain("'--push[Push the local .deepnote blocks to the Deepnote notebook before running]'")
+      expect(output).toContain("'--yes[Skip the --push confirmation prompt]'")
       consoleSpy.mockRestore()
     })
 
@@ -208,6 +212,12 @@ describe('CLI', () => {
       expect(output).toContain('__fish_seen_subcommand_from schedule')
       expect(output).toContain(
         "complete -c deepnote -n '__fish_seen_subcommand_from run' -l storage-mode -a 'read-write readonly' -d 'Project-storage access for a detached cloud run'"
+      )
+      expect(output).toContain(
+        "complete -c deepnote -n '__fish_seen_subcommand_from run' -l push -d 'Push the local .deepnote blocks to the Deepnote notebook before running'"
+      )
+      expect(output).toContain(
+        "complete -c deepnote -n '__fish_seen_subcommand_from run' -l yes -d 'Skip the --push confirmation prompt'"
       )
       consoleSpy.mockRestore()
     })

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -320,7 +320,11 @@ ${c.bold('Examples:')}
       'Max seconds to wait for a cloud run to finish (with --cloud, default 600)',
       parseTimeoutSeconds
     )
-    .addOption(new Option('--push', 'Push a local notebook to Deepnote before running').hideHelp())
+    .option(
+      '--push',
+      'Push the local .deepnote blocks to the Deepnote notebook before running (deletes cloud blocks the file does not have)'
+    )
+    .option('--yes', 'Skip the --push confirmation prompt')
     .addHelpText('after', () => {
       const c = getChalk()
       return `
@@ -348,6 +352,12 @@ ${c.bold('Examples:')}
 
   ${c.dim('# Run a .deepnote (notebook id read from the file) in the cloud, with inputs')}
   $ deepnote run my-project.deepnote --cloud --input name="Alice"
+
+  ${c.dim('# Push local edits to the Deepnote notebook first, then run what is on disk')}
+  $ deepnote run my-project.deepnote --cloud --push
+
+  ${c.dim('# Preview what --push would change without sending or running anything')}
+  $ deepnote run my-project.deepnote --cloud --push --dry-run
 
   ${c.dim('# Run with a specific Python virtual environment')}
   $ deepnote run my-project.deepnote --python path/to/venv

--- a/packages/cli/src/commands/run.ts
+++ b/packages/cli/src/commands/run.ts
@@ -117,6 +117,8 @@ export interface RunOptions {
   timeout?: number
   storageMode?: 'read-write' | 'readonly'
   push?: boolean
+  /** Skip the `--push` confirmation prompt (for CI and scripts). */
+  yes?: boolean
 }
 
 /** Result of a single block execution for JSON output */

--- a/packages/cli/src/completions.ts
+++ b/packages/cli/src/completions.ts
@@ -121,7 +121,7 @@ _deepnote_completions() {
         run)
             # Complete notebook files and flags
             if [[ "\${cur}" == -* ]]; then
-                COMPREPLY=( $(compgen -W "--python --cwd --notebook --block --input -i --list-inputs -o --output --dry-run --top --profile --open --cloud --notebook-id --out --storage-mode --timeout --url --token" -- "\${cur}") )
+                COMPREPLY=( $(compgen -W "--python --cwd --notebook --block --input -i --list-inputs -o --output --dry-run --top --profile --open --cloud --notebook-id --out --storage-mode --timeout --push --yes --url --token" -- "\${cur}") )
             else
                 # Enable extglob for pattern matching, restore original state after
                 local _extglob_was_off=0
@@ -365,6 +365,8 @@ ${commandEntries}
                         '--out[Write the downloaded cloud snapshot to this path]:out path:_files' \\
                         '--storage-mode[Project-storage access for a detached cloud run]:mode:(read-write readonly)' \\
                         '--timeout[Max seconds to wait for a cloud run]:seconds:' \\
+                        '--push[Push the local .deepnote blocks to the Deepnote notebook before running]' \\
+                        '--yes[Skip the --push confirmation prompt]' \\
                         '--url[API base URL]:url:' \\
                         '--token[Bearer token for the Deepnote API]:token:' \\
                         '*:notebook file:_files -g "*.{deepnote,ipynb,qmd,py}"'
@@ -591,6 +593,8 @@ complete -c deepnote -n '__fish_seen_subcommand_from run' -l notebook-id -d 'Clo
 complete -c deepnote -n '__fish_seen_subcommand_from run' -l out -d 'Write the downloaded cloud snapshot to this path'
 complete -c deepnote -n '__fish_seen_subcommand_from run' -l storage-mode -a 'read-write readonly' -d 'Project-storage access for a detached cloud run'
 complete -c deepnote -n '__fish_seen_subcommand_from run' -l timeout -d 'Max seconds to wait for a cloud run'
+complete -c deepnote -n '__fish_seen_subcommand_from run' -l push -d 'Push the local .deepnote blocks to the Deepnote notebook before running'
+complete -c deepnote -n '__fish_seen_subcommand_from run' -l yes -d 'Skip the --push confirmation prompt'
 complete -c deepnote -n '__fish_seen_subcommand_from run' -l url -d 'API base URL'
 complete -c deepnote -n '__fish_seen_subcommand_from run' -l token -d 'Bearer token for the Deepnote API'
 complete -c deepnote -n '__fish_seen_subcommand_from run' -F -a '*.deepnote' -a '*.ipynb' -a '*.qmd' -a '*.py'

--- a/packages/cli/src/utils/cloud-run-errors.ts
+++ b/packages/cli/src/utils/cloud-run-errors.ts
@@ -1,0 +1,13 @@
+/**
+ * User error specific to the cloud run path (bad flag combination, ambiguous notebook, etc.).
+ * `createRunAction` maps this to `ExitCode.InvalidUsage` (2).
+ *
+ * Lives in its own module so `push-to-cloud` (called by `run-in-cloud`) can throw it without
+ * importing `run-in-cloud` back — that would be a runtime import cycle.
+ */
+export class CloudRunUsageError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'CloudRunUsageError'
+  }
+}

--- a/packages/cli/src/utils/push-to-cloud.test.ts
+++ b/packages/cli/src/utils/push-to-cloud.test.ts
@@ -69,22 +69,27 @@ beforeEach(() => {
 
 describe('pushLocalNotebook', () => {
   it('sends nothing when Deepnote already matches the file', async () => {
-    runnerMock.planNotebookSync.mockResolvedValue(plan({ isEmpty: true, changes: [] }))
+    const planned = plan({ isEmpty: true, changes: [] })
+    runnerMock.planNotebookSync.mockResolvedValue(planned)
 
     const outcome = await pushLocalNotebook({ ...BASE })
 
-    expect(outcome).toEqual({ applied: false, declined: false, previewed: false })
+    expect(outcome).toMatchObject({ applied: false, declined: false, previewed: false })
+    expect(outcome.plan).toBe(planned)
     expect(runnerMock.syncNotebookContent).not.toHaveBeenCalled()
     expect(promptMock.promptForBooleanField).not.toHaveBeenCalled()
   })
 
   it('previews without sending or prompting when dryRun is set', async () => {
-    runnerMock.planNotebookSync.mockResolvedValue(plan())
+    const planned = plan()
+    runnerMock.planNotebookSync.mockResolvedValue(planned)
 
     const outcome = await pushLocalNotebook({ ...BASE, dryRun: true })
 
     expect(outcome.previewed).toBe(true)
     expect(outcome.applied).toBe(false)
+    // The caller renders machine-output previews itself, so the plan must ride along.
+    expect(outcome.plan).toBe(planned)
     expect(runnerMock.syncNotebookContent).not.toHaveBeenCalled()
     expect(promptMock.promptForBooleanField).not.toHaveBeenCalled()
   })

--- a/packages/cli/src/utils/push-to-cloud.ts
+++ b/packages/cli/src/utils/push-to-cloud.ts
@@ -8,8 +8,8 @@ import {
 } from '@deepnote/local-runner'
 import ora from 'ora'
 import { debug, getChalk, getOutputConfig, log } from '../output'
+import { CloudRunUsageError } from './cloud-run-errors'
 import { promptForBooleanField } from './inquirer'
-import { CloudRunUsageError } from './run-in-cloud'
 
 /**
  * `deepnote run --cloud --push`: send the local file's blocks to the Deepnote notebook before
@@ -27,6 +27,8 @@ export interface PushOutcome {
   declined: boolean
   /** True when `--dry-run` stopped this before any request. The caller should stop without running. */
   previewed: boolean
+  /** The computed plan, for callers that render their own preview (e.g. machine output). */
+  plan?: SyncPlan
   result?: SyncResult
 }
 
@@ -108,7 +110,7 @@ export async function pushLocalNotebook(args: PushArgs): Promise<PushOutcome> {
     if (!args.machineOutput && !getOutputConfig().quiet) {
       log(chalk.dim('Deepnote already matches this file — nothing to push.'))
     }
-    return { applied: false, declined: false, previewed: false }
+    return { applied: false, declined: false, previewed: false, plan: planned }
   }
 
   if (!args.machineOutput) {
@@ -119,7 +121,7 @@ export async function pushLocalNotebook(args: PushArgs): Promise<PushOutcome> {
     if (!args.machineOutput) {
       log(chalk.dim('\n--dry-run: nothing was sent, and the notebook was not run.'))
     }
-    return { applied: false, declined: false, previewed: true }
+    return { applied: false, declined: false, previewed: true, plan: planned }
   }
 
   if (!args.yes) {
@@ -139,7 +141,7 @@ export async function pushLocalNotebook(args: PushArgs): Promise<PushOutcome> {
     })
     if (!confirmed) {
       log(chalk.dim('Aborted; nothing was sent.'))
-      return { applied: false, declined: true, previewed: false }
+      return { applied: false, declined: true, previewed: false, plan: planned }
     }
   }
 
@@ -168,5 +170,5 @@ export async function pushLocalNotebook(args: PushArgs): Promise<PushOutcome> {
     `Pushed: ${result.created.length} created, ${result.updated.length} updated, ` +
       `${result.deleted.length} deleted, ${result.movesApplied} moved.`
   )
-  return { applied: true, declined: false, previewed: false, result }
+  return { applied: true, declined: false, previewed: false, plan: planned, result }
 }

--- a/packages/cli/src/utils/run-in-cloud.test.ts
+++ b/packages/cli/src/utils/run-in-cloud.test.ts
@@ -9,6 +9,10 @@ import {
 } from '@deepnote/blocks'
 import { splitDeepnoteFile } from '@deepnote/convert'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const pushMock = vi.hoisted(() => ({ pushLocalNotebook: vi.fn() }))
+vi.mock('./push-to-cloud', () => pushMock)
+
 import { ExitCode } from '../exit-codes'
 import { MissingTokenError } from './auth'
 import { InvalidInputError } from './parse-inputs'
@@ -123,6 +127,8 @@ beforeEach(async () => {
   tmpDir = await fs.mkdtemp(join(os.tmpdir(), 'run-cloud-'))
   delete process.env.DEEPNOTE_TOKEN
   process.exitCode = 0
+  // vi.restoreAllMocks() does not touch the hoisted module mock, so reset it here.
+  pushMock.pushLocalNotebook.mockReset()
   vi.spyOn(console, 'log').mockImplementation(() => {})
   vi.spyOn(console, 'error').mockImplementation(() => {})
 })
@@ -159,10 +165,22 @@ async function withCurrentDirectory<T>(directory: string, callback: () => Promis
 }
 
 describe('runInDeepnoteCloud — usage guards', () => {
-  it('rejects --push as not yet implemented', async () => {
+  it('rejects --yes without --push, since there is nothing to confirm', async () => {
     await expect(
-      runInDeepnoteCloud(undefined, { cloud: true, push: true, notebookId: 'nb', token: 't' })
+      runInDeepnoteCloud(undefined, { cloud: true, yes: true, notebookId: 'nb', token: 't' })
     ).rejects.toBeInstanceOf(CloudRunUsageError)
+    await expect(
+      runInDeepnoteCloud(undefined, { cloud: true, yes: true, notebookId: 'nb', token: 't' })
+    ).rejects.toThrow(/--yes/)
+  })
+
+  it('rejects --dry-run with --cloud unless --push gives it a plan to preview', async () => {
+    await expect(
+      runInDeepnoteCloud(undefined, { cloud: true, dryRun: true, notebookId: 'nb', token: 't' })
+    ).rejects.toBeInstanceOf(CloudRunUsageError)
+    await expect(
+      runInDeepnoteCloud(undefined, { cloud: true, dryRun: true, notebookId: 'nb', token: 't' })
+    ).rejects.toThrow(/--push/)
   })
 
   it('rejects local-only flags in cloud mode', async () => {
@@ -182,6 +200,7 @@ describe('runInDeepnoteCloud — usage guards', () => {
       /--storage-mode requires --cloud/
     )
     expect(() => assertCloudOnlyFlagsRequireCloud({ push: true })).toThrow(/--push requires --cloud/)
+    expect(() => assertCloudOnlyFlagsRequireCloud({ yes: true })).toThrow(/--yes requires --cloud/)
     expect(() =>
       assertCloudOnlyFlagsRequireCloud({ notebookId: 'nb', out: 'snap.deepnote', timeout: 30, push: true })
     ).toThrow(/--notebook-id, --out, --timeout, --push require --cloud/)
@@ -460,6 +479,149 @@ describe('runInDeepnoteCloud — snapshot writing', () => {
     await runInDeepnoteCloud(path, { cloud: true, token: 't', url: API_URL, out })
 
     await expect(fs.readFile(out, 'utf-8')).resolves.toBe('just some text')
+  })
+})
+
+describe('runInDeepnoteCloud — --push wiring', () => {
+  it('pushes the local notebook before triggering the run', async () => {
+    const file = makeFile([{ id: 'nb-single', name: 'Main' }])
+    const fetch = installFetch({ terminalStatus: 'success', snapshotContent: serializeDeepnoteFile(file) })
+    const path = await writeFixture('single.deepnote', file)
+    pushMock.pushLocalNotebook.mockResolvedValue({ applied: true, declined: false, previewed: false })
+
+    await runInDeepnoteCloud(path, { cloud: true, token: 't', url: API_URL, push: true, yes: true, output: 'json' })
+
+    expect(pushMock.pushLocalNotebook).toHaveBeenCalledWith(
+      expect.objectContaining({
+        localNotebookId: 'nb-single',
+        notebookId: 'nb-single',
+        baseUrl: API_URL,
+        token: 't',
+        yes: true,
+        machineOutput: true,
+      })
+    )
+    // The push completed before the run was triggered.
+    expect(pushMock.pushLocalNotebook.mock.invocationCallOrder[0]).toBeLessThan(
+      vi.mocked(global.fetch).mock.invocationCallOrder[0]
+    )
+    expect(fetch.postBodies).toHaveLength(1)
+    expect(process.exitCode).toBe(ExitCode.Success)
+  }, 10_000)
+
+  it('pushes the file notebook when --notebook-id names a remote-only notebook', async () => {
+    const file = makeFile([{ id: 'nb-local-1', name: 'Main' }])
+    installFetch({ terminalStatus: 'success', snapshotContent: serializeDeepnoteFile(file) })
+    const path = await writeFixture('single.deepnote', file)
+    pushMock.pushLocalNotebook.mockResolvedValue({ applied: true, declined: false, previewed: false })
+
+    await runInDeepnoteCloud(path, {
+      cloud: true,
+      token: 't',
+      url: API_URL,
+      push: true,
+      yes: true,
+      notebookId: 'remote-nb-9',
+      output: 'json',
+    })
+
+    expect(pushMock.pushLocalNotebook).toHaveBeenCalledWith(
+      expect.objectContaining({ localNotebookId: 'nb-local-1', notebookId: 'remote-nb-9' })
+    )
+  }, 10_000)
+
+  it('previews with --push --dry-run and does not trigger a run', async () => {
+    const file = makeFile([{ id: 'nb-single', name: 'Main' }])
+    installFetch({ terminalStatus: 'success' })
+    const path = await writeFixture('single.deepnote', file)
+    pushMock.pushLocalNotebook.mockResolvedValue({
+      applied: false,
+      declined: false,
+      previewed: true,
+      plan: { changes: [], moves: [], warnings: [], isEmpty: false },
+    })
+
+    await runInDeepnoteCloud(path, { cloud: true, token: 't', url: API_URL, push: true, dryRun: true })
+
+    expect(pushMock.pushLocalNotebook).toHaveBeenCalledWith(expect.objectContaining({ dryRun: true }))
+    expect(vi.mocked(global.fetch)).not.toHaveBeenCalled()
+    expect(process.exitCode).toBe(ExitCode.Success)
+  })
+
+  it('emits the push plan as JSON for a machine-output preview', async () => {
+    const file = makeFile([{ id: 'nb-single', name: 'Main' }])
+    installFetch({ terminalStatus: 'success' })
+    const path = await writeFixture('single.deepnote', file)
+    pushMock.pushLocalNotebook.mockResolvedValue({
+      applied: false,
+      declined: false,
+      previewed: true,
+      plan: {
+        changes: [{ action: 'update', blockId: 'b1', blockType: 'code', reason: 'content changed' }],
+        moves: [],
+        warnings: [],
+        isEmpty: false,
+      },
+    })
+
+    await runInDeepnoteCloud(path, { cloud: true, token: 't', url: API_URL, push: true, dryRun: true, output: 'json' })
+
+    const logged = (console.log as unknown as ReturnType<typeof vi.fn>).mock.calls.at(-1)?.[0] as string
+    expect(JSON.parse(logged)).toMatchObject({
+      previewed: true,
+      plan: { changes: [{ action: 'update', blockId: 'b1' }], isEmpty: false },
+    })
+    expect(vi.mocked(global.fetch)).not.toHaveBeenCalled()
+    expect(process.exitCode).toBe(ExitCode.Success)
+  })
+
+  it('does not run when the push confirmation is declined', async () => {
+    const file = makeFile([{ id: 'nb-single', name: 'Main' }])
+    installFetch({ terminalStatus: 'success' })
+    const path = await writeFixture('single.deepnote', file)
+    pushMock.pushLocalNotebook.mockResolvedValue({ applied: false, declined: true, previewed: false })
+
+    await runInDeepnoteCloud(path, { cloud: true, token: 't', url: API_URL, push: true })
+
+    expect(vi.mocked(global.fetch)).not.toHaveBeenCalled()
+    expect(process.exitCode).toBe(ExitCode.Success)
+  })
+
+  it('runs the recreated cloud id when --block named a block the push rebuilt', async () => {
+    const file = makeFile([{ id: 'nb-single', name: 'Main' }])
+    const fetch = installFetch({ terminalStatus: 'success', snapshotContent: serializeDeepnoteFile(file) })
+    const path = await writeFixture('single.deepnote', file)
+    pushMock.pushLocalNotebook.mockResolvedValue({
+      applied: true,
+      declined: false,
+      previewed: false,
+      result: { idRemap: new Map([['local-b1', 'cloud-b9']]) },
+    })
+
+    await runInDeepnoteCloud(path, {
+      cloud: true,
+      token: 't',
+      url: API_URL,
+      push: true,
+      yes: true,
+      block: 'local-b1',
+      output: 'json',
+    })
+
+    expect(fetch.postBodies[0].blockIds).toEqual(['cloud-b9'])
+  }, 10_000)
+
+  it('fails with a usage error when --push has no local file to send', async () => {
+    // Only --notebook-id, and the cwd holds no .deepnote to fall back to.
+    const empty = join(tmpDir, 'empty')
+    await fs.mkdir(empty)
+
+    await withCurrentDirectory(empty, async () => {
+      await expect(
+        runInDeepnoteCloud(undefined, { cloud: true, token: 't', url: API_URL, push: true, notebookId: 'nb' })
+      ).rejects.toThrow(/\.deepnote/)
+    })
+    expect(pushMock.pushLocalNotebook).not.toHaveBeenCalled()
   })
 })
 

--- a/packages/cli/src/utils/run-in-cloud.ts
+++ b/packages/cli/src/utils/run-in-cloud.ts
@@ -22,6 +22,7 @@ import {
 } from '@deepnote/cloud'
 import { getSnapshotDir, getSnapshotPath, resolveSnapshotNotebookId, splitDeepnoteFile } from '@deepnote/convert'
 import { DEFAULT_API_URL, DEFAULT_ENV_FILE } from '@deepnote/database-integrations'
+import { mapBlockIds } from '@deepnote/local-runner'
 import dotenv from 'dotenv'
 import ora from 'ora'
 import type { RunOptions } from '../commands/run'
@@ -29,8 +30,10 @@ import { DEEPNOTE_TOKEN_ENV } from '../constants'
 import { ExitCode } from '../exit-codes'
 import { debug, getChalk, getOutputConfig, log, outputJson, outputToon } from '../output'
 import { MissingTokenError } from './auth'
+import { CloudRunUsageError } from './cloud-run-errors'
 import { resolvePathToDeepnoteFile } from './file-resolver'
 import { parseInputs } from './parse-inputs'
+import { pushLocalNotebook } from './push-to-cloud'
 
 /**
  * Options consumed by the cloud run path — the `run` command's options, since `--cloud` is a flag
@@ -58,18 +61,13 @@ export interface CloudRunResult {
   error?: string
 }
 
-/**
- * User error specific to the cloud run path (bad flag combination, ambiguous notebook, etc.).
- * `createRunAction` maps this to {@link ExitCode.InvalidUsage} (2).
- */
-export class CloudRunUsageError extends Error {
-  constructor(message: string) {
-    super(message)
-    this.name = 'CloudRunUsageError'
-  }
-}
+export { CloudRunUsageError } from './cloud-run-errors'
 
-/** Local-only flags that make no sense against a cloud run; each rejected with a usage error. */
+/**
+ * Local-only flags that make no sense against a cloud run; each rejected with a usage error.
+ * `--dry-run` is not here: with `--push` it previews the push plan, and without `--push` it is
+ * rejected by an explicit guard in {@link runInDeepnoteCloud} with a message that says so.
+ */
 const INCOMPATIBLE_FLAGS: ReadonlyArray<readonly [keyof RunCloudOptions, string]> = [
   ['python', '--python'],
   ['cwd', '--cwd'],
@@ -77,7 +75,6 @@ const INCOMPATIBLE_FLAGS: ReadonlyArray<readonly [keyof RunCloudOptions, string]
   ['profile', '--profile'],
   ['open', '--open'],
   ['prompt', '--prompt'],
-  ['dryRun', '--dry-run'],
   ['listInputs', '--list-inputs'],
   ['context', '--context'],
 ]
@@ -98,6 +95,7 @@ const CLOUD_ONLY_FLAGS: ReadonlyArray<readonly [keyof RunCloudOptions, string]> 
   ['storageMode', '--storage-mode'],
   ['timeout', '--timeout'],
   ['push', '--push'],
+  ['yes', '--yes'],
 ]
 
 /**
@@ -308,15 +306,15 @@ async function writeCloudSnapshot(args: WriteSnapshotArgs): Promise<WrittenSnaps
  * notebook, network errors before we have a runId) are thrown for `createRunAction` to render.
  */
 export async function runInDeepnoteCloud(path: string | undefined, options: RunCloudOptions): Promise<void> {
-  if (options.push) {
+  assertNoIncompatibleFlags(options)
+  if (options.dryRun && !options.push) {
     throw new CloudRunUsageError(
-      'Pushing a local notebook to Deepnote is not yet implemented.\n' +
-        'Run a notebook that already exists in Deepnote with --notebook-id <uuid> ' +
-        '(or a .deepnote file whose notebook already exists in your workspace).'
+      '--dry-run is local-only with --cloud unless combined with --push, where it previews the push plan.'
     )
   }
-
-  assertNoIncompatibleFlags(options)
+  if (options.yes && !options.push) {
+    throw new CloudRunUsageError('--yes confirms a --push; pass --push too, or drop --yes.')
+  }
   if (options.block && options.storageMode) {
     throw new CloudRunUsageError(
       '--storage-mode cannot be combined with --block: the API runs selected blocks in live mode, ' +
@@ -326,11 +324,12 @@ export async function runInDeepnoteCloud(path: string | undefined, options: RunC
   }
 
   // Resolve a local .deepnote file when we need one to derive the notebook id (no --notebook-id),
-  // or when a path was explicitly given (used for snapshot naming). `resolvePathToDeepnoteFile`
-  // rejects non-.deepnote files and directories without a .deepnote for us.
+  // when a path was explicitly given (used for snapshot naming), or when --push needs blocks to
+  // send. `resolvePathToDeepnoteFile` rejects non-.deepnote files and directories without a
+  // .deepnote for us.
   let sourcePath: string | undefined
   let localFile: DeepnoteFile | undefined
-  const needFile = path !== undefined || !options.notebookId
+  const needFile = path !== undefined || !options.notebookId || options.push === true
   if (needFile) {
     const resolved = await resolvePathToDeepnoteFile(path)
     sourcePath = resolved.absolutePath
@@ -349,8 +348,60 @@ export async function runInDeepnoteCloud(path: string | undefined, options: RunC
   const baseUrl = options.url ?? DEFAULT_API_URL
   const notebookId = resolveTargetNotebookId(options, localFile)
   const inputs = parseCloudInputs(options, localFile, notebookId)
-  const blockIds = options.block ? [options.block] : undefined
   const detachedRunStorageMode = options.storageMode === 'read-write' ? 'read_write' : options.storageMode
+  const isMachineOutput = options.output !== undefined
+
+  // Push before running, so the run executes what is on disk. The push owns its own output (plan,
+  // confirmation, progress); a preview or a declined confirmation ends the command without a run.
+  let blockIds = options.block ? [options.block] : undefined
+  if (options.push) {
+    if (!localFile) {
+      throw new CloudRunUsageError(
+        '--push needs the local .deepnote file whose blocks should be sent. Pass the file ' +
+          '(e.g. `deepnote run my-project.deepnote --cloud --push`).'
+      )
+    }
+    // The file's notebook to push: the run target itself when the file contains it, otherwise
+    // resolved from the file alone (--notebook-id may name a remote notebook the file ids do not
+    // match; the file still says which local notebook holds the blocks).
+    const localNotebookId = localFile.project.notebooks.some(notebook => notebook.id === notebookId)
+      ? notebookId
+      : resolveTargetNotebookId({ ...options, notebookId: undefined }, localFile)
+
+    const outcome = await pushLocalNotebook({
+      file: localFile,
+      localNotebookId,
+      notebookId,
+      baseUrl,
+      token,
+      yes: options.yes,
+      dryRun: options.dryRun,
+      machineOutput: isMachineOutput,
+    })
+    if (outcome.previewed || outcome.declined) {
+      if (outcome.previewed && isMachineOutput && outcome.plan) {
+        const preview = {
+          previewed: true,
+          plan: {
+            changes: outcome.plan.changes,
+            moves: outcome.plan.moves,
+            warnings: outcome.plan.warnings,
+            isEmpty: outcome.plan.isEmpty,
+          },
+        }
+        if (options.output === 'json') {
+          outputJson(preview)
+        } else {
+          outputToon(preview)
+        }
+      }
+      return
+    }
+    if (blockIds && outcome.result) {
+      // A recreated block has a new cloud id; run the block the user actually named.
+      blockIds = mapBlockIds(blockIds, outcome.result.idRemap, '--push')
+    }
+  }
 
   const body: TriggerRunBody = {
     notebookId,
@@ -358,8 +409,6 @@ export async function runInDeepnoteCloud(path: string | undefined, options: RunC
     ...(detachedRunStorageMode ? { detachedRunStorageMode } : {}),
     ...(blockIds ? { blockIds } : {}),
   }
-
-  const isMachineOutput = options.output !== undefined
   const useSpinner = !isMachineOutput && !getOutputConfig().quiet && process.stderr.isTTY
   const spinner = useSpinner ? ora('Starting Deepnote run…').start() : null
 

--- a/skills/deepnote/references/cli-run.md
+++ b/skills/deepnote/references/cli-run.md
@@ -86,11 +86,12 @@ The notebook to run is resolved in this order:
 2. A local `.deepnote` file with `--notebook "<name>"` — the named notebook's id.
 3. A single-notebook `.deepnote` file — its notebook id.
 
-The notebook must already exist in Deepnote; `--cloud` does not upload local content, and
-non-`.deepnote` inputs are rejected. Snapshots are written as a timestamped file plus a `latest`
-copy, unless `--out <path>` is given (single file). `--input`, `--block`, `--notebook`, `--url`,
-`--token`, and `--storage-mode` are honored; local-only flags (`--python`, `--cwd`, `--top`,
-`--profile`, `--open`, `--prompt`, `--dry-run`, `--list-inputs`, `--context`) are not.
+The notebook must already exist in Deepnote; `--cloud` does not create it, and non-`.deepnote`
+inputs are rejected. Snapshots are written as a timestamped file plus a `latest` copy, unless
+`--out <path>` is given (single file). `--input`, `--block`, `--notebook`, `--url`, `--token`,
+`--storage-mode`, `--push`, and `--yes` are honored; local-only flags (`--python`, `--cwd`,
+`--top`, `--profile`, `--open`, `--prompt`, `--list-inputs`, `--context`) are not. `--dry-run` is
+rejected with `--cloud` unless `--push` is set, where it previews the push plan instead.
 
 Full-notebook cloud runs are detached, so Deepnote executes a copy without changing outputs in the
 live editor. This does not isolate anything the notebook accesses: project files remain shared and
@@ -98,6 +99,15 @@ writable by default, and databases, integrations, external APIs, and other syste
 Use `--storage-mode readonly` to make persistent project storage read-only for that detached run;
 reads and temporary files still work. Block-scoped cloud runs are different: the API runs them in
 live mode, they update live-editor outputs, and they cannot be combined with `--storage-mode`.
+
+`--push` sends the local file's blocks to the Deepnote notebook before the run, so the cloud
+executes what is on disk rather than what was last saved in Deepnote. The sync is destructive — a
+cloud block the file does not have is deleted, and a block whose type or metadata changed is
+recreated under a new id (a `--block` selection is remapped to the new id automatically). The CLI
+prints the plan and asks for confirmation: `--yes` skips the question and is required when output
+is piped or machine-readable; a declined confirmation exits `0` without running. `--push --dry-run`
+prints the plan and exits without sending or running anything; with `-o json`/`-o toon` it emits
+`{ previewed, plan: { changes, moves, warnings, isEmpty } }` instead of a run result.
 
 `--input` follows the same rules as a local run: each value is typed by the input block it names,
 and unknown names or invalid values are rejected before the run is triggered. Typing a value
@@ -129,6 +139,9 @@ DEEPNOTE_TOKEN=... deepnote run my-project.deepnote --cloud --input name="Alice"
 
 # Run the whole notebook without allowing writes to persistent project storage
 DEEPNOTE_TOKEN=... deepnote run my-project.deepnote --cloud --storage-mode readonly
+
+# Push local edits to the notebook first, then run what is on disk (asks before changing it)
+DEEPNOTE_TOKEN=... deepnote run my-project.deepnote --cloud --push
 
 # Machine-readable result
 DEEPNOTE_TOKEN=... deepnote run my-project.deepnote --cloud -o json


### PR DESCRIPTION
## Summary

Wires `--push` into `deepnote run --cloud`, completing the feature #432 builds the machinery for.

**Stacked on #432** (`feat/cli-push-blocks`) — merge that first, then retarget this to `main`.

### What changes

- The `'Pushing a local notebook to Deepnote is not yet implemented'` guard in `run-in-cloud.ts` is replaced with the real flow: `pushLocalNotebook` syncs the local file's blocks to the Deepnote notebook **before** the run is triggered, so the run executes what is on disk.
- `--push` is un-hidden and documented; new `--yes` flag confirms the push non-interactively (required when output is piped or machine-readable).
- `--push --dry-run` previews the push plan and exits without sending or running anything (`dryRun` is dropped from `INCOMPATIBLE_FLAGS`, per #432's known-limitations note; without `--push` it is still rejected with a clear message). Under `-o json`/`-o toon` the preview emits `{ previewed, plan: { changes, moves, warnings, isEmpty } }`.
- A declined confirmation stops before the run (exit 0).
- A `--block` selection is remapped through `SyncResult.idRemap` when the push recreated that block under a new id — the API runs block selections by id, so running the stale id would target a deleted block.
- When `--notebook-id` names a remote notebook that is not in the file, the file's own notebook (via `--notebook` or single/main resolution) is pushed into it; `--push` with no resolvable local file fails as a usage error.
- `CloudRunUsageError` moves to `utils/cloud-run-errors.ts` (re-exported from `run-in-cloud` for compatibility) so `push-to-cloud` no longer imports it back from `run-in-cloud`, which would have become a runtime import cycle once `run-in-cloud` started importing `pushLocalNotebook`.
- `PushOutcome` gains the computed `plan`, so the caller can render machine-readable previews.
- Shell completions (bash/zsh/fish) and docs (`packages/cli/README.md`, `skills/deepnote/references/cli-run.md`) updated.

### Verified against the public API (`api.deepnote.com/v2/openapi.json`)

- `POST /runs` accepts `notebookId`, `detachedRunStorageMode` (`read_write`/`readonly`, detached only), `blockIds` (live mode only), `inputs` — unchanged by this PR; the push happens before the trigger, and the existing `--block`/`--storage-mode` guard still applies.
- `POST /blocks` (`CreateBlockBody`), `PATCH /blocks/{id}` (`content`/`integrationId` only), and `POST /notebooks/{id}/reorder-blocks` match the `@deepnote/cloud` client #432 adds — recreation under a new id is real API behavior, which is why the `--block` remap exists.

## Test plan

- [x] 8 new/updated tests in `run-in-cloud.test.ts` (push-before-run ordering, remote-only `--notebook-id`, dry-run preview, JSON preview, declined confirmation, `--block` remap, missing-file usage error, `--yes`/`--dry-run` guards)
- [x] `push-to-cloud.test.ts` covers the new `plan` pass-through
- [x] `cli.test.ts` asserts `--push` is visible, `--yes` exists, and completions for all three shells
- [x] Full repo suite: 3,005 tests pass; typecheck, biome/prettier, and cspell clean
- [ ] Human review

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Cloud runs now support `--push` to synchronize local notebook changes before execution.
  * Added `--yes` to skip synchronization confirmation prompts in scripts and CI.
  * Added dry-run previews, including machine-readable output and destructive-change details.
  * Selected blocks are remapped automatically when synchronization recreates them.

* **Documentation**
  * Updated CLI help, shell completions, and usage guides with the new options and workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->