### PR TITLE
docs: correct support and product reference documentation

### DIFF
--- a/docs/acceptable-use-policy.md
+++ b/docs/acceptable-use-policy.md
@@ -8,7 +8,7 @@ Effective date: February 9, 2023
 
 Deepnote is a collaborative data notebook trusted by the world’s best data teams. We’re on a mission to radically improve how teams think, explore and decide together. In order to do this, we must ensure that our product and services continue to operate smoothly, which includes protection against misuse or abuse by our users.
 
-We've developed this Acceptable Use Policy to clarify what we mean when we say "misuse" or "abuse" and to assist us in identifying such offenses and responding appropriately. In accordance with this policy, we reserve the right to suspend or terminate any accounts that violate these guidelines. Even if actions are not explicitly included in the policy, Deepnote remains the right (in its sole discretion) to suspend or terminate any accounts that have violated this Acceptable Use Policy with or without notice.
+We've developed this Acceptable Use Policy to clarify what we mean when we say "misuse" or "abuse" and to assist us in identifying such offenses and responding appropriately. In accordance with this policy, we reserve the right to suspend or terminate any accounts that violate these guidelines. Even if actions are not explicitly included in the policy, Deepnote retains the right (in its sole discretion) to suspend or terminate any accounts that have violated this Acceptable Use Policy, with or without notice.
 
 ## Prohibited materials
 


### PR DESCRIPTION
## What this changes

Corrects the Acceptable Use Policy sentence that says Deepnote “remains the right” and adds the missing comma before the final qualifier.

## Why

The documentation audit executed https://deepnote.com/docs/support, https://deepnote.com/docs/product-portal, and https://deepnote.com/docs/acceptable-use-policy against the real product and found one reproducible documentation wording difference.

### Finding 1: misleading

> Even if actions are not explicitly included in the policy, Deepnote remains the right (in its sole discretion) to suspend or terminate any accounts that have violated this Acceptable Use Policy with or without notice.

- **Correction:** Change “remains the right” to “retains the right” and add the comma before “with or without notice.”

## How this was verified

Opened automatically by the `doc-verify` skill from the approved GitHub account. Reviewed by a human.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified account-enforcement policy language, including that suspension or termination may occur with or without notice.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->