### PR TITLE
feat(pipelines): define a pipeline in a .deepnote file

### DIFF
--- a/examples/pipelines/sales-pipeline.deepnote
+++ b/examples/pipelines/sales-pipeline.deepnote
@@ -1,0 +1,204 @@
+# A pipeline defined as a file, not as application code.
+#
+# The notebook marked `isPipeline: true` is the pipeline. Each of its notebook-function blocks is one
+# step: the notebook it runs, the inputs to run it with, and the values it publishes. This is the
+# encoding deepnote.com stores for a notebook-function block — an input is `{ variable_name }` (a
+# pipeline variable) or `{ custom_value }` (a literal) — so the same file means the same thing in the
+# product and here.
+#
+# Dependencies are not declared twice: a step that reads `{ variable_name: portfolio }` depends on
+# whichever step exports `portfolio`, so the three regional analyses below are independent by
+# construction and run concurrently.
+#
+# The pipeline notebook is read as a manifest rather than executed. Running it through Deepnote's
+# block engine would serialize these steps into one run with one status; interpreting it keeps the
+# concurrency and reports each step separately.
+#
+# Each notebook ends by printing one JSON object; the export mappings read fields from it. Deepnote
+# input blocks take strings, booleans and lists of strings, so a structure that has to cross into
+# another notebook is exported as a JSON string (the `*_json` fields below).
+#
+# Replace every function_notebook_id with the id of the notebook in your Deepnote project.
+metadata:
+  createdAt: '2026-08-27T00:00:00.000Z'
+project:
+  id: local-runner-sales-pipeline
+  name: Pipelines demo - sales review
+  notebooks:
+    - id: local-runner-sales-pipeline-notebook
+      name: Sales review pipeline
+      isPipeline: true
+      blocks:
+        - blockGroup: analyze-north-america-group
+          id: analyze-north-america
+          sortingKey: a0
+          type: notebook-function
+          metadata:
+            name: North America analysis
+            function_notebook_id: REPLACE_WITH_REGIONAL_NOTEBOOK_ID
+            function_notebook_inputs:
+              region:
+                custom_value: North America
+              trailing_months:
+                custom_value: '6'
+              monthly_target_k:
+                custom_value: '420'
+            function_notebook_export_mappings:
+              summary_json:
+                enabled: true
+                variable_name: northAmerica
+        - blockGroup: analyze-europe-group
+          id: analyze-europe
+          sortingKey: a1
+          type: notebook-function
+          metadata:
+            name: Europe analysis
+            function_notebook_id: REPLACE_WITH_REGIONAL_NOTEBOOK_ID
+            function_notebook_inputs:
+              region:
+                custom_value: Europe
+              trailing_months:
+                custom_value: '6'
+              monthly_target_k:
+                custom_value: '340'
+            function_notebook_export_mappings:
+              summary_json:
+                enabled: true
+                variable_name: europe
+        - blockGroup: analyze-asia-pacific-group
+          id: analyze-asia-pacific
+          sortingKey: a2
+          type: notebook-function
+          metadata:
+            name: Asia Pacific analysis
+            function_notebook_id: REPLACE_WITH_REGIONAL_NOTEBOOK_ID
+            function_notebook_inputs:
+              region:
+                custom_value: Asia Pacific
+              trailing_months:
+                custom_value: '6'
+              monthly_target_k:
+                custom_value: '240'
+            function_notebook_export_mappings:
+              summary_json:
+                enabled: true
+                variable_name: asiaPacific
+        # Depends on all three regions, so it starts only once they finish. One input per variable:
+        # the notebook receives the three summaries separately and combines them itself. Besides the
+        # portfolio it publishes the list of regions that failed the quality gate.
+        - blockGroup: aggregate-group
+          id: aggregate
+          sortingKey: b0
+          type: notebook-function
+          metadata:
+            name: Validated portfolio
+            function_notebook_id: REPLACE_WITH_AGGREGATE_NOTEBOOK_ID
+            function_notebook_inputs:
+              north_america_json:
+                variable_name: northAmerica
+              europe_json:
+                variable_name: europe
+              asia_pacific_json:
+                variable_name: asiaPacific
+              quality_threshold:
+                custom_value: '0.95'
+            function_notebook_export_mappings:
+              portfolio_json:
+                enabled: true
+                variable_name: portfolio
+              below_threshold:
+                enabled: true
+                variable_name: belowThreshold
+        # One run per region that failed the quality gate — and none at all when they all passed.
+        # for_each sizes the fan-out from the data rather than the file; `region` is bound to each
+        # element and can be passed straight in as an input. Recovered summaries collect into
+        # `recovered`, in element order: an empty list, not a missing value, when nothing needed it.
+        - blockGroup: recover-group
+          id: recover
+          sortingKey: c0
+          type: notebook-function
+          metadata:
+            name: Recovery
+            function_notebook_id: REPLACE_WITH_REGIONAL_NOTEBOOK_ID
+            function_notebook_for_each: belowThreshold
+            function_notebook_for_each_as: region
+            function_notebook_inputs:
+              region:
+                variable_name: region
+              trailing_months:
+                custom_value: '6'
+              backfill_missing:
+                custom_value: 'true'
+            function_notebook_export_mappings:
+              summary_json:
+                enabled: true
+                variable_name: recovered
+        # Both reviews depend only on the portfolio and the recovery, so they run at the same time as
+        # each other.
+        - blockGroup: decision-gpt-group
+          id: decision-gpt
+          sortingKey: d0
+          type: notebook-function
+          metadata:
+            name: OpenAI GPT-5.5 review
+            function_notebook_id: REPLACE_WITH_GPT_NOTEBOOK_ID
+            function_notebook_inputs:
+              portfolio_json:
+                variable_name: portfolio
+              recovered_json:
+                variable_name: recovered
+            function_notebook_export_mappings:
+              decision:
+                enabled: true
+                variable_name: gptDecision
+              review_json:
+                enabled: true
+                variable_name: gptReview
+        # allow_failure: a failed review is reported and the pipeline carries on. The step then
+        # publishes nothing, so `claudeDecision` reads as absent in the gate below and the arbiter's
+        # fallback stands in for the review.
+        - blockGroup: decision-claude-group
+          id: decision-claude
+          sortingKey: d1
+          type: notebook-function
+          metadata:
+            name: Anthropic Claude Sonnet 5 review
+            function_notebook_id: REPLACE_WITH_CLAUDE_NOTEBOOK_ID
+            function_notebook_allow_failure: true
+            function_notebook_inputs:
+              portfolio_json:
+                variable_name: portfolio
+              recovered_json:
+                variable_name: recovered
+            function_notebook_export_mappings:
+              decision:
+                enabled: true
+                variable_name: claudeDecision
+              review_json:
+                enabled: true
+                variable_name: claudeReview
+        # A gate in the file, not in application code: arbitration is only worth a notebook run when
+        # the two providers disagree (or one of them failed). run_if reads the decisions, so this step
+        # depends on both reviews; when it is false the step is skipped and reported as skipped.
+        - blockGroup: final-arbiter-group
+          id: final-arbiter
+          sortingKey: e0
+          type: notebook-function
+          metadata:
+            name: Final decision
+            function_notebook_id: REPLACE_WITH_ARBITER_NOTEBOOK_ID
+            function_notebook_run_if: gptDecision != claudeDecision
+            function_notebook_inputs:
+              portfolio_json:
+                variable_name: portfolio
+              gpt_review_json:
+                variable_name: gptReview
+              claude_review_json:
+                variable_name: claudeReview
+                fallback:
+                  custom_value: ''
+            function_notebook_export_mappings:
+              decision:
+                enabled: true
+                variable_name: finalDecision
+version: '1.0.0'

--- a/packages/blocks/src/blocks/notebook-function-blocks.test.ts
+++ b/packages/blocks/src/blocks/notebook-function-blocks.test.ts
@@ -233,8 +233,8 @@ describe('createPythonCodeForNotebookFunctionBlock', () => {
       metadata: {
         function_notebook_id: 'notebook-ghi',
         function_notebook_inputs: {
-          param1: 'value1',
-          param2: 42,
+          param1: { custom_value: 'value1' },
+          param2: { variable_name: 'upstream_value' },
         },
         function_notebook_export_mappings: {
           output: {
@@ -249,11 +249,11 @@ describe('createPythonCodeForNotebookFunctionBlock', () => {
 
     expect(result).toEqual(dedent`
       # Notebook Function: notebook-ghi
-      # Inputs: {"param1":"value1","param2":42}
+      # Inputs: {"param1":{"custom_value":"value1"},"param2":{"variable_name":"upstream_value"}}
       # Exports: output -> result
       result = _dntk.run_notebook_function(
           'notebook-ghi',
-          inputs={"param1":"value1","param2":42},
+          inputs={"param1":{"custom_value":"value1"},"param2":{"variable_name":"upstream_value"}},
           export_mappings={"output":"result"}
       )
     `)

--- a/packages/blocks/src/deepnote-file/deepnote-file-schema.ts
+++ b/packages/blocks/src/deepnote-file/deepnote-file-schema.ts
@@ -188,6 +188,35 @@ const sqlBlockSchema = z.object({
     .default({}),
 })
 
+/**
+ * One input passed to the notebook a `notebook-function` block runs.
+ *
+ * Exactly the shape deepnote.com stores: either a reference to a variable by name, or a literal.
+ * `fallback` is read when the referenced variable is unavailable because the step that would have
+ * exported it was skipped; it is itself an input, so fallbacks can chain.
+ */
+const notebookFunctionInputSchema: z.ZodType<NotebookFunctionInput> = z.lazy(() =>
+  z.object({
+    variable_name: z.string().nullable().optional(),
+    custom_value: z.unknown().optional(),
+    fallback: notebookFunctionInputSchema.optional(),
+  })
+)
+
+export interface NotebookFunctionInput {
+  /** A pipeline variable: another step's export, or the current `for_each_as` element. */
+  variable_name?: string | null
+  /** A literal value, used when `variable_name` is not set. */
+  custom_value?: unknown
+  /** Used when `variable_name` refers to a variable whose producer was skipped. */
+  fallback?: NotebookFunctionInput
+}
+
+const notebookFunctionExportMappingSchema = z.object({
+  enabled: z.boolean(),
+  variable_name: z.string().nullable(),
+})
+
 const notebookFunctionBlockSchema = z.object({
   ...executableBlockFields,
   type: z.literal('notebook-function'),
@@ -195,8 +224,16 @@ const notebookFunctionBlockSchema = z.object({
   metadata: executableBlockMetadataSchema
     .extend({
       function_notebook_id: z.string().nullable(),
-      function_notebook_inputs: z.record(z.any()).optional(),
-      function_notebook_export_mappings: z.record(z.any()).optional(),
+      function_notebook_inputs: z.record(notebookFunctionInputSchema).optional(),
+      function_notebook_export_mappings: z.record(notebookFunctionExportMappingSchema).optional(),
+      /** Pipeline-only: run the step only when this condition holds. */
+      function_notebook_run_if: z.string().optional(),
+      /** Pipeline-only: the pipeline variable holding an array to run this step once per element of. */
+      function_notebook_for_each: z.string().optional(),
+      /** Pipeline-only: the name each `function_notebook_for_each` element is bound to. */
+      function_notebook_for_each_as: z.string().optional(),
+      /** Pipeline-only: return a failed result instead of failing the pipeline. */
+      function_notebook_allow_failure: z.boolean().optional(),
     })
     .default({ function_notebook_id: null }),
 })
@@ -442,6 +479,7 @@ export type AgentBlock = z.infer<typeof agentBlockSchema>
 export type CodeBlock = z.infer<typeof codeBlockSchema>
 export type SqlBlock = z.infer<typeof sqlBlockSchema>
 export type NotebookFunctionBlock = z.infer<typeof notebookFunctionBlockSchema>
+export type NotebookFunctionExportMapping = z.infer<typeof notebookFunctionExportMappingSchema>
 export type VisualizationBlock = z.infer<typeof visualizationBlockSchema>
 export type ButtonBlock = z.infer<typeof buttonBlockSchema>
 export type BigNumberBlock = z.infer<typeof bigNumberBlockSchema>
@@ -571,6 +609,8 @@ export const deepnoteFileSchema = z.object({
         executionMode: z.enum(['block', 'downstream']).optional(),
         id: z.string(),
         isModule: z.boolean().optional(),
+        /** Marks the one notebook whose `notebook-function` blocks define the project's pipeline. */
+        isPipeline: z.boolean().optional(),
         name: z.string(),
         workingDirectory: z.string().optional(),
       })

--- a/packages/blocks/src/deepnote-file/serialize-deepnote-file.test.ts
+++ b/packages/blocks/src/deepnote-file/serialize-deepnote-file.test.ts
@@ -139,6 +139,89 @@ describe('serializeDeepnoteFile', () => {
     })
   })
 
+  describe('pipeline notebooks', () => {
+    const createPipelineFile = (): DeepnoteFile => ({
+      version: '1.0.0',
+      metadata: { createdAt: '2026-01-01T00:00:00.000Z' },
+      project: {
+        id: 'project-1',
+        name: 'Pipeline project',
+        notebooks: [
+          {
+            id: 'pipeline',
+            name: 'Pipeline',
+            isPipeline: true,
+            blocks: [
+              {
+                id: 'load',
+                blockGroup: 'g-load',
+                sortingKey: '000000',
+                type: 'notebook-function',
+                content: '',
+                metadata: {
+                  function_notebook_id: 'nb-load',
+                  function_notebook_inputs: { region: { custom_value: 'Europe' } },
+                  function_notebook_export_mappings: {
+                    regions: { enabled: true, variable_name: 'regions' },
+                    ignored: { enabled: false, variable_name: null },
+                  },
+                },
+              },
+              {
+                id: 'analyze',
+                blockGroup: 'g-analyze',
+                sortingKey: '000001',
+                type: 'notebook-function',
+                content: '',
+                metadata: {
+                  function_notebook_id: 'nb-analyze',
+                  function_notebook_for_each: 'regions',
+                  function_notebook_for_each_as: 'region',
+                  function_notebook_run_if: 'region.qualityScore < 0.95',
+                  function_notebook_allow_failure: true,
+                  function_notebook_inputs: {
+                    region: { variable_name: 'region' },
+                    previous: {
+                      variable_name: 'recovered',
+                      fallback: { variable_name: 'regions', fallback: { custom_value: null } },
+                    },
+                  },
+                },
+              },
+            ],
+          },
+        ],
+      },
+    })
+
+    it('round-trips the pipeline marker and step metadata through YAML', () => {
+      const file = createPipelineFile()
+      const roundtripped = deserializeDeepnoteFile(serializeDeepnoteFile(file))
+
+      expect(roundtripped.project.notebooks[0].isPipeline).toBe(true)
+      expect(roundtripped.project.notebooks[0].blocks).toEqual(file.project.notebooks[0].blocks)
+      // A second pass must be a fixed point, so the serializer is not quietly rewriting anything.
+      expect(serializeDeepnoteFile(roundtripped)).toBe(serializeDeepnoteFile(file))
+    })
+
+    it('rejects an input that is not the variable_name / custom_value shape', () => {
+      const file = createPipelineFile()
+      const yaml = serializeDeepnoteFile(file).replace(
+        'region:\n                custom_value: Europe',
+        'region: Europe'
+      )
+      expect(yaml).not.toBe(serializeDeepnoteFile(file))
+      expect(() => deserializeDeepnoteFile(yaml)).toThrow()
+    })
+
+    it('rejects an export mapping without an enabled flag', () => {
+      const file = createPipelineFile()
+      const yaml = serializeDeepnoteFile(file).replace('enabled: true\n', '')
+      expect(yaml).not.toBe(serializeDeepnoteFile(file))
+      expect(() => deserializeDeepnoteFile(yaml)).toThrow()
+    })
+  })
+
   describe('field ordering', () => {
     it('outputs top-level fields in schema order', () => {
       const file = createFileWithBlocks()

--- a/packages/blocks/src/index.ts
+++ b/packages/blocks/src/index.ts
@@ -22,6 +22,9 @@ export type {
   ExecutionSummary,
   InputBlock,
   McpServerConfig,
+  NotebookFunctionBlock,
+  NotebookFunctionExportMapping,
+  NotebookFunctionInput,
   SnapshotHashInput,
   SqlBlock,
 } from './deepnote-file/deepnote-file-schema'

--- a/packages/local-runner/README.md
+++ b/packages/local-runner/README.md
@@ -183,7 +183,8 @@ The server binds to `127.0.0.1` and provides no WebSocket, watch, or rendering. 
 — or, to _view_ an existing snapshot rather than run one, read it directly (below); that needs no
 server at all.
 
-To run several notebooks as one pipeline — fanning out, gating on results, drawing the graph — see
+To run several notebooks as one pipeline — fanning out, gating on results, drawing the graph, or
+reading the pipeline out of a `.deepnote` file whose notebook is marked `isPipeline: true` — see
 [`@deepnote/pipelines`](../pipelines). That package needs neither this one nor a kernel: every step
 is an HTTP call, so a pipeline also runs in a browser page.
 

--- a/packages/pipelines/README.md
+++ b/packages/pipelines/README.md
@@ -219,7 +219,9 @@ alternative, and it depends on every alternative, since which one wins is a run-
 By default a failed notebook fails the pipeline (`PipelineStepError`). With
 `function_notebook_allow_failure: true` the failed result is returned instead and the run continues;
 the step is listed in `result.failed`, publishes nothing, and dependents fall back or are skipped.
-On a fan-out, exports collect from the elements that succeeded.
+On a fan-out, exports collect from the elements that succeeded. This covers every way a step can
+fail — including a poll timeout or an API error — so one hung run in a fan-out does not discard the
+rest; the result's `status` and `error` say what happened, and a timed-out run's `runId` is on it.
 
 A run that finishes but whose exports cannot be read — no JSON object ends its output, or the object
 lacks an exported key — counts as a failed step too: under `allow_failure` it is listed in `failed`

--- a/packages/pipelines/README.md
+++ b/packages/pipelines/README.md
@@ -67,6 +67,178 @@ callers that want to run steps somewhere else.
 
 See [`examples/pipelines/script`](../../examples/pipelines/script).
 
+## Define a pipeline in a `.deepnote` file
+
+`runPipeline` puts the pipeline in application code. A pipeline can instead live in a file: the
+notebook marked `isPipeline: true`, whose `notebook-function` blocks each name an external notebook,
+the inputs to run it with, and the values it publishes.
+
+The encoding is the one deepnote.com stores for a notebook-function block, so the same file means
+the same thing in the product and here. An input is `{ variable_name }` — a pipeline variable — or
+`{ custom_value }` — a literal. An export is `{ enabled, variable_name }`.
+
+```yaml
+notebooks:
+  - id: pipeline
+    name: Sales review
+    isPipeline: true
+    blocks:
+      - id: analyze-europe
+        type: notebook-function
+        metadata:
+          function_notebook_id: nb-regional
+          function_notebook_inputs:
+            region: { custom_value: Europe }
+            trailing_months: { custom_value: "6" }
+          function_notebook_export_mappings:
+            summary_json: { enabled: true, variable_name: europe }
+
+      - id: aggregate
+        type: notebook-function
+        metadata:
+          function_notebook_id: nb-aggregate
+          function_notebook_inputs:
+            europe_json: { variable_name: europe }
+            north_america_json: { variable_name: northAmerica }
+```
+
+```ts
+import { runPipelineFile, planPipeline } from "@deepnote/pipelines";
+
+const { value, plan, graph, skipped, failed } = await runPipelineFile(file, {
+  token,
+  onEvent,
+});
+```
+
+**Dependencies are never declared twice.** A step reading `{ variable_name: europe }` depends on
+whichever step exports `europe`, so regional steps that read nothing from each other are independent
+_by construction_ and run concurrently. `planPipeline(file)` returns that graph without running
+anything, so a UI can draw the pipeline before it starts.
+
+A variable is referenced by name only — no paths, no templating. Reading a field belongs in a
+`run_if` condition; a step that needs a field of another step's result should have that field
+exported. A step's exports are read from the JSON object that ends its output, so they survive
+Deepnote reassigning block ids; the last block's output must end with a JSON object, and anything
+printed before it on earlier lines is ignored. Deepnote input blocks take strings, booleans and lists
+of strings, so a structure that must cross into a notebook is exported as a JSON string. The runs API
+rejects arrays for text inputs, so a fan-out's collected list can only feed an `input-select` block
+with `deepnote_allow_multiple_values: true`.
+
+**The pipeline notebook is interpreted, not executed.** Deepnote's block engine runs blocks strictly
+in order, so handing it the parent would serialize the fan-out into one run with one status. Reading
+it as a manifest keeps concurrency and per-step events, while the definition still lives in a
+versioned, reviewable file.
+
+Errors a graph can be checked for are raised at plan time, before anything runs: no notebook marked
+`isPipeline` (or more than one), a variable no step exports, two steps exporting the same variable, a
+step naming no notebook, a variable reference that is a path, a `for_each_as` without a `for_each`
+or that shadows an export, a malformed condition, and a dependency cycle.
+
+### Gates: `function_notebook_run_if`
+
+A step's _existence_ can depend on an earlier result, so a gate lives in the file too:
+
+```yaml
+- id: final-arbiter
+  type: notebook-function
+  metadata:
+    function_notebook_run_if: gptDecision != claudeDecision
+    function_notebook_id: nb-arbiter
+```
+
+The condition reads pipeline variables, so the step depends on what it consults without that being
+written down twice — even when no input mentions them. When it is false the step is skipped, and so
+is anything that reads what it would have exported: a dependent is never run with a value that will
+never arrive. Skipped steps come back in `result.skipped`, and each gate appears in the graph as a
+`gate` node between the steps it reads and the step it governs.
+
+The condition language is deliberately **not JavaScript**: a pipeline definition is data, and a file
+that runs arbitrary code in whoever opens it is a different and much worse thing than a file that
+describes a graph. There is no `eval`, no calls, no assignment, and no prototype access — property
+lookups are own-properties only. It supports comparisons (`< <= > >= == !=`), `&& || !`, parentheses,
+numeric indexing, and literals. A malformed condition fails at plan time.
+
+One rule for every comparison operator: when both operands are numbers or numeric strings they
+compare numerically (`"6" == 6`, `"6" < 10`), otherwise strictly (`"a" == 6` is false). `==` also
+treats an absent value as `null`, so a gate can ask whether an earlier step published anything
+(`recovered == null`); a variable whose producer was skipped reads as absent.
+
+### Dynamic fan-out: `function_notebook_for_each`
+
+A step's _width_ can come from the data rather than the file — one run per element, all concurrent:
+
+```yaml
+- id: recover
+  type: notebook-function
+  metadata:
+    function_notebook_for_each: belowThreshold # a pipeline variable holding an array
+    function_notebook_for_each_as: region # each element is bound to this name
+    function_notebook_run_if: region.qualityScore < 0.95 # evaluated per element
+    function_notebook_inputs:
+      region: { variable_name: region } # the element, passed as an input
+    function_notebook_export_mappings:
+      summary_json: { enabled: true, variable_name: recovered }
+```
+
+`run_if` on a fan-out is evaluated per element, so this is conditional recovery: one run for each
+region that failed the gate, and none at all when they all passed. Exports collect into an array in
+element order, so `recovered` is the list of what actually ran.
+
+**A fan-out always publishes a list, even when it ran nothing** — an empty array and every element
+being gated off both give `[]` rather than a skip. A `for_each` over a variable that never arrived
+skips the step, like any other missing value. A `for_each` over something that is not an array, or
+over more than 50 elements, is a run-time error naming the step. Fan-out runs count towards the
+engine's concurrency like any other step.
+
+The fan-out also appears in the graph as a single `join` node its runs converge on, so a later step
+can depend on it by name. The loop variable is bound by the step, so it is not a dependency on
+anything; the step depends on the array and on whatever its other inputs and condition consult.
+
+### Optional values: `fallback`
+
+An input can name what to use when its variable never arrives because the producer was skipped (or
+failed with `allow_failure`):
+
+```yaml
+claude_review_json:
+  variable_name: claudeReview
+  fallback: { custom_value: "" }
+data:
+  variable_name: recovered
+  fallback: { variable_name: original }
+```
+
+A fallback is itself an input, so it may chain. This is what keeps a gate from poisoning everything
+downstream: without it a step reading a value from a gated step is skipped whenever that gate was
+false — correct, but it cascades. A step is skipped only when an input has _no_ satisfiable
+alternative, and it depends on every alternative, since which one wins is a run-time fact.
+
+### Tolerated failures: `function_notebook_allow_failure`
+
+By default a failed notebook fails the pipeline (`PipelineStepError`). With
+`function_notebook_allow_failure: true` the failed result is returned instead and the run continues;
+the step is listed in `result.failed`, publishes nothing, and dependents fall back or are skipped.
+On a fan-out, exports collect from the elements that succeeded.
+
+A run that finishes but whose exports cannot be read — no JSON object ends its output, or the object
+lacks an exported key — counts as a failed step too: under `allow_failure` it is listed in `failed`
+and publishes nothing, and without it the pipeline fails with a `PipelineStepError` naming the step
+rather than a bare error. A terminal step marked `allow_failure` therefore lets the run resolve with
+every other variable present.
+
+### What is still code
+
+`runPipeline` remains the answer for logic that is genuinely computation rather than topology:
+reshaping or merging results between steps, retry policies with backoff, and anything that needs a
+library. A file describes a graph — its steps, their gates, and their width — and that is the
+boundary worth keeping.
+
+See [`examples/pipelines/sales-pipeline.deepnote`](../../examples/pipelines/sales-pipeline.deepnote)
+and the conformance fixtures in
+[`test-fixtures/pipeline-conformance`](../../test-fixtures/pipeline-conformance), which are the
+contract every implementation of this encoding must meet.
+
 ## When a step fails
 
 A failed notebook rejects the pipeline with `PipelineStepError` unless the step has
@@ -98,6 +270,10 @@ try {
 
 The resolved shape is unchanged: a pipeline that returns gets `value`, `steps`, `graph` and the
 timings as before.
+
+`runPipelineFile` attaches the file runner's state as well: the error carries `variables`, `skipped`
+and `failed` as they stood when the run stopped, alongside `partial`, so a caller can render every
+value that did arrive next to the step that stopped the run.
 
 ## What this is not
 

--- a/packages/pipelines/src/condition-expression.test.ts
+++ b/packages/pipelines/src/condition-expression.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it } from 'vitest'
+import { evaluateCondition, parseCondition } from './condition-expression'
+
+const vars = {
+  europe: { qualityScore: 0.91, region: 'Europe', stale: false, retries: 3 },
+  portfolio: { totals: { forecastK: 900, targetK: 1000 }, tags: ['a', 'b'] },
+}
+
+describe('evaluateCondition', () => {
+  it('compares a nested value against a threshold — the quality gate', () => {
+    expect(evaluateCondition('europe.qualityScore < 0.95', vars)).toBe(true)
+    expect(evaluateCondition('europe.qualityScore >= 0.95', vars)).toBe(false)
+  })
+
+  it('compares two nested values', () => {
+    expect(evaluateCondition('portfolio.totals.forecastK >= portfolio.totals.targetK', vars)).toBe(false)
+    expect(evaluateCondition('portfolio.totals.forecastK < portfolio.totals.targetK', vars)).toBe(true)
+  })
+
+  it('combines comparisons with && and ||, and negates with !', () => {
+    expect(evaluateCondition('europe.qualityScore < 0.95 && !europe.stale', vars)).toBe(true)
+    expect(evaluateCondition('europe.stale || europe.retries > 2', vars)).toBe(true)
+    expect(evaluateCondition('europe.stale || europe.retries > 5', vars)).toBe(false)
+  })
+
+  it('honours parentheses', () => {
+    expect(evaluateCondition('(europe.stale || europe.retries > 2) && europe.qualityScore < 0.95', vars)).toBe(true)
+  })
+
+  it('compares strings and booleans by equality', () => {
+    expect(evaluateCondition('europe.region == "Europe"', vars)).toBe(true)
+    expect(evaluateCondition("europe.region != 'Asia'", vars)).toBe(true)
+    expect(evaluateCondition('europe.stale == false', vars)).toBe(true)
+  })
+
+  it('compares numerically when both sides are numbers or numeric strings, for every operator', () => {
+    // Input blocks hand values to notebooks as strings, so an echoed threshold is often "6", not 6.
+    const mixed = { echoed: '6', count: 6, name: 'a', big: '10', small: '9' }
+    expect(evaluateCondition('echoed == 6', mixed)).toBe(true)
+    expect(evaluateCondition('echoed == count', mixed)).toBe(true)
+    expect(evaluateCondition('echoed != 6', mixed)).toBe(false)
+    expect(evaluateCondition('echoed < 10', mixed)).toBe(true)
+    expect(evaluateCondition('echoed >= "6.0"', mixed)).toBe(true)
+    // Both numeric strings: numeric order, not lexicographic — "10" is not less than "9".
+    expect(evaluateCondition('big < small', mixed)).toBe(false)
+  })
+
+  it('compares strictly otherwise, so no operator coerces on its own', () => {
+    const mixed = { name: 'a', count: 6, flag: true, one: '1' }
+    expect(evaluateCondition('name == 6', mixed)).toBe(false)
+    expect(evaluateCondition('name != 6', mixed)).toBe(true)
+    expect(evaluateCondition('flag == 1', mixed)).toBe(false)
+    expect(evaluateCondition('one == true', mixed)).toBe(false)
+    // Ordering two strings is lexicographic; ordering unlike types is simply false.
+    expect(evaluateCondition('name < "b"', mixed)).toBe(true)
+    expect(evaluateCondition('name < 6', mixed)).toBe(false)
+    expect(evaluateCondition('name > 6', mixed)).toBe(false)
+    expect(evaluateCondition('flag > 0', mixed)).toBe(false)
+  })
+
+  it('indexes arrays numerically', () => {
+    expect(evaluateCondition('portfolio.tags[1] == "b"', vars)).toBe(true)
+  })
+
+  it('lets a gate ask whether an upstream step published a value', () => {
+    // Absent and null are one concept: strict equality here would make this always false and leave
+    // a gate no way to test for a value that was never produced.
+    expect(evaluateCondition('missing.thing == null', vars)).toBe(true)
+    expect(evaluateCondition('europe.nope == null', vars)).toBe(true)
+    expect(evaluateCondition('europe.region == null', vars)).toBe(false)
+    expect(evaluateCondition('europe.region != null', vars)).toBe(true)
+  })
+
+  it('treats a missing value as falsy rather than throwing', () => {
+    expect(evaluateCondition('europe.nope', vars)).toBe(false)
+  })
+
+  it('reports the variables a condition reads, so dependencies need no second declaration', () => {
+    const { references } = parseCondition('europe.qualityScore < 0.95 && portfolio.totals.targetK > 0')
+    expect([...references].sort()).toEqual(['europe', 'portfolio'])
+  })
+
+  it('does not treat true/false/null as variables', () => {
+    expect([...parseCondition('europe.stale == false').references]).toEqual(['europe'])
+  })
+
+  describe('is data, not code', () => {
+    it('cannot reach the prototype chain', () => {
+      expect(evaluateCondition('europe.constructor', vars)).toBe(false)
+      expect(evaluateCondition('europe.__proto__', vars)).toBe(false)
+      expect(evaluateCondition('portfolio.toString', vars)).toBe(false)
+    })
+
+    it('refuses anything that looks like a call or assignment', () => {
+      expect(() => evaluateCondition('fetch("http://x")', vars)).toThrow()
+      expect(() => evaluateCondition('europe.qualityScore = 1', vars)).toThrow()
+      expect(() => evaluateCondition('a; b', vars)).toThrow()
+    })
+
+    it('rejects malformed input with the offending text', () => {
+      expect(() => evaluateCondition('europe.qualityScore <', vars)).toThrow('ended unexpectedly')
+      expect(() => evaluateCondition('(europe.stale', vars)).toThrow('Missing ")"')
+      expect(() => evaluateCondition('europe..stale', vars)).toThrow('Expected a property name')
+    })
+  })
+})

--- a/packages/pipelines/src/condition-expression.ts
+++ b/packages/pipelines/src/condition-expression.ts
@@ -1,0 +1,270 @@
+/**
+ * A small, total expression language for step conditions in a `.deepnote` pipeline.
+ *
+ * Deliberately not JavaScript: a pipeline definition is data, and a file that can run arbitrary
+ * code in whoever opens it is a different and much worse thing than a file that describes a graph.
+ * There is no `eval` here, no property access on prototypes, and no way to call anything.
+ *
+ * What it supports is what a gate needs: read an exported value, compare it, and combine
+ * comparisons.
+ *
+ *   europe.qualityScore < 0.95
+ *   portfolio.totals.forecastK >= portfolio.totals.targetK && !portfolio.stale
+ *   region.name == "Europe" || region.retries > 2
+ */
+
+type Token =
+  | { kind: 'number'; value: number }
+  | { kind: 'string'; value: string }
+  | { kind: 'name'; value: string }
+  | { kind: 'operator'; value: string }
+
+const PUNCTUATION = ['===', '!==', '==', '!=', '<=', '>=', '&&', '||', '<', '>', '!', '(', ')', '.', '[', ']']
+
+function tokenize(source: string): Token[] {
+  const tokens: Token[] = []
+  let index = 0
+
+  while (index < source.length) {
+    const char = source[index]
+    if (/\s/.test(char)) {
+      index += 1
+      continue
+    }
+    if (char === '"' || char === "'") {
+      const end = source.indexOf(char, index + 1)
+      if (end === -1) {
+        throw new Error(`Unterminated string in condition: ${source}`)
+      }
+      tokens.push({ kind: 'string', value: source.slice(index + 1, end) })
+      index = end + 1
+      continue
+    }
+    if (/[0-9]/.test(char) || (char === '-' && /[0-9]/.test(source[index + 1] ?? ''))) {
+      const match = source.slice(index).match(/^-?[0-9]+(\.[0-9]+)?/)
+      if (!match) {
+        throw new Error(`Invalid number in condition: ${source}`)
+      }
+      tokens.push({ kind: 'number', value: Number(match[0]) })
+      index += match[0].length
+      continue
+    }
+    if (/[A-Za-z_]/.test(char)) {
+      const match = source.slice(index).match(/^[A-Za-z_][A-Za-z0-9_]*/)
+      const value = match?.[0] ?? ''
+      tokens.push({ kind: 'name', value })
+      index += value.length
+      continue
+    }
+    const operator = PUNCTUATION.find(candidate => source.startsWith(candidate, index))
+    if (!operator) {
+      throw new Error(`Unexpected "${char}" in condition: ${source}`)
+    }
+    tokens.push({ kind: 'operator', value: operator })
+    index += operator.length
+  }
+  return tokens
+}
+
+interface Parsed {
+  evaluate: (variables: Record<string, unknown>) => unknown
+  /** Root variable names the expression reads, so a planner can derive dependencies from it. */
+  references: Set<string>
+}
+
+/**
+ * Parse a condition into an evaluator plus the variables it reads.
+ *
+ * The references are what let a conditional step depend on the steps its condition consults,
+ * without anyone writing that dependency down twice.
+ */
+export function parseCondition(source: string): Parsed {
+  const tokens = tokenize(source)
+  const references = new Set<string>()
+  let position = 0
+
+  const peek = () => tokens[position]
+  const eat = (value: string): boolean => {
+    const token = peek()
+    if (token?.kind === 'operator' && token.value === value) {
+      position += 1
+      return true
+    }
+    return false
+  }
+
+  type Node = (variables: Record<string, unknown>) => unknown
+
+  const parsePrimary = (): Node => {
+    const token = peek()
+    if (!token) {
+      throw new Error(`Condition ended unexpectedly: ${source}`)
+    }
+    if (eat('(')) {
+      const inner = parseOr()
+      if (!eat(')')) {
+        throw new Error(`Missing ")" in condition: ${source}`)
+      }
+      return inner
+    }
+    if (eat('!')) {
+      const operand = parsePrimary()
+      return variables => !operand(variables)
+    }
+    if (token.kind === 'number') {
+      position += 1
+      return () => token.value
+    }
+    if (token.kind === 'string') {
+      position += 1
+      return () => token.value
+    }
+    if (token.kind === 'name') {
+      position += 1
+      if (token.value === 'true') return () => true
+      if (token.value === 'false') return () => false
+      if (token.value === 'null') return () => null
+
+      references.add(token.value)
+      const path: (string | number)[] = []
+      for (;;) {
+        if (eat('.')) {
+          const property = peek()
+          if (property?.kind !== 'name') {
+            throw new Error(`Expected a property name after "." in condition: ${source}`)
+          }
+          position += 1
+          path.push(property.value)
+          continue
+        }
+        if (eat('[')) {
+          const index = peek()
+          if (index?.kind !== 'number') {
+            throw new Error(`Only numeric indexes are supported in condition: ${source}`)
+          }
+          position += 1
+          if (!eat(']')) {
+            throw new Error(`Missing "]" in condition: ${source}`)
+          }
+          path.push(index.value)
+          continue
+        }
+        break
+      }
+      const root = token.value
+      return variables => {
+        let current: unknown = variables[root]
+        for (const segment of path) {
+          if (current == null) {
+            return undefined
+          }
+          // Own properties only: a condition must not be able to reach a prototype.
+          if (typeof current !== 'object' || !Object.hasOwn(current as object, String(segment))) {
+            return undefined
+          }
+          current = (current as Record<string | number, unknown>)[segment]
+        }
+        return current
+      }
+    }
+    throw new Error(`Unexpected "${token.value}" in condition: ${source}`)
+  }
+
+  const COMPARISONS: Record<string, (a: unknown, b: unknown) => boolean> = {
+    '<': (a, b) => ordered(a, b, (x, y) => x < y),
+    '<=': (a, b) => ordered(a, b, (x, y) => x <= y),
+    '>': (a, b) => ordered(a, b, (x, y) => x > y),
+    '>=': (a, b) => ordered(a, b, (x, y) => x >= y),
+    '==': equal,
+    '===': equal,
+    '!=': (a, b) => !equal(a, b),
+    '!==': (a, b) => !equal(a, b),
+  }
+
+  const parseComparison = (): Node => {
+    const left = parsePrimary()
+    const token = peek()
+    if (token?.kind === 'operator' && token.value in COMPARISONS) {
+      position += 1
+      const compare = COMPARISONS[token.value]
+      const right = parsePrimary()
+      return variables => compare(left(variables), right(variables))
+    }
+    return left
+  }
+
+  const parseAnd = (): Node => {
+    let node = parseComparison()
+    while (eat('&&')) {
+      const left = node
+      const right = parseComparison()
+      node = variables => Boolean(left(variables)) && Boolean(right(variables))
+    }
+    return node
+  }
+
+  function parseOr(): Node {
+    let node = parseAnd()
+    while (eat('||')) {
+      const left = node
+      const right = parseAnd()
+      node = variables => Boolean(left(variables)) || Boolean(right(variables))
+    }
+    return node
+  }
+
+  const root = parseOr()
+  if (position !== tokens.length) {
+    throw new Error(`Unexpected "${tokens[position]?.value}" at the end of condition: ${source}`)
+  }
+  return { evaluate: root, references }
+}
+
+/**
+ * A number, or a string that reads as one. Input blocks hand values to notebooks as strings, so a
+ * threshold a notebook echoes back is as likely to be `"6"` as `6`; both count as numeric.
+ */
+function asNumber(value: unknown): number | undefined {
+  if (typeof value === 'number') {
+    return value
+  }
+  if (typeof value === 'string' && value.trim() !== '' && Number.isFinite(Number(value))) {
+    return Number(value)
+  }
+  return undefined
+}
+
+const isAbsent = (value: unknown): boolean => value === null || value === undefined
+
+/**
+ * One rule for every comparison operator: when both operands are numbers or numeric strings they
+ * compare numerically, otherwise strictly. So `"6" == 6` and `"6" < 10` are both true, while
+ * `"a" == 6` is false — no operator coerces on its own.
+ *
+ * Equality additionally treats an absent value as null. A missing path reads as `undefined`, so
+ * strict equality would make `upstream.value == null` always false — leaving a gate no way to ask
+ * whether an earlier step published something, which is one of the main things a gate is for.
+ * Absent and null are one concept here.
+ */
+function equal(a: unknown, b: unknown): boolean {
+  if (isAbsent(a) || isAbsent(b)) {
+    return isAbsent(a) && isAbsent(b)
+  }
+  const [x, y] = [asNumber(a), asNumber(b)]
+  return x !== undefined && y !== undefined ? x === y : a === b
+}
+
+/** Ordering follows the same rule: numeric when both sides are numeric, otherwise strict. */
+function ordered(a: unknown, b: unknown, compare: <T extends number | string>(x: T, y: T) => boolean): boolean {
+  const [x, y] = [asNumber(a), asNumber(b)]
+  if (x !== undefined && y !== undefined) {
+    return compare(x, y)
+  }
+  // Two strings order lexicographically; anything else has no order and the comparison is false.
+  return typeof a === 'string' && typeof b === 'string' ? compare(a, b) : false
+}
+
+/** Evaluate a condition to a decision. Anything truthy runs the step. */
+export function evaluateCondition(source: string, variables: Record<string, unknown>): boolean {
+  return Boolean(parseCondition(source).evaluate(variables))
+}

--- a/packages/pipelines/src/index.ts
+++ b/packages/pipelines/src/index.ts
@@ -1,5 +1,6 @@
 export type { CloudExecutorOptions } from './cloud-executor'
 export { createCloudStepExecutor, DEFAULT_CLOUD_API_URL } from './cloud-executor'
+export { evaluateCondition } from './condition-expression'
 export type { RunBlockOutput } from './extract-outputs'
 export { extractOutputs } from './extract-outputs'
 export type { InputBlockInfo } from './input-info'
@@ -26,5 +27,9 @@ export type {
   PipelineStepResult,
 } from './pipeline'
 export { PipelineRunError, PipelineStepError, pipelineOutputs, runPipeline, runPipelineWithExecutor } from './pipeline'
+export type { PipelinePlan, PlannedStep, PlanOptions } from './pipeline-plan'
+export { planPipeline } from './pipeline-plan'
+export type { PipelineFileError, PipelineFileOptions, PlanPipelineResult, PlanRunResult } from './run-pipeline-file'
+export { MAX_FOR_EACH_WIDTH, runPipelineFile, runPipelineFileWithExecutor } from './run-pipeline-file'
 export type { SnapshotBlock, SnapshotInput, SnapshotNotebook, SnapshotView } from './snapshot-view'
 export { parseSnapshot, toSnapshotView } from './snapshot-view'

--- a/packages/pipelines/src/pipeline-conformance.test.ts
+++ b/packages/pipelines/src/pipeline-conformance.test.ts
@@ -1,0 +1,121 @@
+import { readdirSync, readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { deserializeDeepnoteFile } from '@deepnote/blocks'
+import { describe, expect, it } from 'vitest'
+import type { PipelineStepExecutor } from './pipeline'
+import { planPipeline } from './pipeline-plan'
+import { runPipelineFileWithExecutor } from './run-pipeline-file'
+
+/**
+ * The fixtures are the contract for the pipeline encoding: the shape deepnote.com stores, read the
+ * way deepnote.com will read it. Every implementation of the planner — this one, or the product's —
+ * must produce these plans for these files, and these execution results for the fake runs below.
+ *
+ * Each `<name>.deepnote` has a hand-checked `<name>.expected.json` (the plan) and/or a
+ * `<name>.expected-results.json` (what ran, what was skipped, and with which inputs).
+ */
+
+const FIXTURES = join(__dirname, '../../../test-fixtures/pipeline-conformance')
+
+const fixtures = readdirSync(FIXTURES).filter(name => name.endsWith('.deepnote'))
+const has = (name: string) => readdirSync(FIXTURES).includes(name)
+const readJson = (name: string) => JSON.parse(readFileSync(join(FIXTURES, name), 'utf8'))
+const readFixture = (name: string) => deserializeDeepnoteFile(readFileSync(join(FIXTURES, name), 'utf8'))
+
+/** Through JSON so key order and undefined-vs-absent cannot differ from the committed file. */
+const comparable = (value: unknown): unknown => JSON.parse(JSON.stringify(value))
+
+interface ExpectedResults {
+  /** Step (or fan-out element) id → the JSON object its run produces. Absent means `{}`. */
+  stepOutputs: Record<string, unknown>
+  /** Steps whose run fails. */
+  failingSteps: string[]
+  /** Step id → the inputs it was run with. */
+  ran: Record<string, Record<string, unknown>>
+  skipped: string[]
+  failed: string[]
+  variables: Record<string, unknown>
+}
+
+/** An executor that plays back the scenario a results fixture describes. */
+function scenarioExecutor(scenario: ExpectedResults) {
+  const ran: Record<string, Record<string, unknown>> = {}
+  const executor: PipelineStepExecutor = async ({ id, step, startedAt, startedMs }) => {
+    ran[id] = (step.inputs ?? {}) as Record<string, unknown>
+    const fails = scenario.failingSteps.includes(id)
+    const value = scenario.stepOutputs[id] ?? {}
+    return {
+      id,
+      target: 'fake',
+      success: !fails,
+      status: fails ? 'failed' : 'success',
+      outputs: [],
+      snapshotYaml: null,
+      snapshot: fails
+        ? null
+        : {
+            notebooks: [
+              {
+                id: 'n1',
+                name: 'n',
+                blocks: [
+                  {
+                    id: 'b1',
+                    type: 'code',
+                    content: '',
+                    executionCount: 1,
+                    outputs: [{ output_type: 'execute_result', data: { 'application/json': value }, metadata: {} }],
+                  },
+                ],
+              },
+            ],
+            inputs: [],
+          },
+      error: fails ? 'the notebook raised' : undefined,
+      startedAt,
+      finishedAt: new Date(startedMs + 1).toISOString(),
+      durationMs: 1,
+      // biome-ignore lint/suspicious/noExplicitAny: test double
+    } as any
+  }
+  return { executor, ran }
+}
+
+describe('pipeline conformance', () => {
+  it('has fixtures to check, each with an expectation', () => {
+    expect(fixtures.length).toBeGreaterThan(0)
+    for (const fixture of fixtures) {
+      const base = fixture.replace('.deepnote', '')
+      expect(
+        has(`${base}.expected.json`) || has(`${base}.expected-results.json`),
+        `${fixture} has no expectation`
+      ).toBe(true)
+    }
+  })
+
+  describe('the plan matches the expected plan', () => {
+    for (const fixture of fixtures) {
+      const expectedName = fixture.replace('.deepnote', '.expected.json')
+      it.skipIf(!has(expectedName))(fixture, () => {
+        expect(comparable(planPipeline(readFixture(fixture)))).toEqual(readJson(expectedName))
+      })
+    }
+  })
+
+  describe('execution matches the expected results', () => {
+    for (const fixture of fixtures) {
+      const expectedName = fixture.replace('.deepnote', '.expected-results.json')
+      it.skipIf(!has(expectedName))(fixture, async () => {
+        const scenario = readJson(expectedName) as ExpectedResults
+        const { executor, ran } = scenarioExecutor(scenario)
+
+        const result = await runPipelineFileWithExecutor(readFixture(fixture), {}, executor)
+
+        expect(comparable(ran)).toEqual(scenario.ran)
+        expect([...result.skipped].sort()).toEqual([...scenario.skipped].sort())
+        expect([...result.failed].sort()).toEqual([...scenario.failed].sort())
+        expect(comparable(result.value)).toEqual(scenario.variables)
+      })
+    }
+  })
+})

--- a/packages/pipelines/src/pipeline-plan.test.ts
+++ b/packages/pipelines/src/pipeline-plan.test.ts
@@ -1,0 +1,313 @@
+import { describe, expect, it } from 'vitest'
+import { inputVariables, planPipeline } from './pipeline-plan'
+
+function step(id: string, notebookId: string | null, extra: Record<string, unknown> = {}) {
+  return {
+    blockGroup: `g-${id}`,
+    id,
+    sortingKey: extra.sortingKey as string,
+    type: 'notebook-function' as const,
+    metadata: {
+      function_notebook_id: notebookId,
+      function_notebook_inputs: extra.inputs ?? {},
+      function_notebook_export_mappings: extra.exports ?? {},
+      function_notebook_run_if: extra.run_if,
+      function_notebook_for_each: extra.for_each,
+      function_notebook_for_each_as: extra.for_each_as,
+      function_notebook_allow_failure: extra.allow_failure,
+      name: extra.name,
+    },
+  }
+}
+
+function file(blocks: unknown[], notebook: Record<string, unknown> = {}) {
+  return {
+    metadata: { createdAt: '2026-01-01T00:00:00.000Z' },
+    project: {
+      id: 'p1',
+      name: 'Demo',
+      notebooks: [{ id: 'nb-parent', name: 'Pipeline', isPipeline: true, blocks, ...notebook }],
+    },
+    version: '1.0.0',
+    // biome-ignore lint/suspicious/noExplicitAny: a hand-built fixture, not a parsed file
+  } as any
+}
+
+const exp = (exportName: string, variable: string) => ({ [exportName]: { enabled: true, variable_name: variable } })
+const ref = (variable: string) => ({ variable_name: variable })
+const lit = (value: unknown) => ({ custom_value: value })
+
+describe('planPipeline', () => {
+  it('derives dependencies from variable flow, not a second declaration', () => {
+    const plan = planPipeline(
+      file([
+        step('load', 'nb-load', { sortingKey: 'a0', exports: exp('portfolio', 'portfolio') }),
+        step('review', 'nb-review', { sortingKey: 'a1', inputs: { portfolio_json: ref('portfolio') } }),
+      ])
+    )
+
+    expect(plan.steps.map(s => s.id)).toEqual(['load', 'review'])
+    expect(plan.steps[0].dependsOn).toEqual([])
+    expect(plan.steps[1].dependsOn).toEqual(['load'])
+    expect(plan.producedBy).toEqual({ portfolio: 'load' })
+  })
+
+  it('leaves independent steps independent, which is what lets them run at once', () => {
+    const plan = planPipeline(
+      file([
+        step('na', 'nb-na', { sortingKey: 'a0', inputs: { region: lit('North America') } }),
+        step('eu', 'nb-eu', { sortingKey: 'a1', inputs: { region: lit('Europe') } }),
+      ])
+    )
+
+    expect(plan.steps.every(s => s.dependsOn.length === 0)).toBe(true)
+  })
+
+  it('treats a literal as a literal, even when it looks like a variable name', () => {
+    const plan = planPipeline(
+      file([
+        step('a', 'nb-a', { sortingKey: 'a0', exports: exp('value', 'alpha') }),
+        step('b', 'nb-b', {
+          sortingKey: 'a1',
+          inputs: { x: lit('alpha'), y: { custom_value: null, variable_name: null } },
+        }),
+      ])
+    )
+
+    expect(plan.steps[1].dependsOn).toEqual([])
+  })
+
+  it('depends on every alternative of a fallback chain, since which one wins is a run-time fact', () => {
+    const plan = planPipeline(
+      file([
+        step('a', 'nb-a', { sortingKey: 'a0', exports: exp('value', 'alpha') }),
+        step('b', 'nb-b', { sortingKey: 'a1', exports: exp('value', 'beta') }),
+        step('c', 'nb-c', {
+          sortingKey: 'a2',
+          inputs: { data: { variable_name: 'beta', fallback: { variable_name: 'alpha', fallback: lit(null) } } },
+        }),
+      ])
+    )
+
+    expect(plan.steps[2].dependsOn).toEqual(['a', 'b'])
+  })
+
+  it('depends on what a run_if condition consults, even when no input reads it', () => {
+    const plan = planPipeline(
+      file([
+        step('check', 'nb-check', { sortingKey: 'a0', exports: exp('quality', 'quality') }),
+        step('notify', 'nb-notify', {
+          sortingKey: 'a1',
+          run_if: 'quality.score < 0.95',
+          inputs: { channel: lit('alerts') },
+        }),
+      ])
+    )
+
+    expect(plan.steps[1].dependsOn).toEqual(['check'])
+    expect(plan.steps[1].condition).toBe('quality.score < 0.95')
+  })
+
+  it('depends on the array a for_each iterates, and binds the element without depending on it', () => {
+    const plan = planPipeline(
+      file([
+        step('load', 'nb-load', { sortingKey: 'a0', exports: exp('regions', 'regions') }),
+        step('analyze', 'nb-regional', {
+          sortingKey: 'a1',
+          for_each: 'regions',
+          for_each_as: 'region',
+          run_if: 'region.qualityScore < 0.95',
+          inputs: { region: ref('region') },
+        }),
+      ])
+    )
+
+    expect(plan.steps[1].dependsOn).toEqual(['load'])
+    expect(plan.steps[1].forEach).toBe('regions')
+    expect(plan.steps[1].forEachAs).toBe('region')
+  })
+
+  it('binds a for_each element to "item" unless told otherwise', () => {
+    const plan = planPipeline(
+      file([
+        step('load', 'nb-load', { sortingKey: 'a0', exports: exp('regions', 'regions') }),
+        step('analyze', 'nb-regional', { sortingKey: 'a1', for_each: 'regions', inputs: { region: ref('item') } }),
+      ])
+    )
+    expect(plan.steps[1].forEachAs).toBe('item')
+  })
+
+  it('records allow_failure, and defaults it off', () => {
+    const plan = planPipeline(
+      file([step('a', 'nb-a', { sortingKey: 'a0', allow_failure: true }), step('b', 'nb-b', { sortingKey: 'a1' })])
+    )
+    expect(plan.steps.map(s => s.allowFailure)).toEqual([true, false])
+  })
+
+  it('ignores disabled and unnamed export mappings', () => {
+    const plan = planPipeline(
+      file([
+        step('a', 'nb-a', {
+          sortingKey: 'a0',
+          exports: {
+            kept: { enabled: true, variable_name: 'kept' },
+            off: { enabled: false, variable_name: 'off' },
+            unnamed: { enabled: true, variable_name: null },
+          },
+        }),
+      ])
+    )
+    expect(plan.steps[0].exports).toEqual({ kept: 'kept' })
+    expect(plan.producedBy).toEqual({ kept: 'a' })
+  })
+
+  it('orders steps by sortingKey, not array order', () => {
+    const plan = planPipeline(
+      file([step('second', 'nb-2', { sortingKey: 'a1' }), step('first', 'nb-1', { sortingKey: 'a0' })])
+    )
+    expect(plan.steps.map(s => s.id)).toEqual(['first', 'second'])
+  })
+
+  describe('selecting the pipeline notebook', () => {
+    const marked = (id: string, isPipeline: boolean | undefined, blocks: unknown[]) => ({
+      id,
+      name: id,
+      isPipeline,
+      blocks,
+    })
+    const twoNotebooks = (first?: boolean, second?: boolean) =>
+      ({
+        metadata: { createdAt: '2026-01-01T00:00:00.000Z' },
+        project: {
+          id: 'p1',
+          name: 'Demo',
+          notebooks: [
+            marked('one', first, [step('a', 'nb-a', { sortingKey: 'a0' })]),
+            marked('two', second, [step('b', 'nb-b', { sortingKey: 'a0' })]),
+          ],
+        },
+        version: '1.0.0',
+        // biome-ignore lint/suspicious/noExplicitAny: a hand-built fixture, not a parsed file
+      }) as any
+
+    it('reads the one notebook marked isPipeline', () => {
+      expect(planPipeline(twoNotebooks(undefined, true)).notebookId).toBe('two')
+    })
+
+    it('explains a file with no pipeline marker, and how to add one', () => {
+      expect(() => planPipeline(twoNotebooks())).toThrow('Set `isPipeline: true`')
+    })
+
+    it('refuses to guess between two marked notebooks', () => {
+      expect(() => planPipeline(twoNotebooks(true, true))).toThrow('More than one notebook is marked isPipeline')
+    })
+
+    it('accepts an explicit notebook by id or name, marker or not', () => {
+      expect(planPipeline(twoNotebooks(), { notebook: 'one' }).notebookId).toBe('one')
+      expect(planPipeline(twoNotebooks(true, true), { notebook: 'two' }).notebookId).toBe('two')
+      expect(() => planPipeline(twoNotebooks(), { notebook: 'three' })).toThrow('No notebook with id or name "three"')
+    })
+
+    it('rejects a pipeline notebook with no steps', () => {
+      expect(() => planPipeline(file([]))).toThrow('has no notebook-function blocks')
+    })
+  })
+
+  describe('plan-time errors', () => {
+    it('names a variable no step exports instead of failing at run time', () => {
+      expect(() =>
+        planPipeline(file([step('a', 'nb-a', { sortingKey: 'a0', inputs: { x: ref('missing') } })]))
+      ).toThrow('reads "missing", which no step exports')
+    })
+
+    it('checks fallbacks and for_each too', () => {
+      expect(() =>
+        planPipeline(
+          file([
+            step('a', 'nb-a', { sortingKey: 'a0', inputs: { x: { variable_name: 'nope', fallback: ref('gone') } } }),
+          ])
+        )
+      ).toThrow('reads "nope"')
+      expect(() => planPipeline(file([step('a', 'nb-a', { sortingKey: 'a0', for_each: 'gone' })]))).toThrow(
+        'reads "gone"'
+      )
+    })
+
+    it('rejects two steps exporting the same variable', () => {
+      expect(() =>
+        planPipeline(
+          file([
+            step('a', 'nb-a', { sortingKey: 'a0', exports: exp('v', 'shared') }),
+            step('b', 'nb-b', { sortingKey: 'a1', exports: exp('v', 'shared') }),
+          ])
+        )
+      ).toThrow('both export "shared"')
+    })
+
+    it('detects a dependency cycle before anything runs', () => {
+      expect(() =>
+        planPipeline(
+          file([
+            step('a', 'nb-a', { sortingKey: 'a0', exports: exp('v', 'fromA'), inputs: { x: ref('fromB') } }),
+            step('b', 'nb-b', { sortingKey: 'a1', exports: exp('v', 'fromB'), inputs: { x: ref('fromA') } }),
+          ])
+        )
+      ).toThrow('depend on each other in a cycle')
+    })
+
+    it('rejects a step that reads its own export', () => {
+      expect(() =>
+        planPipeline(
+          file([step('a', 'nb-a', { sortingKey: 'a0', exports: exp('v', 'own'), inputs: { x: ref('own') } })])
+        )
+      ).toThrow('which it exports itself')
+    })
+
+    it('rejects a step that names no notebook', () => {
+      expect(() => planPipeline(file([step('a', null, { sortingKey: 'a0' })]))).toThrow('names no notebook')
+    })
+
+    it('rejects a malformed condition', () => {
+      expect(() => planPipeline(file([step('a', 'nb-a', { sortingKey: 'a0', run_if: 'x <' })]))).toThrow(
+        'ended unexpectedly'
+      )
+    })
+
+    it('rejects a variable reference that is a path, pointing at run_if and exports instead', () => {
+      expect(() =>
+        planPipeline(
+          file([
+            step('a', 'nb-a', { sortingKey: 'a0', exports: exp('v', 'portfolio') }),
+            step('b', 'nb-b', { sortingKey: 'a1', inputs: { x: ref('portfolio.total') } }),
+          ])
+        )
+      ).toThrow('"portfolio.total", which is not a plain variable name')
+    })
+
+    it('rejects for_each_as without for_each, and a binding that shadows an export', () => {
+      expect(() => planPipeline(file([step('a', 'nb-a', { sortingKey: 'a0', for_each_as: 'x' })]))).toThrow(
+        'has no function_notebook_for_each to iterate'
+      )
+      expect(() =>
+        planPipeline(
+          file([
+            step('a', 'nb-a', { sortingKey: 'a0', exports: exp('v', 'regions') }),
+            step('b', 'nb-b', { sortingKey: 'a1', for_each: 'regions', for_each_as: 'regions' }),
+          ])
+        )
+      ).toThrow('which step "a" also exports')
+    })
+  })
+})
+
+describe('inputVariables', () => {
+  it('lists every variable a chain consults, skipping literals and empty names', () => {
+    expect(
+      inputVariables({
+        variable_name: 'a',
+        fallback: { custom_value: 1, fallback: { variable_name: '', fallback: { variable_name: 'b' } } },
+      })
+    ).toEqual(['a', 'b'])
+    expect(inputVariables({ custom_value: 'x' })).toEqual([])
+  })
+})

--- a/packages/pipelines/src/pipeline-plan.ts
+++ b/packages/pipelines/src/pipeline-plan.ts
@@ -1,0 +1,279 @@
+import type { DeepnoteBlock, DeepnoteFile, NotebookFunctionBlock, NotebookFunctionInput } from '@deepnote/blocks'
+import { parseCondition } from './condition-expression'
+
+/**
+ * Read a pipeline out of a `.deepnote` file.
+ *
+ * The notebook marked `isPipeline: true` *is* the pipeline definition: each of its
+ * `notebook-function` blocks names an external notebook, the inputs to run it with, and the values
+ * it publishes. This module turns that into a dependency graph without executing anything.
+ *
+ * The encoding is the one deepnote.com stores for a notebook-function block, so the same file means
+ * the same thing in the product and here. An input is either `{ variable_name }` — a reference to a
+ * pipeline variable — or `{ custom_value }`, a literal. Exports are `{ enabled, variable_name }`.
+ * The pipeline-only keys (`function_notebook_run_if`, `function_notebook_for_each`,
+ * `function_notebook_for_each_as`, `function_notebook_allow_failure`) sit next to them.
+ *
+ * The pipeline notebook is read as a manifest, not run as a notebook. That distinction is the whole
+ * point — Deepnote's own engine runs blocks strictly in order, so executing the parent would
+ * serialize the pipeline and collapse it into a single run with a single status. Interpreting it
+ * instead lets the pipeline run independent steps concurrently and report each one separately,
+ * while the definition still lives in a versioned file that can be reviewed.
+ *
+ * Nothing here is Node-specific, so a browser can plan a pipeline it fetched.
+ */
+
+/** A step's inputs and exports, resolved from one `notebook-function` block. */
+export interface PlannedStep {
+  /** The block id, used as the pipeline step id. */
+  id: string
+  label: string
+  /** The external notebook this step runs. */
+  notebookId: string
+  /**
+   * Input name → what to pass. A `variable_name` reads a pipeline variable (another step's export,
+   * or this step's `forEachAs` element); a `custom_value` is passed as written.
+   */
+  inputs: Record<string, NotebookFunctionInput>
+  /** Export name in the child's structured output → pipeline variable name. */
+  exports: Record<string, string>
+  /** Step ids this step reads a variable from, sorted. */
+  dependsOn: string[]
+  /**
+   * A `run_if` condition. When it evaluates false the step is skipped, and so is anything that
+   * reads what it would have exported.
+   *
+   * This is what lets a gate live in the file rather than in application code: the step's
+   * *existence* becomes a function of an earlier step's result.
+   *
+   * On a {@link forEach} step it is evaluated per element, which is how a file expresses "recover
+   * only the regions that failed the gate".
+   */
+  condition?: string
+  /**
+   * The pipeline variable holding the array this step iterates. The step becomes one run per
+   * element, all concurrent.
+   *
+   * The width is not known until the array exists, so this is the one part of a plan that is
+   * resolved at run time rather than at plan time.
+   */
+  forEach?: string
+  /** The name each element is bound to inside this step's inputs and condition. */
+  forEachAs: string
+  /** Return a failed run as a result instead of failing the pipeline. */
+  allowFailure: boolean
+}
+
+export interface PipelinePlan {
+  /** The notebook the plan was read from. */
+  notebookId: string
+  notebookName: string
+  steps: PlannedStep[]
+  /** Pipeline variable name → the step id that publishes it. */
+  producedBy: Record<string, string>
+}
+
+export interface PlanOptions {
+  /** Which notebook in the file holds the pipeline, by id or name. Defaults to the one marked `isPipeline`. */
+  notebook?: string
+}
+
+/** A pipeline variable name: a plain identifier, no paths. */
+const IDENTIFIER = /^[A-Za-z_][A-Za-z0-9_]*$/
+
+/** Every `variable_name` an input consults, following its fallback chain. */
+export function inputVariables(input: NotebookFunctionInput): string[] {
+  const names: string[] = []
+  for (let current: NotebookFunctionInput | undefined = input; current; current = current.fallback) {
+    if (typeof current.variable_name === 'string' && current.variable_name !== '') {
+      names.push(current.variable_name)
+    }
+  }
+  return names
+}
+
+function isNotebookFunctionBlock(block: DeepnoteBlock): block is NotebookFunctionBlock {
+  return block.type === 'notebook-function'
+}
+
+function selectNotebook(file: DeepnoteFile, options: PlanOptions) {
+  const notebooks = file.project.notebooks
+  if (options.notebook) {
+    const named = notebooks.find(notebook => notebook.id === options.notebook || notebook.name === options.notebook)
+    if (!named) {
+      throw new Error(`No notebook with id or name "${options.notebook}" in this file.`)
+    }
+    return named
+  }
+  const marked = notebooks.filter(notebook => notebook.isPipeline)
+  if (marked.length === 0) {
+    throw new Error(
+      'This file marks no notebook as the pipeline. Set `isPipeline: true` on the notebook whose notebook-function blocks are the steps, or name the notebook to run.'
+    )
+  }
+  if (marked.length > 1) {
+    throw new Error(
+      `More than one notebook is marked isPipeline (${marked.map(n => `"${n.name}"`).join(', ')}). Mark exactly one, or name the notebook to run.`
+    )
+  }
+  return marked[0]
+}
+
+/**
+ * Build the dependency graph a `.deepnote` file describes.
+ *
+ * Dependencies are derived from variable flow rather than declared twice: a step whose input is
+ * `{ variable_name: portfolio }` depends on whichever step exports `portfolio`. This is the same
+ * model the reactivity package already applies to notebook-function blocks.
+ */
+export function planPipeline(file: DeepnoteFile, options: PlanOptions = {}): PipelinePlan {
+  const notebook = selectNotebook(file, options)
+  const blocks = [...notebook.blocks]
+    .filter(isNotebookFunctionBlock)
+    .sort((a, b) => a.sortingKey.localeCompare(b.sortingKey))
+  if (blocks.length === 0) {
+    throw new Error(
+      `Notebook "${notebook.name}" is the pipeline but has no notebook-function blocks. Add one block per step, each naming the notebook it runs.`
+    )
+  }
+
+  const producedBy: Record<string, string> = {}
+  const drafts = blocks.map(block => {
+    const metadata = block.metadata
+    const notebookId = metadata.function_notebook_id
+    if (!notebookId) {
+      throw new Error(`Step "${block.id}" names no notebook. Set function_notebook_id to the notebook it should run.`)
+    }
+    const exports: Record<string, string> = {}
+    for (const [exportName, mapping] of Object.entries(metadata.function_notebook_export_mappings ?? {})) {
+      if (!mapping.enabled || !mapping.variable_name) {
+        continue
+      }
+      assertIdentifier(mapping.variable_name, `Step "${block.id}" exports "${exportName}" as`)
+      if (producedBy[mapping.variable_name]) {
+        throw new Error(
+          `Steps "${producedBy[mapping.variable_name]}" and "${block.id}" both export "${mapping.variable_name}". A variable can only come from one step.`
+        )
+      }
+      producedBy[mapping.variable_name] = block.id
+      exports[exportName] = mapping.variable_name
+    }
+    const condition = metadata.function_notebook_run_if?.trim() || undefined
+    if (condition) {
+      // Parse now so a malformed condition is a plan-time error, not a surprise mid-run.
+      parseCondition(condition)
+    }
+    const forEach = metadata.function_notebook_for_each?.trim() || undefined
+    if (forEach) {
+      assertIdentifier(forEach, `Step "${block.id}" iterates`)
+    }
+    if (!forEach && metadata.function_notebook_for_each_as) {
+      throw new Error(
+        `Step "${block.id}" sets function_notebook_for_each_as but has no function_notebook_for_each to iterate.`
+      )
+    }
+    const forEachAs = metadata.function_notebook_for_each_as?.trim() || 'item'
+    if (forEach) {
+      assertIdentifier(forEachAs, `Step "${block.id}" binds each element to`)
+    }
+    const inputs = metadata.function_notebook_inputs ?? {}
+    for (const [inputName, input] of Object.entries(inputs)) {
+      for (const name of inputVariables(input)) {
+        assertIdentifier(name, `Step "${block.id}" input "${inputName}" reads`)
+      }
+    }
+    return {
+      id: block.id,
+      label: (metadata.name as string | undefined)?.trim() || block.id,
+      notebookId,
+      inputs,
+      exports,
+      condition,
+      forEach,
+      forEachAs,
+      allowFailure: metadata.function_notebook_allow_failure === true,
+    }
+  })
+
+  const steps: PlannedStep[] = drafts.map(draft => {
+    // The loop variable is bound by the step itself, so it is not a dependency on anything.
+    const bound = draft.forEach ? draft.forEachAs : undefined
+    if (bound && producedBy[bound]) {
+      throw new Error(
+        `Step "${draft.id}" binds each element to "${bound}", which step "${producedBy[bound]}" also exports. Pick a name no step exports.`
+      )
+    }
+    // Inputs, fallbacks, the condition and the for_each all read variables, so the step depends on
+    // whatever any of them consults — otherwise the gate could be evaluated, or the fan-out sized,
+    // before those values exist. A fallback counts too: which alternative wins is a run-time fact.
+    const names = new Set<string>()
+    for (const input of Object.values(draft.inputs)) {
+      for (const name of inputVariables(input)) {
+        names.add(name)
+      }
+    }
+    if (draft.forEach) {
+      names.add(draft.forEach)
+    }
+    if (draft.condition) {
+      for (const name of parseCondition(draft.condition).references) {
+        names.add(name)
+      }
+    }
+    if (bound) {
+      names.delete(bound)
+    }
+
+    const dependsOn = new Set<string>()
+    for (const name of names) {
+      const producer = producedBy[name]
+      if (!producer) {
+        throw new Error(
+          `Step "${draft.id}" reads "${name}", which no step exports. Check the export mappings of the step that should produce it.`
+        )
+      }
+      if (producer === draft.id) {
+        throw new Error(`Step "${draft.id}" reads "${name}", which it exports itself.`)
+      }
+      dependsOn.add(producer)
+    }
+    return { ...draft, dependsOn: [...dependsOn].sort() }
+  })
+
+  assertAcyclic(steps)
+  return { notebookId: notebook.id, notebookName: notebook.name, steps, producedBy }
+}
+
+function assertIdentifier(name: string, context: string): void {
+  if (!IDENTIFIER.test(name)) {
+    throw new Error(
+      `${context} "${name}", which is not a plain variable name. Variables are referenced by name only: read a field in a run_if condition, or export the field from the step that produces it.`
+    )
+  }
+}
+
+/** A cycle would deadlock the scheduler, so it is worth naming before anything runs. */
+function assertAcyclic(steps: PlannedStep[]): void {
+  const byId = new Map(steps.map(step => [step.id, step]))
+  const state = new Map<string, 'visiting' | 'done'>()
+
+  const visit = (id: string, trail: string[]): void => {
+    const status = state.get(id)
+    if (status === 'done') {
+      return
+    }
+    if (status === 'visiting') {
+      const cycle = [...trail.slice(trail.indexOf(id)), id]
+      throw new Error(`These steps depend on each other in a cycle: ${cycle.join(' → ')}.`)
+    }
+    state.set(id, 'visiting')
+    for (const dependency of byId.get(id)?.dependsOn ?? []) {
+      visit(dependency, [...trail, id])
+    }
+    state.set(id, 'done')
+  }
+
+  for (const step of steps) {
+    visit(step.id, [])
+  }
+}

--- a/packages/pipelines/src/pipeline.test.ts
+++ b/packages/pipelines/src/pipeline.test.ts
@@ -24,7 +24,7 @@ function snapshotWith(value: unknown): string {
   createdAt: '2026-01-01T00:00:00.000Z'
 project:
   id: project-1
-  name: Client-only orchestration
+  name: Client-only pipeline
   notebooks:
     - id: notebook-1
       name: Main

--- a/packages/pipelines/src/pipeline.ts
+++ b/packages/pipelines/src/pipeline.ts
@@ -39,7 +39,7 @@ interface PipelineNodeDefinition {
   metadata?: Record<string, string | number | boolean | null>
 }
 
-/** One notebook invocation in an orchestration. */
+/** One notebook invocation in a pipeline. */
 export interface PipelineStep extends PipelineNodeDefinition {
   /** Unique within one pipeline, and attached to every event and result. */
   id: string

--- a/packages/pipelines/src/run-pipeline-file.test.ts
+++ b/packages/pipelines/src/run-pipeline-file.test.ts
@@ -1,0 +1,862 @@
+import { describe, expect, it } from 'vitest'
+import type { PipelineEvent, PipelineStepExecutor } from './pipeline'
+import { PipelineStepError } from './pipeline'
+import type { PipelineFileError } from './run-pipeline-file'
+import { MAX_FOR_EACH_WIDTH, runPipelineFileWithExecutor } from './run-pipeline-file'
+
+function step(id: string, notebookId: string, extra: Record<string, unknown> = {}) {
+  return {
+    blockGroup: `g-${id}`,
+    id,
+    sortingKey: extra.sortingKey as string,
+    type: 'notebook-function' as const,
+    metadata: {
+      function_notebook_id: notebookId,
+      function_notebook_inputs: extra.inputs ?? {},
+      function_notebook_export_mappings: extra.exports ?? {},
+      function_notebook_run_if: extra.run_if,
+      function_notebook_for_each: extra.for_each,
+      function_notebook_for_each_as: extra.for_each_as,
+      function_notebook_allow_failure: extra.allow_failure,
+    },
+  }
+}
+
+function file(blocks: unknown[]) {
+  return {
+    metadata: { createdAt: '2026-01-01T00:00:00.000Z' },
+    project: {
+      id: 'p1',
+      name: 'Demo',
+      notebooks: [{ id: 'nb-parent', name: 'Pipeline', isPipeline: true, blocks }],
+    },
+    version: '1.0.0',
+    // biome-ignore lint/suspicious/noExplicitAny: a hand-built fixture, not a parsed file
+  } as any
+}
+
+const exp = (exportName: string, variable: string) => ({ [exportName]: { enabled: true, variable_name: variable } })
+const ref = (variable: string) => ({ variable_name: variable })
+const lit = (value: unknown) => ({ custom_value: value })
+
+function jsonSnapshot(value: unknown) {
+  return {
+    notebooks: [
+      {
+        id: 'n1',
+        name: 'n',
+        blocks: [
+          {
+            id: 'b1',
+            type: 'code',
+            content: '',
+            executionCount: 1,
+            outputs: [{ output_type: 'execute_result', data: { 'application/json': value }, metadata: {} }],
+          },
+        ],
+      },
+    ],
+    inputs: [],
+    // biome-ignore lint/suspicious/noExplicitAny: minimal snapshot view for the helper
+  } as any
+}
+
+type Json = Record<string, unknown> | unknown[] | string | number | boolean | null
+
+interface FakeRun {
+  /** The JSON object the run's last output holds; a function sees the inputs it was given. */
+  json?: Json | ((inputs: Record<string, unknown>) => Json)
+  /** Report the run as failed. */
+  fail?: boolean
+  /** Hold the run open this long, to observe concurrency. */
+  delayMs?: number
+}
+
+/** An executor that answers each step id with a canned result and records what it was asked to run. */
+function fakeExecutor(runs: Record<string, FakeRun> = {}) {
+  const seen: { id: string; inputs: Record<string, unknown> }[] = []
+  let inFlight = 0
+  let peak = 0
+  const executor: PipelineStepExecutor = async ({ id, step: planned, startedAt, startedMs }) => {
+    const inputs = (planned.inputs ?? {}) as Record<string, unknown>
+    seen.push({ id, inputs })
+    const run = runs[id] ?? {}
+    inFlight += 1
+    peak = Math.max(peak, inFlight)
+    if (run.delayMs) {
+      await new Promise(resolve => setTimeout(resolve, run.delayMs))
+    }
+    inFlight -= 1
+    const value = typeof run.json === 'function' ? run.json(inputs) : (run.json ?? {})
+    return {
+      id,
+      target: 'fake',
+      success: !run.fail,
+      status: run.fail ? 'failed' : 'success',
+      outputs: [],
+      snapshotYaml: null,
+      snapshot: run.fail ? null : jsonSnapshot(value),
+      error: run.fail ? 'the notebook raised' : undefined,
+      startedAt,
+      finishedAt: new Date(startedMs + 1).toISOString(),
+      durationMs: 1,
+      // biome-ignore lint/suspicious/noExplicitAny: test double
+    } as any
+  }
+  return {
+    executor,
+    seen,
+    ran: () => seen.map(entry => entry.id),
+    inputsOf: (id: string) => seen.find(entry => entry.id === id)?.inputs,
+    peak: () => peak,
+  }
+}
+
+describe('runPipelineFile', () => {
+  it('runs independent steps concurrently', async () => {
+    const fake = fakeExecutor({ na: { delayMs: 5 }, eu: { delayMs: 5 }, apac: { delayMs: 5 } })
+
+    await runPipelineFileWithExecutor(
+      file([
+        step('na', 'nb-na', { sortingKey: 'a0', inputs: { region: lit('NA') } }),
+        step('eu', 'nb-eu', { sortingKey: 'a1', inputs: { region: lit('EU') } }),
+        step('apac', 'nb-apac', { sortingKey: 'a2', inputs: { region: lit('APAC') } }),
+      ]),
+      {},
+      fake.executor
+    )
+
+    // All three have no dependencies, so all three should be in flight together. Deepnote's own
+    // block engine would have run these one after another.
+    expect(fake.peak()).toBe(3)
+    expect(fake.ran().sort()).toEqual(['apac', 'eu', 'na'])
+  })
+
+  it('waits for a dependency before starting a dependent step', async () => {
+    const fake = fakeExecutor({ load: { json: { portfolio: { total: 5 } } } })
+
+    const result = await runPipelineFileWithExecutor(
+      file([
+        step('load', 'nb-load', { sortingKey: 'a0', exports: exp('portfolio', 'portfolio') }),
+        step('review', 'nb-review', { sortingKey: 'a1', inputs: { portfolio_json: ref('portfolio') } }),
+      ]),
+      {},
+      fake.executor
+    )
+
+    expect(fake.ran()).toEqual(['load', 'review'])
+    expect(result.value).toEqual({ portfolio: { total: 5 } })
+    expect(result.graph.edges).toEqual([{ from: 'load', to: 'review', label: undefined }])
+  })
+
+  it('passes a referenced export as the value itself, and a custom_value as written', async () => {
+    const fake = fakeExecutor({ load: { json: { portfolio: { total: 9 }, threshold: '0.95' } } })
+
+    await runPipelineFileWithExecutor(
+      file([
+        step('load', 'nb-load', {
+          sortingKey: 'a0',
+          exports: { ...exp('portfolio', 'portfolio'), ...exp('threshold', 'threshold') },
+        }),
+        step('review', 'nb-review', {
+          sortingKey: 'a1',
+          inputs: {
+            data: ref('portfolio'),
+            threshold: ref('threshold'),
+            mode: lit('strict'),
+            flag: lit(true),
+            // deepnote.com writes both keys; the variable wins when it is set.
+            both: { custom_value: 'ignored', variable_name: 'threshold' },
+            neither: { custom_value: null, variable_name: null },
+          },
+        }),
+      ]),
+      {},
+      fake.executor
+    )
+
+    expect(fake.inputsOf('review')).toEqual({
+      data: { total: 9 },
+      threshold: '0.95',
+      mode: 'strict',
+      flag: true,
+      both: '0.95',
+      neither: null,
+    })
+  })
+
+  it('reports every step separately, which a single parent run could not', async () => {
+    const events: PipelineEvent[] = []
+    await runPipelineFileWithExecutor(
+      file([step('na', 'nb-na', { sortingKey: 'a0' }), step('eu', 'nb-eu', { sortingKey: 'a1' })]),
+      { onEvent: event => events.push(event) },
+      fakeExecutor().executor
+    )
+
+    const startedIds = events.filter(e => e.type === 'step_started').map(e => (e as { stepId: string }).stepId)
+    const completedIds = events.filter(e => e.type === 'step_completed').map(e => (e as { stepId: string }).stepId)
+    expect(startedIds.sort()).toEqual(['eu', 'na'])
+    expect(completedIds.sort()).toEqual(['eu', 'na'])
+  })
+
+  it('returns the plan so a page can draw the graph before running it', async () => {
+    const result = await runPipelineFileWithExecutor(
+      file([step('na', 'nb-na', { sortingKey: 'a0' })]),
+      {},
+      fakeExecutor().executor
+    )
+    expect(result.plan.notebookName).toBe('Pipeline')
+    expect(result.plan.steps[0].notebookId).toBe('nb-na')
+  })
+
+  it('explains a step whose output is missing a value it promised to export', async () => {
+    await expect(
+      runPipelineFileWithExecutor(
+        file([step('load', 'nb-load', { sortingKey: 'a0', exports: exp('portfolio', 'portfolio') })]),
+        {},
+        fakeExecutor({ load: { json: { somethingElse: 1 } } }).executor
+      )
+    ).rejects.toThrow('exports "portfolio", which its output does not contain')
+  })
+
+  it('rejects a file with no pipeline notebook before running anything', async () => {
+    const fake = fakeExecutor()
+    const unmarked = file([step('a', 'nb-a', { sortingKey: 'a0' })])
+    unmarked.project.notebooks[0].isPipeline = undefined
+    await expect(runPipelineFileWithExecutor(unmarked, {}, fake.executor)).rejects.toThrow('Set `isPipeline: true`')
+    expect(fake.ran()).toEqual([])
+  })
+})
+
+describe('run_if gates in the file', () => {
+  it('skips a step whose condition is false, and runs one whose condition is true', async () => {
+    const fake = fakeExecutor({
+      'analyze-eu': { json: { qualityScore: 0.91 } },
+      'analyze-na': { json: { qualityScore: 0.99 } },
+    })
+
+    const result = await runPipelineFileWithExecutor(
+      file([
+        step('analyze-eu', 'nb-regional', { sortingKey: 'a0', exports: exp('qualityScore', 'euQuality') }),
+        step('analyze-na', 'nb-regional', { sortingKey: 'a1', exports: exp('qualityScore', 'naQuality') }),
+        step('recover-eu', 'nb-regional', { sortingKey: 'b0', run_if: 'euQuality < 0.95' }),
+        step('recover-na', 'nb-regional', { sortingKey: 'b1', run_if: 'naQuality < 0.95' }),
+      ]),
+      {},
+      fake.executor
+    )
+
+    // Europe fell below the threshold and was recovered; North America did not and was skipped.
+    expect(fake.ran()).toContain('recover-eu')
+    expect(fake.ran()).not.toContain('recover-na')
+    expect(result.skipped).toEqual(['recover-na'])
+  })
+
+  it('shows the gate decision in the graph next to the step it governs', async () => {
+    const result = await runPipelineFileWithExecutor(
+      file([
+        step('analyze-eu', 'nb-regional', { sortingKey: 'a0', exports: exp('qualityScore', 'euQuality') }),
+        step('recover-eu', 'nb-regional', { sortingKey: 'b0', run_if: 'euQuality < 0.95' }),
+      ]),
+      {},
+      fakeExecutor({ 'analyze-eu': { json: { qualityScore: 0.5 } } }).executor
+    )
+
+    const gate = result.graph.nodes.find(node => node.id === 'recover-eu-gate')
+    expect(gate?.kind).toBe('gate')
+    expect(gate?.label).toBe('euQuality < 0.95')
+    expect(result.graph.edges).toContainEqual({ from: 'analyze-eu', to: 'recover-eu-gate', label: undefined })
+    expect(result.graph.edges).toContainEqual({ from: 'recover-eu-gate', to: 'recover-eu', label: undefined })
+  })
+
+  it('skips anything that reads a skipped step, rather than running it with a missing value', async () => {
+    const fake = fakeExecutor({ 'analyze-eu': { json: { qualityScore: 0.99 } } })
+    const result = await runPipelineFileWithExecutor(
+      file([
+        step('analyze-eu', 'nb-regional', { sortingKey: 'a0', exports: exp('qualityScore', 'euQuality') }),
+        step('recover-eu', 'nb-regional', {
+          sortingKey: 'b0',
+          exports: exp('value', 'recovered'),
+          run_if: 'euQuality < 0.95',
+        }),
+        step('report', 'nb-report', { sortingKey: 'c0', inputs: { data: ref('recovered') } }),
+      ]),
+      {},
+      fake.executor
+    )
+
+    expect(fake.ran()).toEqual(['analyze-eu'])
+    expect(result.skipped.sort()).toEqual(['recover-eu', 'report'])
+  })
+
+  it('lets a gate ask whether a skipped step published anything', async () => {
+    const fake = fakeExecutor({ 'analyze-eu': { json: { qualityScore: 0.99 } } })
+    const result = await runPipelineFileWithExecutor(
+      file([
+        step('analyze-eu', 'nb-regional', { sortingKey: 'a0', exports: exp('qualityScore', 'euQuality') }),
+        step('recover-eu', 'nb-regional', {
+          sortingKey: 'b0',
+          exports: exp('value', 'recovered'),
+          run_if: 'euQuality < 0.95',
+        }),
+        step('celebrate', 'nb-report', { sortingKey: 'c0', run_if: 'recovered == null' }),
+      ]),
+      {},
+      fake.executor
+    )
+
+    expect(fake.ran()).toEqual(['analyze-eu', 'celebrate'])
+    expect(result.skipped).toEqual(['recover-eu'])
+  })
+
+  it('rejects a malformed condition at plan time, before anything runs', async () => {
+    const fake = fakeExecutor()
+    await expect(
+      runPipelineFileWithExecutor(file([step('a', 'nb-a', { sortingKey: 'a0', run_if: 'x <' })]), {}, fake.executor)
+    ).rejects.toThrow()
+    expect(fake.ran()).toEqual([])
+  })
+})
+
+describe('for_each fan-out', () => {
+  it('runs one concurrent step per element of a run-time array', async () => {
+    const fake = fakeExecutor({
+      load: { json: { regions: ['NA', 'EU', 'APAC'] } },
+      'analyze[0]': { delayMs: 5, json: inputs => ({ echoed: inputs.region }) },
+      'analyze[1]': { delayMs: 5, json: inputs => ({ echoed: inputs.region }) },
+      'analyze[2]': { delayMs: 5, json: inputs => ({ echoed: inputs.region }) },
+    })
+
+    const result = await runPipelineFileWithExecutor(
+      file([
+        step('load', 'nb-load', { sortingKey: 'a0', exports: exp('regions', 'regions') }),
+        step('analyze', 'nb-regional', {
+          sortingKey: 'b0',
+          exports: exp('echoed', 'analyzed'),
+          inputs: { region: ref('region'), depth: lit('full') },
+          for_each: 'regions',
+          for_each_as: 'region',
+        }),
+      ]),
+      {},
+      fake.executor
+    )
+
+    // Width came from the data, and all three ran at once.
+    expect(fake.ran().slice(1).sort()).toEqual(['analyze[0]', 'analyze[1]', 'analyze[2]'])
+    expect(fake.peak()).toBe(3)
+    expect(fake.inputsOf('analyze[1]')).toEqual({ region: 'EU', depth: 'full' })
+    // Exports from a fan-out collect into an array, in element order.
+    expect(result.value.analyzed).toEqual(['NA', 'EU', 'APAC'])
+  })
+
+  it('evaluates run_if per element, which is how a file expresses conditional recovery', async () => {
+    const echo = { json: (inputs: Record<string, unknown>) => ({ region: inputs.region }) }
+    const fake = fakeExecutor({
+      load: {
+        json: {
+          regions: [
+            { name: 'NA', qualityScore: 0.99 },
+            { name: 'EU', qualityScore: 0.91 },
+            { name: 'APAC', qualityScore: 0.8 },
+          ],
+        },
+      },
+      'recover[1]': echo,
+      'recover[2]': echo,
+    })
+
+    const result = await runPipelineFileWithExecutor(
+      file([
+        step('load', 'nb-load', { sortingKey: 'a0', exports: exp('regions', 'regions') }),
+        step('recover', 'nb-regional', {
+          sortingKey: 'b0',
+          exports: exp('region', 'recovered'),
+          inputs: { region: ref('region') },
+          for_each: 'regions',
+          for_each_as: 'region',
+          run_if: 'region.qualityScore < 0.95',
+        }),
+      ]),
+      {},
+      fake.executor
+    )
+
+    // Only the two regions below the threshold were recovered.
+    expect(
+      fake
+        .ran()
+        .filter(id => id.startsWith('recover'))
+        .sort()
+    ).toEqual(['recover[1]', 'recover[2]'])
+    expect(result.value.recovered).toEqual([
+      { name: 'EU', qualityScore: 0.91 },
+      { name: 'APAC', qualityScore: 0.8 },
+    ])
+  })
+
+  it('publishes empty arrays when every element is gated off, matching the empty-list case', async () => {
+    // Both mean "no element qualified", so downstream must get the same answer either way —
+    // otherwise a pipeline breaks precisely on the happy path where nothing needed recovering.
+    const fake = fakeExecutor({ load: { json: { regions: [{ qualityScore: 0.99 }, { qualityScore: 0.98 }] } } })
+    const result = await runPipelineFileWithExecutor(
+      file([
+        step('load', 'nb-load', { sortingKey: 'a0', exports: exp('regions', 'regions') }),
+        step('recover', 'nb-regional', {
+          sortingKey: 'b0',
+          exports: exp('region', 'recovered'),
+          for_each: 'regions',
+          for_each_as: 'region',
+          run_if: 'region.qualityScore < 0.95',
+        }),
+        step('aggregate', 'nb-agg', { sortingKey: 'c0', inputs: { recovered_json: ref('recovered') } }),
+      ]),
+      {},
+      fake.executor
+    )
+
+    expect(fake.ran()).toEqual(['load', 'aggregate'])
+    expect(result.skipped).toEqual([])
+    expect(result.value.recovered).toEqual([])
+    expect(fake.inputsOf('aggregate')).toEqual({ recovered_json: [] })
+  })
+
+  it('lets a later step depend on a fan-out, which needs a node of its own', async () => {
+    // The runs register as analyze[0], analyze[1]; without a join node named `analyze` a dependent
+    // is rejected for depending on a node that never started.
+    const result = await runPipelineFileWithExecutor(
+      file([
+        step('load', 'nb-load', { sortingKey: 'a0', exports: exp('regions', 'regions') }),
+        step('analyze', 'nb-regional', {
+          sortingKey: 'b0',
+          exports: exp('name', 'analyzed'),
+          inputs: { region: ref('region') },
+          for_each: 'regions',
+          for_each_as: 'region',
+        }),
+        step('report', 'nb-report', { sortingKey: 'c0', inputs: { all: ref('analyzed') } }),
+      ]),
+      {},
+      fakeExecutor({
+        load: { json: { regions: ['NA', 'EU'] } },
+        'analyze[0]': { json: { name: 'NA' } },
+        'analyze[1]': { json: { name: 'EU' } },
+      }).executor
+    )
+
+    expect(result.value.analyzed).toEqual(['NA', 'EU'])
+    const join = result.graph.nodes.find(node => node.id === 'analyze')
+    expect(join?.kind).toBe('join')
+    expect(result.graph.edges).toContainEqual({ from: 'analyze[0]', to: 'analyze', label: undefined })
+    expect(result.graph.edges).toContainEqual({ from: 'analyze', to: 'report', label: undefined })
+  })
+
+  it('treats an empty list as an empty result, not a skip', async () => {
+    const result = await runPipelineFileWithExecutor(
+      file([
+        step('load', 'nb-load', { sortingKey: 'a0', exports: exp('regions', 'regions') }),
+        step('analyze', 'nb-regional', {
+          sortingKey: 'b0',
+          exports: exp('x', 'analyzed'),
+          for_each: 'regions',
+          for_each_as: 'region',
+        }),
+      ]),
+      {},
+      fakeExecutor({ load: { json: { regions: [] } } }).executor
+    )
+
+    expect(result.value.analyzed).toEqual([])
+    expect(result.skipped).toEqual([])
+  })
+
+  it('skips a for_each whose array never arrived, like any other step missing a value', async () => {
+    const fake = fakeExecutor({ check: { json: { quality: { score: 0.99 } } } })
+    const result = await runPipelineFileWithExecutor(
+      file([
+        step('check', 'nb-check', { sortingKey: 'a0', exports: exp('quality', 'quality') }),
+        step('recover', 'nb-recover', {
+          sortingKey: 'b0',
+          run_if: 'quality.score < 0.95',
+          exports: exp('regions', 'recoveredRegions'),
+        }),
+        step('redo', 'nb-redo', {
+          sortingKey: 'c0',
+          for_each: 'recoveredRegions',
+          for_each_as: 'region',
+          exports: exp('x', 'redone'),
+        }),
+        step('report', 'nb-report', { sortingKey: 'd0', inputs: { all: ref('redone') } }),
+      ]),
+      {},
+      fake.executor
+    )
+
+    expect(fake.ran()).toEqual(['check'])
+    expect(result.skipped).toEqual(['recover', 'redo', 'report'])
+    expect(result.value).toEqual({ quality: { score: 0.99 } })
+  })
+
+  it('explains a for_each over something that is not an array', async () => {
+    await expect(
+      runPipelineFileWithExecutor(
+        file([
+          step('load', 'nb-load', { sortingKey: 'a0', exports: exp('regions', 'regions') }),
+          step('analyze', 'nb-regional', { sortingKey: 'b0', for_each: 'regions' }),
+        ]),
+        {},
+        fakeExecutor({ load: { json: { regions: 'not-a-list' } } }).executor
+      )
+    ).rejects.toThrow(
+      'Step "analyze" iterates "regions", which is a string. function_notebook_for_each needs an array.'
+    )
+  })
+
+  it(`refuses to fan out wider than ${MAX_FOR_EACH_WIDTH}, naming the step`, async () => {
+    const fake = fakeExecutor({
+      load: { json: { regions: Array.from({ length: MAX_FOR_EACH_WIDTH + 1 }, (_, i) => i) } },
+    })
+    await expect(
+      runPipelineFileWithExecutor(
+        file([
+          step('load', 'nb-load', { sortingKey: 'a0', exports: exp('regions', 'regions') }),
+          step('analyze', 'nb-regional', { sortingKey: 'b0', for_each: 'regions' }),
+        ]),
+        {},
+        fake.executor
+      )
+    ).rejects.toThrow(
+      `Step "analyze" would fan out to ${MAX_FOR_EACH_WIDTH + 1} runs of "regions"; the limit is ${MAX_FOR_EACH_WIDTH}.`
+    )
+    expect(fake.ran()).toEqual(['load'])
+  })
+
+  it('runs exactly the limit without complaint', async () => {
+    const fake = fakeExecutor({ load: { json: { regions: Array.from({ length: MAX_FOR_EACH_WIDTH }, (_, i) => i) } } })
+    await runPipelineFileWithExecutor(
+      file([
+        step('load', 'nb-load', { sortingKey: 'a0', exports: exp('regions', 'regions') }),
+        step('analyze', 'nb-regional', { sortingKey: 'b0', for_each: 'regions' }),
+      ]),
+      {},
+      fake.executor
+    )
+    expect(fake.ran().length).toBe(MAX_FOR_EACH_WIDTH + 1)
+  })
+})
+
+describe('fallbacks across a skipped step', () => {
+  const gated = (aggregateInput: Record<string, unknown>) =>
+    file([
+      step('first-pass', 'nb-a', { sortingKey: 'a0', exports: exp('value', 'original') }),
+      step('recover', 'nb-a', {
+        sortingKey: 'b0',
+        exports: exp('value', 'recovered'),
+        run_if: 'original.quality < 0.5',
+      }),
+      step('aggregate', 'nb-agg', { sortingKey: 'c0', inputs: { data: aggregateInput } }),
+    ])
+
+  it('uses the fallback when the preferred step was skipped, instead of cascading the skip', async () => {
+    const fake = fakeExecutor({ 'first-pass': { json: { value: { quality: 0.9 } } } })
+    const result = await runPipelineFileWithExecutor(
+      gated({ variable_name: 'recovered', fallback: ref('original') }),
+      {},
+      fake.executor
+    )
+
+    // Recovery was gated off, but aggregate still ran on the first pass rather than being skipped.
+    expect(result.skipped).toEqual(['recover'])
+    expect(fake.inputsOf('aggregate')).toEqual({ data: { quality: 0.9 } })
+    expect(result.graph.nodes.find(node => node.id === 'aggregate')?.status).toBe('success')
+  })
+
+  it('prefers the variable when it is available', async () => {
+    const fake = fakeExecutor({
+      'first-pass': { json: { value: { quality: 0.1 } } },
+      recover: { json: { value: { quality: 0.8 } } },
+    })
+    const result = await runPipelineFileWithExecutor(
+      gated({ variable_name: 'recovered', fallback: ref('original') }),
+      {},
+      fake.executor
+    )
+    expect(result.skipped).toEqual([])
+    expect(fake.inputsOf('aggregate')).toEqual({ data: { quality: 0.8 } })
+  })
+
+  it('chains fallbacks down to a literal', async () => {
+    const fake = fakeExecutor({ 'first-pass': { json: { value: { quality: 0.9 } } } })
+    await runPipelineFileWithExecutor(
+      gated({ variable_name: 'recovered', fallback: { variable_name: 'recovered', fallback: lit('none') } }),
+      {},
+      fake.executor
+    )
+    expect(fake.inputsOf('aggregate')).toEqual({ data: 'none' })
+  })
+
+  it('still skips when no alternative can be satisfied', async () => {
+    const result = await runPipelineFileWithExecutor(
+      gated(ref('recovered')),
+      {},
+      fakeExecutor({ 'first-pass': { json: { value: { quality: 0.9 } } } }).executor
+    )
+
+    expect(result.skipped.sort()).toEqual(['aggregate', 'recover'])
+  })
+})
+
+describe('allow_failure', () => {
+  it('returns a failed step as a result and leaves its exports unavailable', async () => {
+    const fake = fakeExecutor({ flaky: { fail: true } })
+    const result = await runPipelineFileWithExecutor(
+      file([
+        step('flaky', 'nb-flaky', { sortingKey: 'a0', exports: exp('value', 'flakyValue'), allow_failure: true }),
+        step('needs-it', 'nb-b', { sortingKey: 'b0', inputs: { v: ref('flakyValue') } }),
+        step('copes', 'nb-c', {
+          sortingKey: 'b1',
+          inputs: { v: { variable_name: 'flakyValue', fallback: lit('default') } },
+        }),
+      ]),
+      {},
+      fake.executor
+    )
+
+    expect(result.failed).toEqual(['flaky'])
+    expect(result.skipped).toEqual(['needs-it'])
+    expect(fake.inputsOf('copes')).toEqual({ v: 'default' })
+    expect(result.steps.find(step => step.id === 'flaky')?.success).toBe(false)
+  })
+
+  it('fails the pipeline without it', async () => {
+    await expect(
+      runPipelineFileWithExecutor(
+        file([step('flaky', 'nb-flaky', { sortingKey: 'a0' })]),
+        {},
+        fakeExecutor({ flaky: { fail: true } }).executor
+      )
+    ).rejects.toThrow('the notebook raised')
+  })
+
+  it("collects a fan-out's exports from the elements that succeeded", async () => {
+    const fake = fakeExecutor({
+      load: { json: { regions: ['NA', 'EU', 'APAC'] } },
+      'analyze[0]': { json: { name: 'NA' } },
+      'analyze[1]': { fail: true },
+      'analyze[2]': { json: { name: 'APAC' } },
+    })
+    const result = await runPipelineFileWithExecutor(
+      file([
+        step('load', 'nb-load', { sortingKey: 'a0', exports: exp('regions', 'regions') }),
+        step('analyze', 'nb-regional', {
+          sortingKey: 'b0',
+          exports: exp('name', 'analyzed'),
+          inputs: { region: ref('region') },
+          for_each: 'regions',
+          for_each_as: 'region',
+          allow_failure: true,
+        }),
+      ]),
+      {},
+      fake.executor
+    )
+    expect(result.failed).toEqual(['analyze'])
+    expect(result.value.analyzed).toEqual(['NA', 'APAC'])
+  })
+})
+
+describe('when a step fails', () => {
+  /** The error a run rejects with; fails the test when it resolves instead. */
+  async function rejection(promise: Promise<unknown>): Promise<PipelineFileError> {
+    try {
+      await promise
+    } catch (error) {
+      return error as PipelineFileError
+    }
+    throw new Error('expected the pipeline to reject')
+  }
+
+  it('treats an unreadable export on an allow_failure step as a failed step', async () => {
+    // `summarize` finishes, but prints prose instead of the JSON object its export mapping needs.
+    const fake = fakeExecutor({
+      load: { json: { portfolio: { total: 5 } } },
+      summarize: { json: 'Wrote the summary to disk.' },
+    })
+
+    const result = await runPipelineFileWithExecutor(
+      file([
+        step('load', 'nb-load', { sortingKey: 'a0', exports: exp('portfolio', 'portfolio') }),
+        step('summarize', 'nb-summarize', {
+          sortingKey: 'a1',
+          inputs: { portfolio_json: ref('portfolio') },
+          exports: exp('total', 'total'),
+          allow_failure: true,
+        }),
+        step('report', 'nb-report', {
+          sortingKey: 'a2',
+          inputs: { total: { ...ref('total'), fallback: lit('unknown') } },
+        }),
+      ]),
+      {},
+      fake.executor
+    )
+
+    expect(result.failed).toEqual(['summarize'])
+    expect(result.skipped).toEqual([])
+    expect(result.value).toEqual({ portfolio: { total: 5 } })
+    expect(fake.inputsOf('report')).toEqual({ total: 'unknown' })
+    expect(result.graph.nodes.find(node => node.id === 'summarize')?.status).toBe('success')
+  })
+
+  it('collects only the readable elements of an allow_failure fan-out', async () => {
+    const fake = fakeExecutor({
+      load: { json: { regions: ['NA', 'EU', 'APAC'] } },
+      'analyze[0]': { json: { score: 1 } },
+      'analyze[1]': { json: 'no JSON here' },
+      'analyze[2]': { json: { score: 3 } },
+    })
+
+    const result = await runPipelineFileWithExecutor(
+      file([
+        step('load', 'nb-load', { sortingKey: 'a0', exports: exp('regions', 'regions') }),
+        step('analyze', 'nb-analyze', {
+          sortingKey: 'a1',
+          for_each: 'regions',
+          for_each_as: 'region',
+          inputs: { region: ref('region') },
+          exports: exp('score', 'scores'),
+          allow_failure: true,
+        }),
+      ]),
+      {},
+      fake.executor
+    )
+
+    expect(result.failed).toEqual(['analyze'])
+    expect(result.value.scores).toEqual([1, 3])
+  })
+
+  it('fails the pipeline with a step error naming the step when the export is unreadable', async () => {
+    const fake = fakeExecutor({
+      load: { json: { portfolio: { total: 5 } } },
+      summarize: { json: 'Wrote the summary to disk.' },
+    })
+
+    const caught = await rejection(
+      runPipelineFileWithExecutor(
+        file([
+          step('load', 'nb-load', { sortingKey: 'a0', exports: exp('portfolio', 'portfolio') }),
+          step('summarize', 'nb-summarize', {
+            sortingKey: 'a1',
+            inputs: { portfolio_json: ref('portfolio') },
+            exports: exp('total', 'total'),
+          }),
+          step('report', 'nb-report', { sortingKey: 'a2', inputs: { total: ref('total') } }),
+        ]),
+        {},
+        fake.executor
+      )
+    )
+
+    expect(caught).toBeInstanceOf(PipelineStepError)
+    expect((caught as PipelineStepError).stepId).toBe('summarize')
+    expect(caught.message).toContain('Pipeline step "summarize" failed')
+    expect(caught.message).toContain('exports "total" but produced no structured JSON output')
+    expect(caught.message).toContain('It ends with: "Wrote the summary to disk."')
+    expect((caught as PipelineStepError).result?.success).toBe(true)
+    // The state so far rides along with the error, so a caller can render what did arrive.
+    expect(caught.variables).toEqual({ portfolio: { total: 5 } })
+    expect(caught.skipped).toEqual([])
+    expect(caught.failed).toEqual([])
+    expect(caught.partial?.steps.map(result => result.id)).toEqual(['load', 'summarize'])
+    expect(caught.partial?.graph.nodes.map(node => node.status)).toEqual(['success', 'success'])
+    expect(fake.ran()).toEqual(['load', 'summarize'])
+  })
+
+  it('carries the variables published before a step failed', async () => {
+    const fake = fakeExecutor({
+      na: { json: { summary: 'NA fine' } },
+      eu: { json: { summary: 'EU fine' } },
+      aggregate: { fail: true },
+    })
+
+    const caught = await rejection(
+      runPipelineFileWithExecutor(
+        file([
+          step('na', 'nb-na', { sortingKey: 'a0', exports: exp('summary', 'northAmerica') }),
+          step('eu', 'nb-eu', { sortingKey: 'a1', exports: exp('summary', 'europe') }),
+          step('aggregate', 'nb-aggregate', {
+            sortingKey: 'b0',
+            inputs: { na: ref('northAmerica'), eu: ref('europe') },
+            exports: exp('report', 'report'),
+          }),
+          step('notify', 'nb-notify', { sortingKey: 'c0', inputs: { report: ref('report') } }),
+        ]),
+        {},
+        fake.executor
+      )
+    )
+
+    expect(caught).toBeInstanceOf(PipelineStepError)
+    expect((caught as PipelineStepError).stepId).toBe('aggregate')
+    expect(caught.variables).toEqual({ northAmerica: 'NA fine', europe: 'EU fine' })
+    expect(caught.partial?.steps.map(result => [result.id, result.success])).toEqual([
+      ['na', true],
+      ['eu', true],
+      ['aggregate', false],
+    ])
+    expect(caught.partial?.graph.nodes.find(node => node.id === 'aggregate')?.status).toBe('failed')
+    expect(fake.ran()).not.toContain('notify')
+  })
+
+  it('lets a terminal allow_failure step resolve the run with every other variable present', async () => {
+    const fake = fakeExecutor({
+      na: { json: { summary: 'NA fine' } },
+      eu: { json: { summary: 'EU fine' } },
+      notify: { fail: true },
+    })
+
+    const result = await runPipelineFileWithExecutor(
+      file([
+        step('na', 'nb-na', { sortingKey: 'a0', exports: exp('summary', 'northAmerica') }),
+        step('eu', 'nb-eu', { sortingKey: 'a1', exports: exp('summary', 'europe') }),
+        step('notify', 'nb-notify', {
+          sortingKey: 'b0',
+          inputs: { na: ref('northAmerica'), eu: ref('europe') },
+          exports: exp('ticket', 'ticket'),
+          allow_failure: true,
+        }),
+      ]),
+      {},
+      fake.executor
+    )
+
+    expect(result.failed).toEqual(['notify'])
+    expect(result.value).toEqual({ northAmerica: 'NA fine', europe: 'EU fine' })
+    expect(result.steps.map(step => [step.id, step.success])).toEqual([
+      ['na', true],
+      ['eu', true],
+      ['notify', false],
+    ])
+  })
+
+  it('attaches the runner state to a plain run-time error too', async () => {
+    const fake = fakeExecutor({ load: { json: { regions: 'not a list' } } })
+
+    const caught = await rejection(
+      runPipelineFileWithExecutor(
+        file([
+          step('load', 'nb-load', { sortingKey: 'a0', exports: exp('regions', 'regions') }),
+          step('analyze', 'nb-analyze', { sortingKey: 'a1', for_each: 'regions' }),
+        ]),
+        {},
+        fake.executor
+      )
+    )
+
+    expect(caught.name).toBe('PipelineRunError')
+    expect(caught.message).toContain('function_notebook_for_each needs an array')
+    expect(caught.variables).toEqual({ regions: 'not a list' })
+    expect(caught.partial?.steps.map(result => result.id)).toEqual(['load'])
+  })
+})

--- a/packages/pipelines/src/run-pipeline-file.test.ts
+++ b/packages/pipelines/src/run-pipeline-file.test.ts
@@ -70,6 +70,8 @@ interface FakeRun {
   fail?: boolean
   /** Hold the run open this long, to observe concurrency. */
   delayMs?: number
+  /** Throw this from the executor instead of returning a result: a timeout, an API error. */
+  throws?: unknown
 }
 
 /** An executor that answers each step id with a canned result and records what it was asked to run. */
@@ -87,6 +89,9 @@ function fakeExecutor(runs: Record<string, FakeRun> = {}) {
       await new Promise(resolve => setTimeout(resolve, run.delayMs))
     }
     inFlight -= 1
+    if (run.throws !== undefined) {
+      throw run.throws
+    }
     const value = typeof run.json === 'function' ? run.json(inputs) : (run.json ?? {})
     return {
       id,
@@ -706,6 +711,54 @@ describe('when a step fails', () => {
     expect(result.value).toEqual({ portfolio: { total: 5 } })
     expect(fake.inputsOf('report')).toEqual({ total: 'unknown' })
     expect(result.graph.nodes.find(node => node.id === 'summarize')?.status).toBe('success')
+  })
+
+  it('collects from the other elements when one run of an allow_failure fan-out times out', async () => {
+    // Observed live: one cloud run hung, and after the poll timeout the whole pipeline rejected,
+    // discarding the work allow_failure was there to protect.
+    const timeout = Object.assign(new Error('Timed out waiting for Deepnote run run-eu to complete.'), {
+      name: 'RunTimeoutError',
+      runId: 'run-eu',
+    })
+    const events: PipelineEvent[] = []
+    const fake = fakeExecutor({
+      load: { json: { regions: ['NA', 'EU', 'APAC'] } },
+      'analyze[0]': { json: { score: 1 } },
+      'analyze[1]': { throws: timeout },
+      'analyze[2]': { json: { score: 3 } },
+      report: { json: { ok: true } },
+    })
+
+    const result = await runPipelineFileWithExecutor(
+      file([
+        step('load', 'nb-load', { sortingKey: 'a0', exports: exp('regions', 'regions') }),
+        step('analyze', 'nb-analyze', {
+          sortingKey: 'a1',
+          for_each: 'regions',
+          for_each_as: 'region',
+          inputs: { region: ref('region') },
+          exports: exp('score', 'scores'),
+          allow_failure: true,
+        }),
+        step('report', 'nb-report', { sortingKey: 'a2', inputs: { scores: ref('scores') } }),
+      ]),
+      { onEvent: event => events.push(event) },
+      fake.executor
+    )
+
+    expect(result.value.scores).toEqual([1, 3])
+    expect(result.failed).toEqual(['analyze'])
+    expect(fake.inputsOf('report')).toEqual({ scores: [1, 3] })
+    const timedOut = result.steps.find(step => step.id === 'analyze[1]')
+    expect(timedOut).toMatchObject({ success: false, status: 'timeout', runId: 'run-eu' })
+    expect(timedOut?.error).toContain('Timed out waiting for Deepnote run run-eu')
+    expect(result.graph.nodes.find(node => node.id === 'analyze[1]')).toMatchObject({
+      status: 'failed',
+      runId: 'run-eu',
+    })
+    const failedEvent = events.find(event => event.type === 'step_failed')
+    expect(failedEvent).toMatchObject({ type: 'step_failed', stepId: 'analyze[1]' })
+    expect((failedEvent as { result?: unknown }).result).toBe(timedOut)
   })
 
   it('collects only the readable elements of an allow_failure fan-out', async () => {

--- a/packages/pipelines/src/run-pipeline-file.ts
+++ b/packages/pipelines/src/run-pipeline-file.ts
@@ -1,0 +1,436 @@
+import type { DeepnoteFile, NotebookFunctionInput } from '@deepnote/blocks'
+import type { CloudExecutorOptions } from './cloud-executor'
+import { createCloudStepExecutor } from './cloud-executor'
+import { evaluateCondition } from './condition-expression'
+import type {
+  PipelineContext,
+  PipelineOptions,
+  PipelineResult,
+  PipelineStepExecutor,
+  PipelineStepResult,
+} from './pipeline'
+import { PipelineRunError, PipelineStepError, runPipelineWithExecutor } from './pipeline'
+import type { PipelinePlan, PlannedStep, PlanOptions } from './pipeline-plan'
+import { planPipeline } from './pipeline-plan'
+
+/**
+ * Run a pipeline that a `.deepnote` file defines.
+ *
+ * The pipeline notebook is interpreted, not executed: its `notebook-function` blocks become steps
+ * in the ordinary pipeline engine, so independent steps run concurrently and each one reports its
+ * own status — neither of which survives handing the parent to Deepnote's sequential block engine.
+ *
+ * What the file buys is that the pipeline stops being application code. The same manifest runs from
+ * a browser, a script, or CI, and it can be reviewed and versioned like the notebooks it composes.
+ */
+
+/** The most elements one `for_each` step may fan out to. More is a run-time error naming the step. */
+export const MAX_FOR_EACH_WIDTH = 50
+
+export interface PlanRunResult<T> extends PipelineResult<T> {
+  /** The plan that was executed, for a UI that wants to draw it before anything runs. */
+  plan: PipelinePlan
+  /**
+   * Steps that did not run: their `run_if` was false, or they read a value from a step that was
+   * itself skipped. Reported rather than silently absent, so a page can grey them out.
+   */
+  skipped: string[]
+  /** Steps marked `allow_failure` whose run failed. Their exports were not published. */
+  failed: string[]
+}
+
+export interface PlanPipelineResult {
+  variables: Record<string, unknown>
+  skipped: string[]
+  failed: string[]
+}
+
+/**
+ * What `runPipelineFile` rejects with: the engine's error — `partial` holds the steps and graph
+ * recorded so far — plus the file runner's own state at that moment, so a caller can render every
+ * variable that did arrive alongside the step that stopped the run.
+ */
+export type PipelineFileError = (PipelineStepError | PipelineRunError) & PlanPipelineResult
+
+/** "This variable never arrived": its producer was skipped, or failed with `allow_failure`. */
+const UNAVAILABLE = Symbol('unavailable')
+
+/**
+ * The value an input resolves to in a scope.
+ *
+ * A `variable_name` reads the pipeline variable of that name. When it is unavailable the fallback is
+ * consulted, and so on down the chain; a chain that ends without a value is UNAVAILABLE, which is
+ * what skips the step. Without a `variable_name` the input is the literal `custom_value`.
+ */
+function resolveInput(input: NotebookFunctionInput, scope: Record<string, unknown>): unknown | typeof UNAVAILABLE {
+  const name = input.variable_name
+  if (typeof name === 'string' && name !== '') {
+    if (Object.hasOwn(scope, name)) {
+      return scope[name]
+    }
+    return input.fallback ? resolveInput(input.fallback, scope) : UNAVAILABLE
+  }
+  return input.custom_value ?? null
+}
+
+/** The variables a completed step publishes, read from its structured output. */
+function exportsFrom(
+  step: { exports: Record<string, string>; id: string },
+  result: PipelineStepResult,
+  outputs: PipelineContext['outputs']
+): Record<string, unknown> {
+  const names = Object.entries(step.exports)
+  if (names.length === 0) {
+    return {}
+  }
+  // One structured value per step, read without depending on block ids — Deepnote reassigns those
+  // when it creates a notebook, so reading by id would break the first time a pipeline is published.
+  let value: unknown
+  try {
+    value = outputs.lastJson(result)
+  } catch (error) {
+    throw new Error(
+      `Step "${step.id}" exports ${names.map(([name]) => `"${name}"`).join(', ')} but produced no structured JSON output: ${
+        error instanceof Error ? error.message : String(error)
+      }`
+    )
+  }
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    throw new Error(`Step "${step.id}" exports values, so its last output must end with a JSON object.`)
+  }
+  const record = value as Record<string, unknown>
+  const published: Record<string, unknown> = {}
+  for (const [exportName, variableName] of names) {
+    if (!(exportName in record)) {
+      throw new Error(
+        `Step "${step.id}" exports "${exportName}", which its output does not contain. It produced: ${Object.keys(record).join(', ') || '(nothing)'}.`
+      )
+    }
+    published[variableName] = record[exportName]
+  }
+  return published
+}
+
+/** One run of a step: the whole step, or one element of a `for_each` fan-out. */
+interface Instance {
+  id: string
+  label: string
+  /** Variables visible to this instance — the pipeline's, plus the loop binding. */
+  scope: Record<string, unknown>
+}
+
+/**
+ * Execute a plan, running every step whose dependencies are met at the same time.
+ *
+ * This is an ordinary workflow callback, so it reuses the engine's graph, events, and output
+ * helpers rather than reimplementing them — the declarative front end and the imperative one
+ * produce identical results.
+ */
+export function pipelineForPlan(plan: PipelinePlan, state: PlanPipelineResult = emptyState()) {
+  return async ({ run, control, outputs }: PipelineContext): Promise<PlanPipelineResult> => {
+    // The runner writes into `state` as it goes, so whoever supplied it can read what had been
+    // published, skipped and tolerated even when the run ends in a rejection.
+    const { variables, skipped, failed } = state
+    const pending = new Map(plan.steps.map(step => [step.id, step]))
+    const settled = new Set<string>()
+    const running = new Map<string, Promise<void>>()
+
+    const skip = (id: string): void => {
+      skipped.push(id)
+      settled.add(id)
+      pending.delete(id)
+    }
+
+    const markFailed = (id: string): void => {
+      if (!failed.includes(id)) {
+        failed.push(id)
+      }
+    }
+
+    /**
+     * Whether every variable the step's inputs need is available, once the loop variable is bound.
+     *
+     * Checked once per step rather than per element: the element itself is always available, so an
+     * unavailable input is unavailable for every element, and the whole step is skipped.
+     */
+    const inputsAvailable = (step: PlannedStep): boolean => {
+      const scope = step.forEach ? { ...variables, [step.forEachAs]: undefined } : variables
+      return Object.values(step.inputs).every(input => resolveInput(input, scope) !== UNAVAILABLE)
+    }
+
+    /** Pass each input's resolved value to the notebook. */
+    const resolveInputs = (step: PlannedStep, scope: Record<string, unknown>): Record<string, unknown> => {
+      const resolved: Record<string, unknown> = {}
+      for (const [name, input] of Object.entries(step.inputs)) {
+        resolved[name] = resolveInput(input, scope)
+      }
+      return resolved
+    }
+
+    /**
+     * The element list a `for_each` step expands over, `null` when it is not a fan-out, or
+     * UNAVAILABLE when the array it iterates never arrived.
+     */
+    const expand = (step: PlannedStep): Instance[] | null | typeof UNAVAILABLE => {
+      if (step.forEach === undefined) {
+        return null
+      }
+      if (!Object.hasOwn(variables, step.forEach)) {
+        return UNAVAILABLE
+      }
+      const list = variables[step.forEach]
+      if (!Array.isArray(list)) {
+        throw new Error(
+          `Step "${step.id}" iterates "${step.forEach}", which is ${list === null ? 'null' : `a ${typeof list}`}. function_notebook_for_each needs an array.`
+        )
+      }
+      if (list.length > MAX_FOR_EACH_WIDTH) {
+        throw new Error(
+          `Step "${step.id}" would fan out to ${list.length} runs of "${step.forEach}"; the limit is ${MAX_FOR_EACH_WIDTH}.`
+        )
+      }
+      return list.map((item, index) => ({
+        id: `${step.id}[${index}]`,
+        label: `${step.label} ${index + 1}/${list.length}`,
+        scope: { ...variables, [step.forEachAs]: item },
+      }))
+    }
+
+    /**
+     * Give a fan-out a node of its own.
+     *
+     * Its runs are registered under `id[0]`, `id[1]`, … so without this there is no node named
+     * `id` at all, and any step declaring `dependsOn: [id]` is rejected as depending on something
+     * that never started. The join also reads correctly in the graph: N runs converging on one
+     * result, including the case where N is zero.
+     */
+    const joinFanOut = async (step: PlannedStep, instanceIds: string[], fallback: string[]): Promise<void> => {
+      await control(
+        {
+          id: step.id,
+          kind: 'join',
+          label: step.label,
+          dependsOn: instanceIds.length > 0 ? instanceIds : fallback,
+          metadata: { elements: instanceIds.length },
+        },
+        () => null
+      )
+    }
+
+    /** Decide whether one instance runs: its gate, if it has one. */
+    const admit = async (step: PlannedStep, instance: Instance, dependsOn: string[]): Promise<boolean> => {
+      if (!step.condition) {
+        return true
+      }
+      // The gate is a control node, so the decision appears in the graph next to the step it
+      // governs instead of happening invisibly. A variable whose producer was skipped reads as
+      // absent here, so a gate can still ask `recovered == null`.
+      return Boolean(
+        await control(
+          {
+            id: `${instance.id}-gate`,
+            kind: 'gate',
+            label: step.condition,
+            dependsOn,
+            metadata: { condition: step.condition },
+          },
+          () => evaluateCondition(step.condition as string, instance.scope)
+        )
+      )
+    }
+
+    /**
+     * Read one run's exports, treating an unreadable export like a failed run.
+     *
+     * A notebook that finished but printed no JSON object, or one missing an exported key, has not
+     * delivered what the pipeline asked of it. Under `allow_failure` the step is recorded in `failed`
+     * and publishes nothing from this run; otherwise it fails the pipeline as a step error naming
+     * the step, so the caller learns which notebook to fix rather than seeing a bare message.
+     */
+    const readExports = (
+      step: PlannedStep,
+      { instance, result }: { instance: Instance; result: PipelineStepResult }
+    ): Record<string, unknown> | null => {
+      try {
+        return exportsFrom(step, result, outputs)
+      } catch (error) {
+        if (step.allowFailure) {
+          markFailed(step.id)
+          return null
+        }
+        throw new PipelineStepError(instance.id, error instanceof Error ? error.message : String(error), {
+          result,
+          cause: error,
+        })
+      }
+    }
+
+    /**
+     * Publish a step's exports. A fan-out collects one array per exported name, in element order.
+     *
+     * A failed run (allowed by `allow_failure`) publishes nothing: a plain step's variables stay
+     * unavailable, and a fan-out collects only from the elements that succeeded — and, of those,
+     * only the ones whose output could be read.
+     */
+    const publish = (step: PlannedStep, results: { instance: Instance; result: PipelineStepResult }[]): void => {
+      if (Object.keys(step.exports).length === 0) {
+        return
+      }
+      const succeeded = results.filter(({ result }) => result.success)
+      if (step.forEach === undefined) {
+        const only = succeeded[0]
+        if (only) {
+          const published = readExports(step, only)
+          if (published) {
+            Object.assign(variables, published)
+          }
+        }
+        return
+      }
+      const collected: Record<string, unknown[]> = {}
+      for (const variableName of Object.values(step.exports)) {
+        collected[variableName] = []
+      }
+      for (const entry of succeeded) {
+        const published = readExports(step, entry)
+        if (!published) {
+          continue
+        }
+        for (const [variableName, value] of Object.entries(published)) {
+          collected[variableName].push(value)
+        }
+      }
+      Object.assign(variables, collected)
+    }
+
+    while (settled.size < plan.steps.length) {
+      const ready = [...pending.values()].filter(step => step.dependsOn.every(id => settled.has(id)))
+
+      if (ready.length === 0 && running.size === 0) {
+        // Guarded against at plan time; reaching it means a step never settled.
+        throw new Error('The pipeline stalled: no step is ready and none is running.')
+      }
+
+      for (const step of ready) {
+        pending.delete(step.id)
+
+        // A step whose inputs — or whose array — can never resolve is skipped rather than started
+        // with a value that will never arrive. That is what propagates a skip downstream, and what
+        // a fallback interrupts.
+        const expanded = inputsAvailable(step) ? expand(step) : UNAVAILABLE
+        if (expanded === UNAVAILABLE) {
+          skip(step.id)
+          continue
+        }
+
+        const instances = expanded ?? [{ id: step.id, label: step.label, scope: variables }]
+        const gateDependsOn = step.dependsOn.filter(id => !skipped.includes(id))
+
+        const admitted: Instance[] = []
+        for (const instance of instances) {
+          if (await admit(step, instance, gateDependsOn)) {
+            admitted.push(instance)
+          }
+        }
+
+        if (admitted.length === 0) {
+          // A fan-out that ran nothing publishes empty arrays rather than being skipped, whether
+          // the list was empty or every element was gated off — both mean "no element qualified",
+          // and downstream deserves the same answer either way. A plain step is different: it
+          // publishes a value, not a collection, so "none" there really is absent.
+          if (step.forEach !== undefined) {
+            publish(step, [])
+            await joinFanOut(step, [], gateDependsOn)
+            settled.add(step.id)
+          } else {
+            skip(step.id)
+          }
+          continue
+        }
+
+        running.set(
+          step.id,
+          Promise.all(
+            admitted.map(instance =>
+              run({
+                id: instance.id,
+                label: instance.label,
+                notebookId: step.notebookId,
+                dependsOn: step.condition ? [`${instance.id}-gate`] : gateDependsOn,
+                inputs: resolveInputs(step, instance.scope),
+                allowFailure: step.allowFailure,
+              }).then(result => ({ instance, result }))
+            )
+          ).then(async results => {
+            if (results.some(({ result }) => !result.success)) {
+              markFailed(step.id)
+            }
+            publish(step, results)
+            if (step.forEach !== undefined) {
+              await joinFanOut(
+                step,
+                results.map(({ instance }) => instance.id),
+                gateDependsOn
+              )
+            }
+            settled.add(step.id)
+            running.delete(step.id)
+          })
+        )
+      }
+
+      // Wake as soon as any step finishes so its dependents can start, rather than waiting for the
+      // whole wave — a slow step must not hold back work that no longer depends on it.
+      if (running.size > 0) {
+        await Promise.race(running.values())
+      }
+    }
+
+    return state
+  }
+}
+
+function emptyState(): PlanPipelineResult {
+  return { variables: {}, skipped: [], failed: [] }
+}
+
+export interface PipelineFileOptions extends PipelineOptions, PlanOptions {}
+
+/**
+ * Run the pipeline a `.deepnote` file defines, in Deepnote Cloud.
+ *
+ * This is the file-defined counterpart to `runPipeline`: same engine, same events, same graph —
+ * the pipeline comes from a definition rather than from code.
+ */
+export async function runPipelineFile(
+  file: DeepnoteFile,
+  options: PipelineFileOptions & CloudExecutorOptions
+): Promise<PlanRunResult<Record<string, unknown>>> {
+  return runPipelineFileWithExecutor(file, options, createCloudStepExecutor(options))
+}
+
+/**
+ * Plan a `.deepnote` file and run it with a caller-supplied executor.
+ *
+ * Rejects with a {@link PipelineFileError}: the engine's error, carrying the partial run, with the
+ * runner's `variables`, `skipped` and `failed` so far attached alongside it.
+ */
+export async function runPipelineFileWithExecutor(
+  file: DeepnoteFile,
+  options: PipelineFileOptions,
+  execute: PipelineStepExecutor
+): Promise<PlanRunResult<Record<string, unknown>>> {
+  const plan = planPipeline(file, options)
+  const state = emptyState()
+  let result: PipelineResult<PlanPipelineResult>
+  try {
+    result = await runPipelineWithExecutor(pipelineForPlan(plan, state), options, execute)
+  } catch (error) {
+    if (error instanceof PipelineStepError || error instanceof PipelineRunError) {
+      const failure: PipelineFileError = Object.assign(error, state)
+      throw failure
+    }
+    throw error
+  }
+  return { ...result, value: result.value.variables, plan, skipped: result.value.skipped, failed: result.value.failed }
+}

--- a/skills/deepnote/SKILL.md
+++ b/skills/deepnote/SKILL.md
@@ -82,6 +82,7 @@ Every block has these common fields:
 - [Text blocks](references/blocks-text.md)
 - [Input blocks](references/blocks-input.md)
 - [Display and action blocks](references/blocks-display.md)
+- [Pipeline notebooks and steps](references/blocks-pipeline.md)
 
 ## Integrations
 

--- a/skills/deepnote/references/blocks-pipeline.md
+++ b/skills/deepnote/references/blocks-pipeline.md
@@ -18,16 +18,16 @@ A file with no marked notebook, or with more than one, is rejected at plan time 
 
 **Metadata fields:**
 
-| Field                               | Type                            | Required | Description                                                                                         |
-| ----------------------------------- | ------------------------------- | -------- | --------------------------------------------------------------------------------------------------- |
-| `function_notebook_id`              | `string \| null`                | yes      | Id of the notebook this step runs. `null` is a plan-time error.                                     |
-| `function_notebook_inputs`          | `Record<string, Input>`         | no       | Input-block name → what to pass (see below).                                                        |
-| `function_notebook_export_mappings` | `Record<string, ExportMapping>` | no       | Field in the notebook's last JSON output → pipeline variable it publishes.                          |
-| `function_notebook_run_if`          | `string`                        | no       | Condition; the step runs only when it holds. Evaluated per element on a fan-out.                    |
-| `function_notebook_for_each`        | `string`                        | no       | Name of a pipeline variable holding an array. The step runs once per element, concurrently.         |
-| `function_notebook_for_each_as`     | `string`                        | no       | Name each element is bound to (default `item`). Usable as an input `variable_name` and in `run_if`. |
-| `function_notebook_allow_failure`   | `boolean`                       | no       | Return a failed run as a result instead of failing the pipeline (default `false`).                  |
-| `name`                              | `string`                        | no       | Display label; the block id is used when absent.                                                    |
+| Field                               | Type                            | Required | Description                                                                                                            |
+| ----------------------------------- | ------------------------------- | -------- | ---------------------------------------------------------------------------------------------------------------------- |
+| `function_notebook_id`              | `string \| null`                | yes      | Id of the notebook this step runs. `null` is a plan-time error.                                                        |
+| `function_notebook_inputs`          | `Record<string, Input>`         | no       | Input-block name → what to pass (see below).                                                                           |
+| `function_notebook_export_mappings` | `Record<string, ExportMapping>` | no       | Field in the notebook's last JSON output → pipeline variable it publishes.                                             |
+| `function_notebook_run_if`          | `string`                        | no       | Condition; the step runs only when it holds. Evaluated per element on a fan-out.                                       |
+| `function_notebook_for_each`        | `string`                        | no       | Name of a pipeline variable holding an array. The step runs once per element, concurrently.                            |
+| `function_notebook_for_each_as`     | `string`                        | no       | Name each element is bound to (default `item`). Usable as an input `variable_name` and in `run_if`.                    |
+| `function_notebook_allow_failure`   | `boolean`                       | no       | Return a failed run as a result instead of failing the pipeline (default `false`). Covers timeouts and API errors too. |
+| `name`                              | `string`                        | no       | Display label; the block id is used when absent.                                                                       |
 
 **Input** (each value in `function_notebook_inputs`):
 
@@ -76,7 +76,7 @@ Comparison rule: when both operands are numbers or numeric strings they compare 
 - A step whose input (after its `fallback` chain) refers to a variable that never arrived is skipped. So is a `for_each` over such a variable. This is how a skip propagates downstream, and what `fallback` interrupts.
 - A fan-out over an empty array, or whose every element was gated off, is not skipped: it publishes empty arrays.
 - A `for_each` over something that is not an array, or over more than 50 elements, is a run-time error naming the step.
-- A failed run fails the pipeline unless `function_notebook_allow_failure` is `true`; then the failed result is returned, the step publishes nothing, and dependents fall back or are skipped. On a fan-out, exports collect from the elements that succeeded.
+- A failed run fails the pipeline unless `function_notebook_allow_failure` is `true`; then the failed result is returned, the step publishes nothing, and dependents fall back or are skipped. On a fan-out, exports collect from the elements that succeeded. `allow_failure` covers every way a step can fail — a notebook that finished with an error status, a poll that timed out, a transport or API error, a run that produced no snapshot — and the returned result's `status` (`timeout` when the runner stopped waiting, `error` for the rest, otherwise Deepnote's run status) and `error` say which. A timed-out run may still be executing in Deepnote; its `runId` is on the result.
 - A run that finishes but whose exports cannot be read — no JSON object ends its output, or the object lacks an exported key — counts as a failed step. With `allow_failure` it is listed in `failed`, publishes nothing, and emits no further event; on a fan-out only the readable elements are collected. Without `allow_failure` it fails the pipeline with a step error naming the step.
 
 When the pipeline fails, the run so far is not discarded. The error is a `PipelineStepError` (a step failed, or its exports could not be read) or a `PipelineRunError` (anything else the run threw, with the original error as `cause`), and both carry `partial`: the step results that finished in start order, the graph with each node's status, and `startedAt`, `finishedAt`, `durationMs`. The file runner also attaches `variables`, `skipped` and `failed` as they stood when the run stopped, so a caller can render every value that did arrive next to the step that stopped the run. A terminal step marked `allow_failure` therefore never fails the run: it resolves with every other variable present and the step in `failed`.

--- a/skills/deepnote/references/blocks-pipeline.md
+++ b/skills/deepnote/references/blocks-pipeline.md
@@ -1,0 +1,152 @@
+# Pipeline Notebooks
+
+> Common block fields (`id`, `blockGroup`, `type`, `content`, `sortingKey`, `metadata`) are described in [SKILL.md](../SKILL.md).
+
+A pipeline is a notebook marked `isPipeline: true` whose `notebook-function` blocks are its steps. Each step names an external notebook to run, the inputs to run it with, and the values it publishes as pipeline variables. The pipeline notebook is read as a manifest rather than executed: `@deepnote/pipelines` derives a dependency graph from variable flow, runs independent steps concurrently, and reports each one separately.
+
+The encoding is the one deepnote.com stores for a notebook-function block. There is no templating and no expression syntax inside inputs — a value is either a reference to a variable by name, or a literal.
+
+## Pipeline marker
+
+| Field        | Type      | Description                                                                                     |
+| ------------ | --------- | ----------------------------------------------------------------------------------------------- |
+| `isPipeline` | `boolean` | Set on exactly one notebook in `project.notebooks`. Its notebook-function blocks are the steps. |
+
+A file with no marked notebook, or with more than one, is rejected at plan time (a caller may name the notebook explicitly instead). Steps run in `sortingKey` order only where dependencies require it.
+
+## Step block (`notebook-function`)
+
+**Metadata fields:**
+
+| Field                               | Type                            | Required | Description                                                                                         |
+| ----------------------------------- | ------------------------------- | -------- | --------------------------------------------------------------------------------------------------- |
+| `function_notebook_id`              | `string \| null`                | yes      | Id of the notebook this step runs. `null` is a plan-time error.                                     |
+| `function_notebook_inputs`          | `Record<string, Input>`         | no       | Input-block name → what to pass (see below).                                                        |
+| `function_notebook_export_mappings` | `Record<string, ExportMapping>` | no       | Field in the notebook's last JSON output → pipeline variable it publishes.                          |
+| `function_notebook_run_if`          | `string`                        | no       | Condition; the step runs only when it holds. Evaluated per element on a fan-out.                    |
+| `function_notebook_for_each`        | `string`                        | no       | Name of a pipeline variable holding an array. The step runs once per element, concurrently.         |
+| `function_notebook_for_each_as`     | `string`                        | no       | Name each element is bound to (default `item`). Usable as an input `variable_name` and in `run_if`. |
+| `function_notebook_allow_failure`   | `boolean`                       | no       | Return a failed run as a result instead of failing the pipeline (default `false`).                  |
+| `name`                              | `string`                        | no       | Display label; the block id is used when absent.                                                    |
+
+**Input** (each value in `function_notebook_inputs`):
+
+| Field           | Type             | Description                                                                                                  |
+| --------------- | ---------------- | ------------------------------------------------------------------------------------------------------------ |
+| `variable_name` | `string \| null` | A pipeline variable: another step's export, or this step's `for_each_as` element. Creates a dependency edge. |
+| `custom_value`  | `any`            | A literal, passed as written. Used when `variable_name` is not set.                                          |
+| `fallback`      | `Input`          | Used when `variable_name` refers to a variable whose producer was skipped or failed. May chain.              |
+
+deepnote.com writes both `variable_name` and `custom_value` (one of them `null`); the variable wins when it is a non-empty string. A `variable_name` is a plain identifier — no dotted paths. Read a field in `run_if`, or export the field from the step that produces it.
+
+**ExportMapping** (each value in `function_notebook_export_mappings`):
+
+| Field           | Type             | Description                                                               |
+| --------------- | ---------------- | ------------------------------------------------------------------------- |
+| `enabled`       | `boolean`        | Disabled mappings publish nothing.                                        |
+| `variable_name` | `string \| null` | The pipeline variable name. Each variable may come from exactly one step. |
+
+Exports are read from the JSON object that ends the notebook's output, keyed by the mapping's key. The last block's output must _end_ with a JSON object; anything printed before it on earlier lines is ignored, so a summary `print` before the `json.dumps` is fine, and pretty-printed JSON spanning several lines parses. A later block that prints only prose is skipped. When nothing parses, the error quotes the last 200 characters the block printed. On a fan-out, each exported variable collects one value per element, in element order — an empty array when no element ran.
+
+Deepnote input blocks accept strings, booleans and lists of strings (numbers are sent as strings), so a structure that has to cross into another notebook should be exported as a JSON string.
+
+The runs API rejects arrays for text inputs, so a variable that holds a fan-out's collected list can only feed an `input-select` block with `deepnote_allow_multiple_values: true`. Passing it to an `input-text` block fails the step. In the consuming notebook:
+
+```yaml
+- type: input-select
+  metadata:
+    { deepnote_variable_name: regions, deepnote_allow_multiple_values: true }
+```
+
+with the step's input `regions: { variable_name: regions }` where `regions` is the fan-out's collected variable.
+
+## Dependencies
+
+Edges are derived, never declared: a step depends on every step whose variable it reads — in an input, in any `fallback` of that input, in `function_notebook_for_each`, or in `function_notebook_run_if`. The `for_each_as` element is bound by the step itself and is not a dependency.
+
+## Conditions (`function_notebook_run_if`)
+
+A small expression language, not JavaScript: variable paths (`quality.score`, `tags[0]`), literals (numbers, quoted strings, `true`, `false`, `null`), comparisons (`< <= > >= == !=`), `&& || !`, and parentheses. No calls, no assignment, and own-property lookups only. A malformed condition is a plan-time error.
+
+Comparison rule: when both operands are numbers or numeric strings they compare numerically (`"6" == 6` is true, `"10" > "9"` is true); otherwise strictly (`"a" == 6` is false). `==` treats absent as `null`, so `recovered == null` asks whether a skipped step published anything.
+
+## Skipping and failure
+
+- A false `run_if` skips the step.
+- A step whose input (after its `fallback` chain) refers to a variable that never arrived is skipped. So is a `for_each` over such a variable. This is how a skip propagates downstream, and what `fallback` interrupts.
+- A fan-out over an empty array, or whose every element was gated off, is not skipped: it publishes empty arrays.
+- A `for_each` over something that is not an array, or over more than 50 elements, is a run-time error naming the step.
+- A failed run fails the pipeline unless `function_notebook_allow_failure` is `true`; then the failed result is returned, the step publishes nothing, and dependents fall back or are skipped. On a fan-out, exports collect from the elements that succeeded.
+- A run that finishes but whose exports cannot be read — no JSON object ends its output, or the object lacks an exported key — counts as a failed step. With `allow_failure` it is listed in `failed`, publishes nothing, and emits no further event; on a fan-out only the readable elements are collected. Without `allow_failure` it fails the pipeline with a step error naming the step.
+
+When the pipeline fails, the run so far is not discarded. The error is a `PipelineStepError` (a step failed, or its exports could not be read) or a `PipelineRunError` (anything else the run threw, with the original error as `cause`), and both carry `partial`: the step results that finished in start order, the graph with each node's status, and `startedAt`, `finishedAt`, `durationMs`. The file runner also attaches `variables`, `skipped` and `failed` as they stood when the run stopped, so a caller can render every value that did arrive next to the step that stopped the run. A terminal step marked `allow_failure` therefore never fails the run: it resolves with every other variable present and the step in `failed`.
+
+Plan-time errors (before anything runs): no or multiple `isPipeline` notebooks, a pipeline notebook with no steps, a step with `function_notebook_id: null`, a variable no step exports, two steps exporting one variable, a variable reference that is not a plain identifier, `for_each_as` without `for_each` or shadowing an export, a malformed condition, and a dependency cycle.
+
+## Example
+
+```yaml
+project:
+  notebooks:
+    - id: pipeline
+      name: Regional review
+      isPipeline: true
+      blocks:
+        - id: load
+          blockGroup: g-load
+          sortingKey: a0
+          type: notebook-function
+          metadata:
+            function_notebook_id: nb-config
+            function_notebook_export_mappings:
+              regions:
+                enabled: true
+                variable_name: regions
+        - id: analyze
+          blockGroup: g-analyze
+          sortingKey: b0
+          type: notebook-function
+          metadata:
+            function_notebook_id: nb-regional
+            function_notebook_for_each: regions
+            function_notebook_for_each_as: region
+            function_notebook_inputs:
+              region:
+                variable_name: region
+              trailing_months:
+                custom_value: "6"
+            function_notebook_export_mappings:
+              summary_json:
+                enabled: true
+                variable_name: summaries
+              quality_score:
+                enabled: true
+                variable_name: qualityScores
+        - id: escalate
+          blockGroup: g-escalate
+          sortingKey: c0
+          type: notebook-function
+          metadata:
+            function_notebook_id: nb-escalate
+            function_notebook_run_if: qualityScores[0] < 0.95 || qualityScores[1] < 0.95
+            function_notebook_allow_failure: true
+            function_notebook_export_mappings:
+              ticket:
+                enabled: true
+                variable_name: ticket
+        - id: report
+          blockGroup: g-report
+          sortingKey: d0
+          type: notebook-function
+          metadata:
+            function_notebook_id: nb-report
+            function_notebook_inputs:
+              summaries_json:
+                variable_name: summaries
+              ticket:
+                variable_name: ticket
+                fallback:
+                  custom_value: none
+```
+
+`analyze` runs once per element of `regions` and collects `summaries` and `qualityScores`. `escalate` depends on `analyze` through its condition alone, and a failure there does not stop the run. `report` depends on both; when `escalate` was skipped or failed, `ticket` is `"none"` rather than the step being skipped.

--- a/skills/deepnote/references/schema.ts
+++ b/skills/deepnote/references/schema.ts
@@ -394,11 +394,22 @@ export type DeepnoteBlock =
         };
         function_notebook_id: string | null;
         function_notebook_inputs?: {
-          [k: string]: any;
+          [k: string]: {
+            variable_name?: string | null;
+            custom_value?: any;
+            fallback?: any;
+          };
         };
         function_notebook_export_mappings?: {
-          [k: string]: any;
+          [k: string]: {
+            enabled: boolean;
+            variable_name: string | null;
+          };
         };
+        function_notebook_run_if?: string;
+        function_notebook_for_each?: string;
+        function_notebook_for_each_as?: string;
+        function_notebook_allow_failure?: boolean;
         [k: string]: any;
       };
     }
@@ -1356,11 +1367,22 @@ export interface DeepnoteFile {
               };
               function_notebook_id: string | null;
               function_notebook_inputs?: {
-                [k: string]: any;
+                [k: string]: {
+                  variable_name?: string | null;
+                  custom_value?: any;
+                  fallback?: any;
+                };
               };
               function_notebook_export_mappings?: {
-                [k: string]: any;
+                [k: string]: {
+                  enabled: boolean;
+                  variable_name: string | null;
+                };
               };
+              function_notebook_run_if?: string;
+              function_notebook_for_each?: string;
+              function_notebook_for_each_as?: string;
+              function_notebook_allow_failure?: boolean;
               [k: string]: any;
             };
           }
@@ -1884,6 +1906,7 @@ export interface DeepnoteFile {
       executionMode?: 'block' | 'downstream';
       id: string;
       isModule?: boolean;
+      isPipeline?: boolean;
       name: string;
       workingDirectory?: string;
     }[];

--- a/test-fixtures/pipeline-conformance/condition-only-dependency.deepnote
+++ b/test-fixtures/pipeline-conformance/condition-only-dependency.deepnote
@@ -1,0 +1,34 @@
+# The gate is the *only* thing that reads `quality`: the step's inputs never mention it.
+# So the dependency edge exists solely because the condition consults it — which is the case a
+# planner is most likely to get wrong.
+metadata:
+  createdAt: '2026-08-27T00:00:00.000Z'
+project:
+  id: conformance-condition-dependency
+  name: Conformance - condition-only dependency
+  notebooks:
+    - id: pipeline-notebook
+      name: Pipeline
+      isPipeline: true
+      blocks:
+        - blockGroup: g-check
+          id: check
+          sortingKey: a0
+          type: notebook-function
+          metadata:
+            function_notebook_id: nb-check
+            function_notebook_export_mappings:
+              quality:
+                enabled: true
+                variable_name: quality
+        - blockGroup: g-notify
+          id: notify
+          sortingKey: b0
+          type: notebook-function
+          metadata:
+            function_notebook_id: nb-notify
+            function_notebook_run_if: quality.score < 0.95 && !quality.suppressed
+            function_notebook_inputs:
+              channel:
+                custom_value: alerts
+version: '1.0.0'

--- a/test-fixtures/pipeline-conformance/condition-only-dependency.expected.json
+++ b/test-fixtures/pipeline-conformance/condition-only-dependency.expected.json
@@ -1,0 +1,36 @@
+{
+  "notebookId": "pipeline-notebook",
+  "notebookName": "Pipeline",
+  "steps": [
+    {
+      "id": "check",
+      "label": "check",
+      "notebookId": "nb-check",
+      "inputs": {},
+      "exports": {
+        "quality": "quality"
+      },
+      "forEachAs": "item",
+      "allowFailure": false,
+      "dependsOn": []
+    },
+    {
+      "id": "notify",
+      "label": "notify",
+      "notebookId": "nb-notify",
+      "inputs": {
+        "channel": {
+          "custom_value": "alerts"
+        }
+      },
+      "exports": {},
+      "condition": "quality.score < 0.95 && !quality.suppressed",
+      "forEachAs": "item",
+      "allowFailure": false,
+      "dependsOn": ["check"]
+    }
+  ],
+  "producedBy": {
+    "quality": "check"
+  }
+}

--- a/test-fixtures/pipeline-conformance/fan-out-and-gate.deepnote
+++ b/test-fixtures/pipeline-conformance/fan-out-and-gate.deepnote
@@ -1,0 +1,94 @@
+# Exercises the whole surface: a fan-out sized by data, a second fan-out over the first one's
+# collected exports with a per-element run_if, a fallback for a value that may never arrive, and a
+# plain gate at the end.
+metadata:
+  createdAt: '2026-08-27T00:00:00.000Z'
+project:
+  id: conformance-fan-out
+  name: Conformance - fan out and gate
+  notebooks:
+    - id: pipeline-notebook
+      name: Pipeline
+      isPipeline: true
+      blocks:
+        - blockGroup: g-load
+          id: load
+          sortingKey: a0
+          type: notebook-function
+          metadata:
+            name: Regions to analyze
+            function_notebook_id: nb-config
+            function_notebook_export_mappings:
+              regions:
+                enabled: true
+                variable_name: regions
+        # One run per region; `region` is the element, so it is not a dependency on anything.
+        - blockGroup: g-analyze
+          id: analyze
+          sortingKey: b0
+          type: notebook-function
+          metadata:
+            name: Regional analysis
+            function_notebook_id: nb-regional
+            function_notebook_for_each: regions
+            function_notebook_for_each_as: region
+            function_notebook_inputs:
+              region:
+                variable_name: region
+              trailing_months:
+                custom_value: '6'
+            function_notebook_export_mappings:
+              region:
+                enabled: true
+                variable_name: analyzed
+        # Iterates the previous fan-out's collected exports; the gate is evaluated per element.
+        - blockGroup: g-recover
+          id: recover
+          sortingKey: c0
+          type: notebook-function
+          metadata:
+            name: Recovery
+            function_notebook_id: nb-regional
+            function_notebook_for_each: analyzed
+            function_notebook_for_each_as: region
+            function_notebook_run_if: region.qualityScore < 0.95
+            function_notebook_inputs:
+              region:
+                variable_name: region
+              backfill_missing:
+                custom_value: 'true'
+            function_notebook_export_mappings:
+              region:
+                enabled: true
+                variable_name: recovered
+        - blockGroup: g-aggregate
+          id: aggregate
+          sortingKey: d0
+          type: notebook-function
+          metadata:
+            name: Aggregate
+            function_notebook_id: nb-aggregate
+            function_notebook_inputs:
+              regions_json:
+                variable_name: analyzed
+              recovered_json:
+                variable_name: recovered
+                fallback:
+                  custom_value: null
+            function_notebook_export_mappings:
+              portfolio:
+                enabled: true
+                variable_name: portfolio
+        - blockGroup: g-arbiter
+          id: arbiter
+          sortingKey: e0
+          type: notebook-function
+          metadata:
+            name: Final decision
+            function_notebook_id: nb-arbiter
+            function_notebook_run_if: portfolio.forecastK < portfolio.targetK
+            function_notebook_allow_failure: true
+            function_notebook_inputs:
+              context_json:
+                variable_name: portfolio
+version: '1.0.0'

--- a/test-fixtures/pipeline-conformance/fan-out-and-gate.expected.json
+++ b/test-fixtures/pipeline-conformance/fan-out-and-gate.expected.json
@@ -1,0 +1,102 @@
+{
+  "notebookId": "pipeline-notebook",
+  "notebookName": "Pipeline",
+  "steps": [
+    {
+      "id": "load",
+      "label": "Regions to analyze",
+      "notebookId": "nb-config",
+      "inputs": {},
+      "exports": {
+        "regions": "regions"
+      },
+      "forEachAs": "item",
+      "allowFailure": false,
+      "dependsOn": []
+    },
+    {
+      "id": "analyze",
+      "label": "Regional analysis",
+      "notebookId": "nb-regional",
+      "inputs": {
+        "region": {
+          "variable_name": "region"
+        },
+        "trailing_months": {
+          "custom_value": "6"
+        }
+      },
+      "exports": {
+        "region": "analyzed"
+      },
+      "forEach": "regions",
+      "forEachAs": "region",
+      "allowFailure": false,
+      "dependsOn": ["load"]
+    },
+    {
+      "id": "recover",
+      "label": "Recovery",
+      "notebookId": "nb-regional",
+      "inputs": {
+        "region": {
+          "variable_name": "region"
+        },
+        "backfill_missing": {
+          "custom_value": "true"
+        }
+      },
+      "exports": {
+        "region": "recovered"
+      },
+      "condition": "region.qualityScore < 0.95",
+      "forEach": "analyzed",
+      "forEachAs": "region",
+      "allowFailure": false,
+      "dependsOn": ["analyze"]
+    },
+    {
+      "id": "aggregate",
+      "label": "Aggregate",
+      "notebookId": "nb-aggregate",
+      "inputs": {
+        "regions_json": {
+          "variable_name": "analyzed"
+        },
+        "recovered_json": {
+          "variable_name": "recovered",
+          "fallback": {
+            "custom_value": null
+          }
+        }
+      },
+      "exports": {
+        "portfolio": "portfolio"
+      },
+      "forEachAs": "item",
+      "allowFailure": false,
+      "dependsOn": ["analyze", "recover"]
+    },
+    {
+      "id": "arbiter",
+      "label": "Final decision",
+      "notebookId": "nb-arbiter",
+      "inputs": {
+        "context_json": {
+          "variable_name": "portfolio"
+        }
+      },
+      "exports": {},
+      "condition": "portfolio.forecastK < portfolio.targetK",
+      "forEachAs": "item",
+      "allowFailure": true,
+      "dependsOn": ["aggregate"]
+    }
+  ],
+  "producedBy": {
+    "regions": "load",
+    "analyzed": "analyze",
+    "recovered": "recover",
+    "portfolio": "aggregate"
+  }
+}

--- a/test-fixtures/pipeline-conformance/linear.deepnote
+++ b/test-fixtures/pipeline-conformance/linear.deepnote
@@ -1,0 +1,32 @@
+# The simplest shape: two steps, one dependency, no extensions.
+# The step that reads `portfolio` depends on the step that exports it — nothing is declared twice.
+metadata:
+  createdAt: '2026-08-27T00:00:00.000Z'
+project:
+  id: conformance-linear
+  name: Conformance - linear
+  notebooks:
+    - id: pipeline-notebook
+      name: Pipeline
+      isPipeline: true
+      blocks:
+        - blockGroup: g-load
+          id: load
+          sortingKey: a0
+          type: notebook-function
+          metadata:
+            function_notebook_id: nb-load
+            function_notebook_export_mappings:
+              portfolio:
+                enabled: true
+                variable_name: portfolio
+        - blockGroup: g-review
+          id: review
+          sortingKey: a1
+          type: notebook-function
+          metadata:
+            function_notebook_id: nb-review
+            function_notebook_inputs:
+              portfolio_json:
+                variable_name: portfolio
+version: '1.0.0'

--- a/test-fixtures/pipeline-conformance/linear.expected.json
+++ b/test-fixtures/pipeline-conformance/linear.expected.json
@@ -1,0 +1,35 @@
+{
+  "notebookId": "pipeline-notebook",
+  "notebookName": "Pipeline",
+  "steps": [
+    {
+      "id": "load",
+      "label": "load",
+      "notebookId": "nb-load",
+      "inputs": {},
+      "exports": {
+        "portfolio": "portfolio"
+      },
+      "forEachAs": "item",
+      "allowFailure": false,
+      "dependsOn": []
+    },
+    {
+      "id": "review",
+      "label": "review",
+      "notebookId": "nb-review",
+      "inputs": {
+        "portfolio_json": {
+          "variable_name": "portfolio"
+        }
+      },
+      "exports": {},
+      "forEachAs": "item",
+      "allowFailure": false,
+      "dependsOn": ["load"]
+    }
+  ],
+  "producedBy": {
+    "portfolio": "load"
+  }
+}

--- a/test-fixtures/pipeline-conformance/skip-and-fallback.deepnote
+++ b/test-fixtures/pipeline-conformance/skip-and-fallback.deepnote
@@ -1,0 +1,119 @@
+# Execution semantics, checked against skip-and-fallback.expected-results.json with a fake executor:
+# a false gate skips `recover`; the skip propagates to `redo` (a for_each over a variable that never
+# arrived) and to `audit` (an input with no fallback); `report` survives through fallbacks, one to a
+# literal and one to another variable; `notify` fans out over an available array; `flaky` fails with
+# allow_failure and publishes nothing, so `after-flaky` runs on its fallback.
+metadata:
+  createdAt: '2026-08-27T00:00:00.000Z'
+project:
+  id: conformance-skip-and-fallback
+  name: Conformance - skip and fallback
+  notebooks:
+    - id: pipeline-notebook
+      name: Pipeline
+      isPipeline: true
+      blocks:
+        - blockGroup: g-check
+          id: check
+          sortingKey: a0
+          type: notebook-function
+          metadata:
+            function_notebook_id: nb-check
+            function_notebook_export_mappings:
+              quality:
+                enabled: true
+                variable_name: quality
+              regions:
+                enabled: true
+                variable_name: regions
+        - blockGroup: g-flaky
+          id: flaky
+          sortingKey: a1
+          type: notebook-function
+          metadata:
+            function_notebook_id: nb-flaky
+            function_notebook_allow_failure: true
+            function_notebook_export_mappings:
+              value:
+                enabled: true
+                variable_name: flakyValue
+        - blockGroup: g-recover
+          id: recover
+          sortingKey: b0
+          type: notebook-function
+          metadata:
+            function_notebook_id: nb-recover
+            function_notebook_run_if: quality.score < 0.95
+            function_notebook_export_mappings:
+              regions:
+                enabled: true
+                variable_name: recoveredRegions
+              summary:
+                enabled: true
+                variable_name: recoverySummary
+        - blockGroup: g-redo
+          id: redo
+          sortingKey: c0
+          type: notebook-function
+          metadata:
+            function_notebook_id: nb-redo
+            function_notebook_for_each: recoveredRegions
+            function_notebook_for_each_as: region
+            function_notebook_inputs:
+              region:
+                variable_name: region
+            function_notebook_export_mappings:
+              region:
+                enabled: true
+                variable_name: redone
+        - blockGroup: g-report
+          id: report
+          sortingKey: d0
+          type: notebook-function
+          metadata:
+            function_notebook_id: nb-report
+            function_notebook_inputs:
+              summary:
+                variable_name: recoverySummary
+                fallback:
+                  custom_value: nothing to recover
+              regions:
+                variable_name: redone
+                fallback:
+                  variable_name: regions
+              threshold:
+                custom_value: '0.95'
+        - blockGroup: g-audit
+          id: audit
+          sortingKey: d1
+          type: notebook-function
+          metadata:
+            function_notebook_id: nb-audit
+            function_notebook_inputs:
+              summary:
+                variable_name: recoverySummary
+        - blockGroup: g-notify
+          id: notify
+          sortingKey: e0
+          type: notebook-function
+          metadata:
+            function_notebook_id: nb-notify
+            function_notebook_for_each: regions
+            function_notebook_for_each_as: region
+            function_notebook_inputs:
+              region:
+                variable_name: region
+              mode:
+                custom_value: email
+        - blockGroup: g-after-flaky
+          id: after-flaky
+          sortingKey: f0
+          type: notebook-function
+          metadata:
+            function_notebook_id: nb-after
+            function_notebook_inputs:
+              value:
+                variable_name: flakyValue
+                fallback:
+                  custom_value: default
+version: '1.0.0'

--- a/test-fixtures/pipeline-conformance/skip-and-fallback.expected-results.json
+++ b/test-fixtures/pipeline-conformance/skip-and-fallback.expected-results.json
@@ -1,0 +1,24 @@
+{
+  "stepOutputs": {
+    "check": { "quality": { "score": 0.99 }, "regions": ["NA", "EU"] }
+  },
+  "failingSteps": ["flaky"],
+  "ran": {
+    "check": {},
+    "flaky": {},
+    "report": {
+      "summary": "nothing to recover",
+      "regions": ["NA", "EU"],
+      "threshold": "0.95"
+    },
+    "notify[0]": { "region": "NA", "mode": "email" },
+    "notify[1]": { "region": "EU", "mode": "email" },
+    "after-flaky": { "value": "default" }
+  },
+  "skipped": ["audit", "recover", "redo"],
+  "failed": ["flaky"],
+  "variables": {
+    "quality": { "score": 0.99 },
+    "regions": ["NA", "EU"]
+  }
+}


### PR DESCRIPTION
**2 of 5.** Stacked on #496. The diff shown here is against #496's branch.

A pipeline can live in a file instead of in code: a notebook marked `isPipeline: true` whose `notebook-function` blocks each name a module notebook, its inputs, and the values it publishes. The encoding is the one deepnote.com already stores for module imports, extended with four typed keys, so the same file can later be executed natively by the product against the same planner.

```yaml
notebooks:
  - id: sales-pipeline
    name: Sales pipeline
    isPipeline: true
    blocks:
      - id: analyze-europe
        type: notebook-function
        metadata:
          function_notebook_id: nb-regional
          function_notebook_inputs:
            region: { custom_value: Europe }
          function_notebook_export_mappings:
            result: { enabled: true, variable_name: europe }

      - id: recover
        type: notebook-function
        metadata:
          function_notebook_id: nb-regional
          function_notebook_for_each: belowThreshold
          function_notebook_for_each_as: region
          function_notebook_inputs:
            region: { variable_name: region }
          function_notebook_export_mappings:
            result: { enabled: true, variable_name: recovered }

      - id: aggregate
        type: notebook-function
        metadata:
          function_notebook_id: nb-aggregate
          function_notebook_run_if: europe.qualityScore >= 0.95 || recovered != null
          function_notebook_inputs:
            europe_json: { variable_name: recovered, fallback: { variable_name: europe } }
```

### Dependencies come from variable flow

An input with `variable_name` references a value another step exports through `function_notebook_export_mappings`. That is the dependency edge; nothing is declared twice, and independent steps are independent by construction. Identifiers in `run_if`, the `for_each` source, and every `fallback` alternative are edges too.

### The primitives

| Key | Meaning |
|---|---|
| `function_notebook_run_if` | Gate a step on earlier results. Evaluated per element on a fan-out. |
| `function_notebook_for_each` / `_as` | One concurrent run per element of an exported array. Capped at 50. |
| `fallback` on an input | First alternative with a value, so a skipped producer does not cascade a skip. |
| `function_notebook_allow_failure` | Return a failed step result instead of failing the pipeline. |

A step whose inputs never arrived is skipped, including a `for_each` whose source was skipped. A failed step without `allow_failure` fails the pipeline; unrelated steps in flight finish. The rejection carries the engine's `partial` run plus the runner's `variables`, `skipped` and `failed` so far, so a caller can render what finished.

### Interpreted, not executed

The parent is read as a manifest. Deepnote's block engine runs blocks strictly in order, so executing the parent would serialize the fan-out into one run with one status. `planPipeline(file)` returns the graph without running anything. Plan-time errors cover everything checkable without running: missing or duplicate `isPipeline`, unknown references, duplicate exports, a step naming no notebook, `for_each_as` without `for_each` or shadowing an export, malformed conditions, cycles.

### Deliberately not JavaScript

A pipeline definition is data. The condition language has no `eval`, no calls, no assignment, own-property lookups only. `europe.__proto__` evaluates to false and `fetch("x")` fails at plan time. One rule for every comparison operator: numeric when both operands are numbers or numeric strings, strict otherwise, because the runs API delivers inputs as strings.

### Conformance fixtures

`test-fixtures/pipeline-conformance/` holds `.deepnote` files with expected plans (`linear`, `condition-only-dependency`, `fan-out-and-gate`) and one with expected execution results (`skip-and-fallback`). These are the language-neutral spec a native implementation must match.

### Changes since the previous revision

- **Docs and a test for `allow_failure` on a timed-out run.** The engine fix on #496 makes `function_notebook_allow_failure` cover a throwing executor, so a fan-out with one hung element now collects from the rest and continues; a test here proves it against the file runner (two-element list published, the step in `failed`, the downstream step reached, `step_failed` carrying the synthesized `timeout` result). `blocks-pipeline.md` and the README say `allow_failure` covers every way a step can fail, that the result's `status` and `error` say which, and that a timed-out run may still be executing in Deepnote with its `runId` on the result. No engine change on this branch.
- **Unreadable exports are failed steps.** `exportsFrom` threw a plain `Error` from inside `publish` when a step's output held no JSON object or lacked an exported key, and `allow_failure` did not cover it because `publish` only checked `result.success`. With `allow_failure` the step is now listed in `failed`, publishes nothing and emits nothing new (a fan-out collects only its readable elements); without it the pipeline fails with a `PipelineStepError` naming the step.
- **The file runner's state rides on the error.** `runPipelineFile` and `runPipelineFileWithExecutor` attach `variables`, `skipped` and `failed` alongside the engine's `partial` (new exported `PipelineFileError` type). A terminal `allow_failure` step therefore lets the run resolve with every other variable present.
- **Documented input constraint.** The runs API rejects arrays for text inputs, so a variable holding a fan-out's collected list can only feed an `input-select` block with `deepnote_allow_multiple_values: true`. Stated in `blocks-pipeline.md` with an example; no engine change.
- Docs now say exports are read from the JSON object that ends the last block's output, with anything printed on earlier lines ignored, and spell out the failure semantics above in the README and `blocks-pipeline.md`.
- Rebuilt onto the new #496 tip as one squashed commit plus the two commits above.

### Open items

- Module-target validation is not possible yet: `getNotebook` in `@deepnote/cloud` does not expose an `isModule` flag. Worth adding to the v2 notebook response.
- A variable referenced only in `run_if` whose producer was skipped reads as absent rather than skipping the step, so `recovered == null` works as a gate. Confirm this is the semantics the product wants.
- `toRunInputs` still rejects object inputs, so structured values flow between steps as JSON strings.

### Testing

Planner, scheduler, condition language, schema round-trip, and conformance fixtures, including a peak-concurrency assertion that sequential execution could not pass. Full suite (3218), typecheck, biome, prettier, cspell green.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for defining, planning, and running pipelines directly from `.deepnote` files.
  * Added conditional execution, dependency-based scheduling, fallback inputs, failure tolerance, and dynamic fan-out.
  * Added configurable concurrency controls for pipeline steps.
  * Added typed notebook-function inputs, exports, pipeline metadata, and public planning and execution APIs.
  * Added support for partial results, skipped steps, and failed-step reporting.

* **Documentation**
  * Added guidance and examples for file-based pipelines, conditions, fan-out, dependencies, and execution behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

