### PR TITLE
fix(cloud,cli): stale retry error no longer reclassifies a confirmed no-snapshot as unavailable

### DIFF
--- a/packages/cli/src/utils/run-in-cloud.test.ts
+++ b/packages/cli/src/utils/run-in-cloud.test.ts
@@ -654,6 +654,39 @@ describe('runInDeepnoteCloud — output and exit codes', () => {
     expect(process.exitCode).toBe(ExitCode.Error)
   })
 
+  it('reports not_produced when a later re-fetch confirms no snapshot after a transient failure', async () => {
+    // GET#1 is the poll (terminal, no snapshot); the first settle re-fetch (GET#2) fails
+    // transiently; the later re-fetches succeed and freshly confirm no snapshot was attached.
+    // The stale early error must not reclassify that confirmed no-snapshot as unavailable.
+    let getCount = 0
+    vi.spyOn(global, 'fetch').mockImplementation(async (_url, init) => {
+      const method = (init?.method as string) ?? 'GET'
+      if (method === 'POST') {
+        return response({ run: { id: 'run-x', status: 'pending' } })
+      }
+      getCount++
+      if (getCount === 2) {
+        throw new Error('503 Service Unavailable')
+      }
+      return response({ run: { id: 'run-x', status: 'success' } })
+    })
+
+    await runInDeepnoteCloud(undefined, {
+      cloud: true,
+      notebookId: 'remote-nb',
+      token: 't',
+      url: API_URL,
+      output: 'json',
+    })
+
+    const logged = (console.log as unknown as ReturnType<typeof vi.fn>).mock.calls.at(-1)?.[0] as string
+    const result = JSON.parse(logged)
+    expect(result).toMatchObject({ success: false, status: 'success', artifactStatus: 'not_produced' })
+    expect(result.artifactError).toMatch(/produced no snapshot/i)
+    expect(result.artifactError).not.toMatch(/503/)
+    expect(process.exitCode).toBe(ExitCode.Error)
+  }, 10_000)
+
   it('treats all-failed snapshot re-fetches as unavailable, not not_produced', async () => {
     let getCount = 0
     vi.spyOn(global, 'fetch').mockImplementation(async (_url, init) => {

--- a/packages/cli/src/utils/run-in-cloud.ts
+++ b/packages/cli/src/utils/run-in-cloud.ts
@@ -396,10 +396,8 @@ export async function runInDeepnoteCloud(path: string | undefined, options: RunC
   let artifactStatus: CloudArtifactStatus = 'not_produced'
   let artifactError: string | undefined
   try {
-    let lastRetryError: unknown
     const settled = await waitForRunSnapshot(baseUrl, token, finalRun, {
       onRetryError: error => {
-        lastRetryError = error
         debug(
           `Re-fetching run ${finalRun.runId} for its snapshot failed: ${error instanceof Error ? error.message : error}`
         )
@@ -425,8 +423,11 @@ export async function runInDeepnoteCloud(path: string | undefined, options: RunC
       snapshotPath = written.snapshotPath
       timestampedSnapshotPath = written.timestampedSnapshotPath
       artifactStatus = synthesized ? 'synthesized' : 'saved'
-    } else if (lastRetryError !== undefined) {
-      throw lastRetryError
+    } else if (settled.retryError !== undefined) {
+      // The last status re-fetch failed, so "no snapshot" rests on stale data — an outage must not
+      // read as a valid empty run. A failure a *successful* re-fetch later superseded is not here:
+      // that null is a fresh, confirmed not_produced.
+      throw settled.retryError
     } else {
       debug(`Run ${finalRun.runId} returned no snapshot content.`)
     }

--- a/packages/cloud/src/cloud-runs.test.ts
+++ b/packages/cloud/src/cloud-runs.test.ts
@@ -377,6 +377,31 @@ describe('waitForRunSnapshot', () => {
     expect(vi.mocked(global.fetch)).toHaveBeenCalledTimes(2)
   })
 
+  it('clears the retry error once a later re-fetch succeeds, so the null is a confirmed no-snapshot', async () => {
+    let gets = 0
+    vi.spyOn(global, 'fetch').mockImplementation(async () => {
+      gets++
+      if (gets === 1) {
+        throw new Error('503 transient')
+      }
+      return response({ run: { id: 'r', status: 'success' } })
+    })
+
+    const settled = await waitForRunSnapshot(BASE_URL, TOKEN, run(), { attempts: 2, sleep: async () => {} })
+
+    expect(settled.content).toBeNull()
+    expect(settled.retryError).toBeUndefined()
+  })
+
+  it('reports the retry error when the final re-fetch failed, since the null rests on stale data', async () => {
+    vi.spyOn(global, 'fetch').mockRejectedValue(new Error('503 down'))
+
+    const settled = await waitForRunSnapshot(BASE_URL, TOKEN, run(), { attempts: 2, sleep: async () => {} })
+
+    expect(settled.content).toBeNull()
+    expect((settled.retryError as Error).message).toBe('503 down')
+  })
+
   it('throws a persistent snapshot download failure instead of calling it no output', async () => {
     vi.spyOn(global, 'fetch').mockImplementation(async url => {
       if (String(url).startsWith('https://storage.example.com/')) {

--- a/packages/cloud/src/cloud-runs.ts
+++ b/packages/cloud/src/cloud-runs.ts
@@ -493,6 +493,12 @@ export interface SettledRunSnapshot {
    * read/download failures throw instead.
    */
   content: string | null
+  /**
+   * The status re-fetch failure that left `run` stale — set only when the *last* re-fetch failed.
+   * A failure followed by a successful re-fetch clears it: the final observation is fresh, so a
+   * null `content` is a confirmed "no snapshot", not a side effect of the outage.
+   */
+  retryError?: unknown
 }
 
 async function abortableSleep(ms: number, signal?: AbortSignal): Promise<void> {
@@ -552,6 +558,7 @@ export async function waitForRunSnapshot(
   const intervalMs = options.intervalMs ?? DEFAULT_SNAPSHOT_SETTLE_INTERVAL_MS
   let current = run
   let lastReadError: unknown
+  let retryError: unknown
 
   for (let attempt = 0; ; attempt++) {
     if (current.snapshot) {
@@ -576,7 +583,7 @@ export async function waitForRunSnapshot(
       if (lastReadError !== undefined) {
         throw lastReadError
       }
-      return { run: current, content: null }
+      return { run: current, content: null, retryError }
     }
 
     if (attempt > 0) {
@@ -592,10 +599,12 @@ export async function waitForRunSnapshot(
         requestTimeoutMs: options.requestTimeoutMs,
         signal: options.signal,
       })
+      retryError = undefined
     } catch (error) {
       if (options.signal?.aborted) {
         throw options.signal.reason
       }
+      retryError = error
       options.onRetryError?.(error)
     }
   }


### PR DESCRIPTION
## Summary

Fixes a misclassification voyti found post-merge on #448 ([comment](https://github.com/deepnote/deepnote/pull/448#discussion_r3815879676)): during snapshot settling, the CLI accumulated `onRetryError` failures and threw the last one whenever content ended up null — even when a **later status re-fetch succeeded** and freshly confirmed that no snapshot was attached. A single early transient 503 therefore turned a confirmed `artifactStatus: 'not_produced'` into `'unavailable'` with an unrelated network message.

### Fix

The success signal only exists inside `waitForRunSnapshot`, so the tracking moves there:

- `waitForRunSnapshot` clears its tracked re-fetch failure on every successful status re-fetch and reports it as `SettledRunSnapshot.retryError` — set **only when the last re-fetch failed**, i.e. when the final "no snapshot" observation rests on stale data.
- The CLI throws `settled.retryError` instead of its own accumulated state; `onRetryError` remains a pure debug-logging hook.

Behavior matrix (null content):

| Settle re-fetches | Before | After |
|---|---|---|
| all succeed | `not_produced` | `not_produced` |
| early failure, later success | `unavailable` + stale network error | `not_produced` |
| all fail (or last fails) | `unavailable` | `unavailable` |

## Test plan

- [x] New cloud tests: `retryError` cleared by a later successful re-fetch; reported when the final re-fetch failed
- [x] New CLI regression test: transient 503 then successful confirmation → `not_produced`, `artifactError` without the network message (fails on `main`)
- [x] Existing all-failed-re-fetches → `unavailable` test still passes
- [x] Full repo suite (2,919 tests), typecheck, biome/prettier, cspell green

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of temporary snapshot retrieval failures.
  * Successful follow-up checks now clear stale errors and correctly recognize when no snapshot was produced.
  * Final retrieval failures are reported accurately while cancellation errors continue to propagate.

* **Tests**
  * Added coverage for transient and persistent snapshot retrieval failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->