### PR TITLE
feat(pipelines): an ergonomic client over the v2 runs API

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,7 +13,7 @@ This is a TypeScript monorepo for Deepnote's open-source packages, managed with 
 - **packages/database-integrations** - Database integration definitions, schemas, and authentication methods
 - **packages/local-runner** - Local Python-backed runner and static UI for Deepnote notebooks
 - **packages/mcp** - MCP server for AI-assisted Deepnote notebook creation and manipulation
-- **packages/pipelines** - Compose Deepnote notebook runs into pipelines, with no server and no orchestration engine
+- **packages/pipelines** - Deepnote client SDK and pipeline composition, with no server and no orchestration engine
 - **packages/reactivity** - Reactivity and dependency graph for Deepnote notebooks
 - **packages/runtime-core** - Core runtime for executing Deepnote projects
 
@@ -30,6 +30,7 @@ Start with the owning package and its README before searching broadly. Avoid tra
 | Deepnote Cloud runs and schedules API clients                  | `packages/cloud/`                                     |
 | Local notebook execution and serving                           | `packages/local-runner/` and `packages/runtime-core/` |
 | Composing several notebook runs into one pipeline              | `packages/pipelines/`                                 |
+| The ergonomic client SDK (notebook handles, awaitable runs)    | `packages/pipelines/src/client/`                      |
 | Dependency and reactivity analysis                             | `packages/reactivity/`                                |
 | Database integration definitions                               | `packages/database-integrations/`                     |
 | Shared test data                                               | `test-fixtures/`                                      |

--- a/examples/pipelines/sdk/README.md
+++ b/examples/pipelines/sdk/README.md
@@ -1,0 +1,22 @@
+# A pipeline with no pipeline API
+
+The same fan-out-and-gate as [`../script`](../script), written with the client instead of
+`runPipeline`. About 30 lines of ordinary JavaScript.
+
+```bash
+DEEPNOTE_TOKEN=… NA_NOTEBOOK_ID=… EU_NOTEBOOK_ID=… APAC_NOTEBOOK_ID=… pnpm example:pipeline-sdk
+```
+
+The point of this example is what is missing from it. There is no workflow object, no step
+registry, no graph to declare: `Promise.all` fans out, `filter` gates, `await` sequences. JavaScript
+executes the pipeline, and the SDK only makes each remote operation awaitable, typed, and named.
+
+That is also the trade. Because the coordination lives in this process, it is not durable: kill the
+script mid-run and the notebook runs continue in Deepnote — they are detached, and their ids are
+printed — but nothing aggregates them and no gate fires. Pick this up again with
+`deepnote.getRun(id)`, or reach for one of the durable options in the
+[package README](../../../packages/pipelines/README.md).
+
+Compared with [`../script`](../script), what you give up is the execution graph and the event
+stream. `runPipeline` records both; a plain function records neither, because nothing is watching.
+Callers who want the graph and event stream import `runPipeline` from `@deepnote/pipelines` directly.

--- a/examples/pipelines/sdk/run.mjs
+++ b/examples/pipelines/sdk/run.mjs
@@ -1,0 +1,60 @@
+// The same fan-out-and-gate pipeline as ../script, written with no pipeline API at all.
+//
+// Every remote operation is awaitable, so the pipeline is the language: `Promise.all` fans out,
+// `filter` gates, `await` sequences. Nothing here schedules, persists, replays, or supervises —
+// which is why the same file runs from cron, CI, a Lambda, or another Deepnote notebook.
+//
+// In a real project, import from '@deepnote/pipelines' after installing it.
+import { Deepnote, outputs } from '../../../packages/pipelines/dist/index.js'
+
+try {
+  process.loadEnvFile()
+} catch {}
+
+const REGIONS = [
+  { name: 'North America', notebookId: process.env.NA_NOTEBOOK_ID },
+  { name: 'Europe', notebookId: process.env.EU_NOTEBOOK_ID },
+  { name: 'Asia Pacific', notebookId: process.env.APAC_NOTEBOOK_ID },
+].filter(region => region.notebookId)
+
+if (REGIONS.length === 0) {
+  console.error('Set NA_NOTEBOOK_ID / EU_NOTEBOOK_ID / APAC_NOTEBOOK_ID to the notebooks to run.')
+  process.exit(1)
+}
+
+const QUALITY_THRESHOLD = 0.95
+
+// Reads DEEPNOTE_TOKEN, and DEEPNOTE_API_URL when you are not pointing at Deepnote Cloud.
+const deepnote = Deepnote.fromEnv()
+
+// A notebook plus the names of the values it publishes. Declared once, reused per region.
+const analysis = notebookId =>
+  deepnote.notebooks.define({
+    id: notebookId,
+    outputs: {
+      // lastJson survives Deepnote reassigning block ids when it creates a notebook.
+      reading: outputs.lastJson(),
+    },
+  })
+
+const started = Date.now()
+
+// Fan out. Independent work is concurrent because Promise.all is, not because a framework said so.
+const analyses = await Promise.all(
+  REGIONS.map(region =>
+    analysis(region.notebookId).runAndWait({
+      inputs: { region: region.name, trailing_months: 6 },
+      onStatus: status => console.log(`  ${region.name}: ${status}`),
+    })
+  )
+)
+
+// Gate. An ordinary filter over values that are already typed and named.
+const belowThreshold = analyses
+  .map(result => result.values.reading)
+  .filter(reading => reading.qualityScore < QUALITY_THRESHOLD)
+  .map(reading => reading.region)
+
+console.log(`\n  ${analyses.length} regions in ${((Date.now() - started) / 1000).toFixed(1)}s`)
+console.log(`  below threshold: ${belowThreshold.join(', ') || 'none'}`)
+console.log(`  runs: ${analyses.map(result => result.runId).join(', ')}\n`)

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "example:gallery": "pnpm --filter @deepnote/local-runner... build && node examples/local-runner/gallery/serve.mjs",
     "example:local-runner": "pnpm --filter @deepnote/pipelines... build && node examples/local-runner/run-app/serve.mjs",
     "example:pipeline": "pnpm --filter @deepnote/pipelines... build && node examples/pipelines/script/run.mjs",
+    "example:pipeline-sdk": "pnpm --filter @deepnote/pipelines... build && node examples/pipelines/sdk/run.mjs",
     "example:schedule-cloud": "pnpm --filter @deepnote/local-runner... build && node examples/local-runner/schedule-cloud.mjs",
     "example:snapshot-viewer": "pnpm --filter @deepnote/local-runner... build && node examples/local-runner/snapshot-viewer/serve.mjs",
     "license-check": "license-checker-rseidelsohn --json --onlyAllow \"MIT;Apache-2.0;BSD-2-Clause;BSD-3-Clause;ISC\" --excludePackages \"deepnote\"",

--- a/packages/pipelines/README.md
+++ b/packages/pipelines/README.md
@@ -6,6 +6,78 @@ Compose Deepnote notebook runs into pipelines. No server, no kernel, no orchestr
 pnpm add @deepnote/pipelines
 ```
 
+## Start a run, wait for it, use its result
+
+```ts
+import { Deepnote, outputs } from "@deepnote/pipelines";
+
+const deepnote = Deepnote.fromEnv(); // DEEPNOTE_TOKEN, optionally DEEPNOTE_API_URL
+
+const extract = deepnote.notebooks.define({
+  id: "nb-extract",
+  outputs: {
+    datasetUri: outputs.text("uri-block"),
+    rowCount: outputs.json<number>("stats-block", "row_count"),
+  },
+});
+
+// Starting and waiting are separate, because they are separate in the API.
+const run = await extract.run({ inputs: { region: "eu", months: 6 } });
+console.log(run.id); // the run continues in Deepnote whether or not this process does
+
+const result = await run.wait({ onStatus: (status) => console.log(status) });
+result.values.datasetUri; // string
+result.values.rowCount; // number
+```
+
+`runAndWait()` is those two steps when you want them together. A failed run throws
+`DeepnoteRunError` carrying the result — the snapshot is usually the only record of what the failing
+block actually said — and `allowFailure: true` returns it instead. `wait({ timeoutMs })` throws
+`DeepnoteRunTimeout` when the deadline passes first; only the watching stopped, the run continues in
+Deepnote, and `deepnote.getRun(id)` picks it up again.
+
+`extract.runs({ pageSize, pageToken })` is one page of the notebook's run history, newest first,
+including runs started from Deepnote's UI; the page's `nextPageToken` fetches the next one.
+
+### A pipeline is just a function
+
+There is no workflow API to learn for the common case. `await` sequences, `Promise.all` fans out,
+`if` branches, `try/catch` handles failure:
+
+```ts
+const [customers, products] = await Promise.all([
+  deepnote.notebooks.ref("nb-customers").runAndWait({ inputs: { date } }),
+  deepnote.notebooks.ref("nb-products").runAndWait({ inputs: { date } }),
+]);
+
+if (customers.values.rowCount > 1_000_000) {
+  await deepnote.notebooks.ref("nb-partition").runAndWait();
+}
+```
+
+Deepnote does not interpret that function; JavaScript does. Which means the same code runs from
+cron, GitHub Actions, a Lambda, a FastAPI route, a CLI, Temporal, Airflow, or another Deepnote
+notebook, and Deepnote competes with none of them. What the SDK adds is the remote operation being
+awaitable, typed, and named — not a runtime that owns your control flow.
+
+Reach for `runPipeline` (below) when you want what a plain function does not give you: the execution
+graph, an event stream, and control nodes that make a local gate visible.
+
+### Named outputs are a client-side contract
+
+Inputs are symmetrical already: `POST /v2/runs` takes values keyed by the notebook's input-block
+names. Outputs are not — a finished run is a snapshot of blocks, and only the author knows which
+block holds the answer. So `outputs.text()`, `outputs.json()` and `outputs.lastJson()` declare that
+mapping on the client, and the error names your binding rather than a block id you never typed:
+
+```
+Output "euShare" could not be read from totals.eu of block "stats-block" of run run-42: …
+```
+
+`outputs.lastJson()` is the one to prefer for a notebook Deepnote created from a file, since
+Deepnote reassigns block ids on creation. If Deepnote later grows a server-side notion of named
+outputs, this surface does not change — only the resolver behind it does.
+
 ## Run several notebooks as one pipeline
 
 Fan out, gate on the results, decide:

--- a/packages/pipelines/src/client/bindings.ts
+++ b/packages/pipelines/src/client/bindings.ts
@@ -1,0 +1,140 @@
+import type { PipelineStepResult } from '../pipeline'
+import { allOutputText, lastAgentText, lastOutputJson, outputJson, outputText } from '../pipeline'
+
+/**
+ * Named outputs, declared by the caller.
+ *
+ * Deepnote's API has a clean contract for a notebook's *inputs* — named input blocks, and
+ * `POST /v2/runs` takes values keyed by those names. Outputs are not symmetrical: a finished run
+ * gives you a snapshot of blocks and Jupyter-style outputs, and which block holds "the answer" is
+ * something only the author knows.
+ *
+ * So the contract lives on the client for now. A binding says where a named value comes from, and
+ * the SDK reads it off the snapshot. If Deepnote later grows a server-side notion of named outputs,
+ * this surface does not have to change — only the resolver below does.
+ */
+
+/** Where one named output comes from, and how to read it. */
+export interface OutputBinding<T> {
+  /** Called with the finished step result. Throws if the value is not there. */
+  read: (result: PipelineStepResult) => T
+  /** Human-readable source, used in error messages. */
+  describe: string
+}
+
+/** A block's textual output. */
+export function text(blockId: string): OutputBinding<string> {
+  return { read: result => outputText(result, blockId), describe: `text of block "${blockId}"` }
+}
+
+/**
+ * A block's JSON output, optionally one path into it.
+ *
+ * `path` is a dotted path with numeric indexes — `totals.eu`, `regions[0].name` — deliberately not
+ * a full JSONPath: a binding that needs filters or wildcards is a computation, and computations
+ * belong in the notebook that produced the value or in the pipeline that consumes it.
+ */
+export function json<T = unknown>(blockId: string, path?: string): OutputBinding<T> {
+  return {
+    read: result => pluck<T>(outputJson(result, blockId), path, `block "${blockId}"`),
+    describe: path ? `${path} of block "${blockId}"` : `JSON of block "${blockId}"`,
+  }
+}
+
+/**
+ * The run's last structured JSON value, optionally one path into it.
+ *
+ * Preferred over {@link json} when a notebook was created by Deepnote from a file, because Deepnote
+ * reassigns block ids on creation and this does not depend on them.
+ */
+export function lastJson<T = unknown>(path?: string): OutputBinding<T> {
+  return {
+    read: result => pluck<T>(lastOutputJson(result), path, 'the last JSON output'),
+    describe: path ? `${path} of the run's last JSON output` : "the run's last JSON output",
+  }
+}
+
+/** Every block's textual output, in notebook order. Portable across remapped block ids. */
+export function allText(): OutputBinding<string> {
+  return { read: allOutputText, describe: "the run's textual output" }
+}
+
+/** The final text of the last agent block. */
+export function agentText(): OutputBinding<string> {
+  return { read: lastAgentText, describe: "the last agent block's text" }
+}
+
+/** A binding whose value the caller derives from the whole result. */
+export function derived<T>(read: (result: PipelineStepResult) => T, describe = 'a derived value'): OutputBinding<T> {
+  return { read, describe }
+}
+
+/** Named bindings for one notebook. */
+export type OutputBindings = Record<string, OutputBinding<unknown>>
+
+/** The object a set of bindings produces: each name typed by its own binding. */
+export type BoundOutputs<B extends OutputBindings> = {
+  [K in keyof B]: B[K] extends OutputBinding<infer T> ? T : never
+}
+
+/**
+ * Resolve every binding against a finished run.
+ *
+ * One failing binding fails the whole read, and the error names the binding rather than the block:
+ * a caller who declared `rowCount` should be told `rowCount` is missing, not handed a block id they
+ * may never have typed themselves.
+ */
+export function resolveBindings<B extends OutputBindings>(bindings: B, result: PipelineStepResult): BoundOutputs<B> {
+  const resolved: Record<string, unknown> = {}
+  for (const [name, binding] of Object.entries(bindings)) {
+    try {
+      resolved[name] = binding.read(result)
+    } catch (error) {
+      throw new Error(
+        `Output "${name}" could not be read from ${binding.describe} of run ${result.runId ?? result.id}: ${
+          error instanceof Error ? error.message : String(error)
+        }`,
+        { cause: error }
+      )
+    }
+  }
+  return resolved as BoundOutputs<B>
+}
+
+/** Walk a dotted path with numeric indexes into a parsed JSON value. */
+function pluck<T>(value: unknown, path: string | undefined, source: string): T {
+  if (path === undefined) {
+    return value as T
+  }
+  let current = value
+  for (const segment of path.split('.')) {
+    const match = /^([A-Za-z_$][\w$]*)((?:\[\d+\])*)$/.exec(segment)
+    if (!match) {
+      throw new Error(`"${path}" is not a dotted path with numeric indexes.`)
+    }
+    current = step(current, match[1], path, source)
+    for (const index of match[2].matchAll(/\[(\d+)\]/g)) {
+      current = step(current, Number(index[1]), path, source)
+    }
+  }
+  return current as T
+}
+
+function step(value: unknown, key: string | number, path: string, source: string): unknown {
+  if (value === null || typeof value !== 'object') {
+    throw new Error(`"${path}" does not exist in ${source}: ${JSON.stringify(value)} has no "${key}".`)
+  }
+  const next = (value as Record<string | number, unknown>)[key]
+  if (next === undefined) {
+    throw new Error(`"${path}" does not exist in ${source}.`)
+  }
+  return next
+}
+
+/**
+ * The binding constructors, namespaced.
+ *
+ * A namespace rather than bare exports because `text` and `json` are far too generic to occupy a
+ * package's root, and because `outputs.json("block-stats", "row_count")` reads as what it is.
+ */
+export const outputs = { text, json, lastJson, allText, agentText, derived } as const

--- a/packages/pipelines/src/client/client.test.ts
+++ b/packages/pipelines/src/client/client.test.ts
@@ -1,0 +1,387 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const cloudMock = vi.hoisted(() => ({
+  triggerNotebookRun: vi.fn(),
+  pollRunUntilComplete: vi.fn(),
+  waitForRunSnapshot: vi.fn(),
+  getRun: vi.fn(),
+  listNotebookRuns: vi.fn(),
+}))
+
+vi.mock('@deepnote/cloud', async () => {
+  const actual = await vi.importActual<typeof import('@deepnote/cloud')>('@deepnote/cloud')
+  return { ...actual, ...cloudMock }
+})
+
+import { Deepnote, DeepnoteRunError, DeepnoteRunTimeout, outputs, TOKEN_ENV } from './index'
+
+/** A snapshot with one text block and one JSON block, which is what the bindings read. */
+function snapshot(json: unknown, textOutput = 's3://bucket/data.parquet'): string {
+  return `metadata:
+  createdAt: '2026-01-01T00:00:00.000Z'
+project:
+  id: project-1
+  name: SDK
+  notebooks:
+    - id: notebook-1
+      name: Main
+      blocks:
+        - blockGroup: group-1
+          content: print(uri)
+          id: uri-block
+          metadata: {}
+          sortingKey: a0
+          type: code
+          executionCount: 1
+          outputs:
+            - output_type: stream
+              name: stdout
+              text: '${textOutput}'
+        - blockGroup: group-2
+          content: emit stats
+          id: stats-block
+          metadata: {}
+          sortingKey: a1
+          type: code
+          executionCount: 2
+          outputs:
+            - output_type: execute_result
+              data:
+                application/json: ${JSON.stringify(json)}
+              metadata: {}
+version: '1.0.0'
+`
+}
+
+const TOKEN = 'api-token'
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  cloudMock.triggerNotebookRun.mockImplementation(async (_base, _token, body) => ({
+    runId: `run-${body.notebookId}`,
+    status: 'running',
+    notebookId: body.notebookId,
+    createdAt: '2026-01-01T00:00:00.000Z',
+    raw: {},
+  }))
+  cloudMock.pollRunUntilComplete.mockImplementation(async (_base, _token, runId, options) => {
+    options?.onStatus?.('success', { runId, status: 'success', raw: {} })
+    return { runId, status: 'success', raw: {} }
+  })
+  cloudMock.waitForRunSnapshot.mockImplementation(async (_base, _token, run) => ({
+    run,
+    content: snapshot({ row_count: 182451, totals: { eu: 0.96 }, regions: [{ name: 'eu' }] }),
+  }))
+})
+
+describe('Deepnote', () => {
+  it('requires a token, and says how to supply one', () => {
+    expect(() => new Deepnote({ token: '' })).toThrow(/token is required/i)
+    const previous = process.env[TOKEN_ENV]
+    delete process.env[TOKEN_ENV]
+    try {
+      expect(() => Deepnote.fromEnv()).toThrow(new RegExp(TOKEN_ENV))
+    } finally {
+      if (previous !== undefined) {
+        process.env[TOKEN_ENV] = previous
+      }
+    }
+  })
+
+  it('reads the token and origin from the environment', () => {
+    const previousToken = process.env[TOKEN_ENV]
+    const previousUrl = process.env.DEEPNOTE_API_URL
+    process.env[TOKEN_ENV] = 'from-env'
+    process.env.DEEPNOTE_API_URL = 'https://api.example.test'
+    try {
+      expect(Deepnote.fromEnv().baseUrl).toBe('https://api.example.test')
+    } finally {
+      if (previousToken === undefined) delete process.env[TOKEN_ENV]
+      else process.env[TOKEN_ENV] = previousToken
+      if (previousUrl === undefined) delete process.env.DEEPNOTE_API_URL
+      else process.env.DEEPNOTE_API_URL = previousUrl
+    }
+  })
+
+  it('defaults to Deepnote Cloud', () => {
+    expect(new Deepnote({ token: TOKEN }).baseUrl).toBe('https://api.deepnote.com')
+  })
+})
+
+describe('notebooks.ref().run()', () => {
+  it('starts a detached run and returns a handle with the run id', async () => {
+    const deepnote = new Deepnote({ token: TOKEN })
+    const run = await deepnote.notebooks.ref('nb-extract').run({ inputs: { region: 'eu', months: 6 } })
+
+    expect(run.id).toBe('run-nb-extract')
+    expect(run.status).toBe('running')
+    expect(run.isTerminal).toBe(false)
+    expect(cloudMock.triggerNotebookRun).toHaveBeenCalledWith(
+      'https://api.deepnote.com',
+      TOKEN,
+      // Numbers are stringified, which is all the runs API accepts.
+      { notebookId: 'nb-extract', inputs: { region: 'eu', months: '6' } },
+      expect.anything()
+    )
+    // Starting a run does not wait for it: that is a separate operation on the handle.
+    expect(cloudMock.pollRunUntilComplete).not.toHaveBeenCalled()
+  })
+
+  it('rejects an empty notebook id rather than calling the API with one', async () => {
+    expect(() => new Deepnote({ token: TOKEN }).notebooks.ref('')).toThrow(/notebook id is required/i)
+    expect(cloudMock.triggerNotebookRun).not.toHaveBeenCalled()
+  })
+
+  it('waits as an operation on the run, reporting status changes', async () => {
+    const seen: string[] = []
+    const deepnote = new Deepnote({ token: TOKEN })
+    const run = await deepnote.notebooks.ref('nb-extract').run()
+    const result = await run.wait({ onStatus: status => seen.push(status) })
+
+    expect(seen).toEqual(['success'])
+    expect(result.success).toBe(true)
+    expect(result.runId).toBe('run-nb-extract')
+    expect(result.snapshot).not.toBeNull()
+    expect(result.durationMs).toBeGreaterThanOrEqual(0)
+  })
+
+  it('runAndWait is run() then wait()', async () => {
+    const result = await new Deepnote({ token: TOKEN }).notebooks.ref('nb-extract').runAndWait({
+      inputs: { region: 'eu' },
+    })
+
+    expect(result.status).toBe('success')
+    expect(cloudMock.triggerNotebookRun).toHaveBeenCalledTimes(1)
+    expect(cloudMock.pollRunUntilComplete).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('notebooks.ref().runs()', () => {
+  it('returns one page of the notebook run history with the pagination params passed through', async () => {
+    cloudMock.listNotebookRuns.mockResolvedValue({
+      runs: [
+        { runId: 'run-2', status: 'running', createdAt: '2026-01-02T00:00:00.000Z', completedAt: null },
+        {
+          runId: 'run-1',
+          status: 'success',
+          createdAt: '2026-01-01T00:00:00.000Z',
+          completedAt: '2026-01-01T00:01:00.000Z',
+        },
+      ],
+      nextPageToken: 'page-2',
+      hasMore: true,
+    })
+    const page = await new Deepnote({ token: TOKEN }).notebooks
+      .ref('nb-extract')
+      .runs({ pageSize: 2, pageToken: 'page-1' })
+
+    expect(page.runs.map(run => run.runId)).toEqual(['run-2', 'run-1'])
+    expect(page.runs[0]).toEqual({
+      runId: 'run-2',
+      status: 'running',
+      createdAt: '2026-01-02T00:00:00.000Z',
+      completedAt: null,
+    })
+    expect(page.hasMore).toBe(true)
+    expect(page.nextPageToken).toBe('page-2')
+    expect(cloudMock.listNotebookRuns).toHaveBeenCalledWith('https://api.deepnote.com', TOKEN, 'nb-extract', {
+      signal: undefined,
+      pageSize: 2,
+      pageToken: 'page-1',
+    })
+    // History is a read: nothing is started or waited for.
+    expect(cloudMock.triggerNotebookRun).not.toHaveBeenCalled()
+    expect(cloudMock.pollRunUntilComplete).not.toHaveBeenCalled()
+  })
+
+  it('carries the client signal when the caller gives none', async () => {
+    const controller = new AbortController()
+    cloudMock.listNotebookRuns.mockResolvedValue({ runs: [], hasMore: false })
+    await new Deepnote({ token: TOKEN, signal: controller.signal }).notebooks.ref('nb-extract').runs()
+
+    expect(cloudMock.listNotebookRuns).toHaveBeenCalledWith('https://api.deepnote.com', TOKEN, 'nb-extract', {
+      signal: controller.signal,
+    })
+  })
+})
+
+describe('a failed run', () => {
+  beforeEach(() => {
+    cloudMock.pollRunUntilComplete.mockResolvedValue({ runId: 'run-nb-extract', status: 'error', raw: {} })
+  })
+
+  it('throws DeepnoteRunError carrying the result, so a caller can still show it', async () => {
+    const deepnote = new Deepnote({ token: TOKEN })
+    let caught: DeepnoteRunError | undefined
+    try {
+      await deepnote.notebooks.ref('nb-extract').runAndWait()
+    } catch (error) {
+      caught = error as DeepnoteRunError
+    }
+
+    expect(caught).toBeInstanceOf(DeepnoteRunError)
+    expect(caught?.runId).toBe('run-nb-extract')
+    expect(caught?.status).toBe('error')
+    expect(caught?.result.snapshot).not.toBeNull()
+  })
+
+  it('returns it instead when the caller allows failure', async () => {
+    const result = await new Deepnote({ token: TOKEN }).notebooks.ref('nb-extract').runAndWait({ allowFailure: true })
+
+    expect(result.success).toBe(false)
+    expect(result.status).toBe('error')
+    expect(result.error).toBeTruthy()
+    // Bindings are not resolved for a failure the caller asked to see: an unreadable output must
+    // not mask the failure it was going to explain.
+    expect(result.values).toEqual({})
+  })
+})
+
+describe('a wait that times out', () => {
+  beforeEach(async () => {
+    const { RunTimeoutError } = await vi.importActual<typeof import('@deepnote/cloud')>('@deepnote/cloud')
+    cloudMock.pollRunUntilComplete.mockRejectedValue(new RunTimeoutError('run-nb-extract', 'running'))
+  })
+
+  it('throws DeepnoteRunTimeout naming the run and how to pick it up again', async () => {
+    const deepnote = new Deepnote({ token: TOKEN })
+    const run = await deepnote.notebooks.ref('nb-extract').run()
+    let caught: unknown
+    try {
+      await run.wait({ timeoutMs: 10 })
+    } catch (error) {
+      caught = error
+    }
+
+    expect(caught).toBeInstanceOf(DeepnoteRunTimeout)
+    const timeout = caught as DeepnoteRunTimeout
+    expect(timeout.name).toBe('DeepnoteRunTimeout')
+    expect(timeout.runId).toBe('run-nb-extract')
+    expect(timeout.lastStatus).toBe('running')
+    expect(timeout.message).toMatch(/run itself is unaffected/)
+    expect(timeout.message).toContain('deepnote.getRun("run-nb-extract")')
+    // The cloud error is kept as the cause, not leaked as the error.
+    expect((timeout.cause as Error).name).toBe('RunTimeoutError')
+    expect(cloudMock.pollRunUntilComplete).toHaveBeenCalledWith(
+      'https://api.deepnote.com',
+      TOKEN,
+      'run-nb-extract',
+      expect.objectContaining({ timeoutMs: 10 })
+    )
+    // Giving up on watching does not read a snapshot the run has not produced.
+    expect(cloudMock.waitForRunSnapshot).not.toHaveBeenCalled()
+  })
+
+  it('is not a DeepnoteRunError: the run did not fail, the caller stopped watching', async () => {
+    await expect(new Deepnote({ token: TOKEN }).notebooks.ref('nb-extract').runAndWait()).rejects.toSatisfy(
+      error => error instanceof DeepnoteRunTimeout && !(error instanceof DeepnoteRunError)
+    )
+  })
+
+  it('lets other polling errors through untranslated', async () => {
+    cloudMock.pollRunUntilComplete.mockRejectedValue(new Error('network down'))
+    await expect(new Deepnote({ token: TOKEN }).notebooks.ref('nb-extract').runAndWait()).rejects.toThrow(
+      'network down'
+    )
+  })
+})
+
+describe('named outputs', () => {
+  const extract = (deepnote: Deepnote) =>
+    deepnote.notebooks.define({
+      id: 'nb-extract',
+      outputs: {
+        datasetUri: outputs.text('uri-block'),
+        rowCount: outputs.json<number>('stats-block', 'row_count'),
+        euShare: outputs.json<number>('stats-block', 'totals.eu'),
+        firstRegion: outputs.json<string>('stats-block', 'regions[0].name'),
+        wholeStats: outputs.lastJson(),
+      },
+    })
+
+  it('reads each declared value off the snapshot, typed', async () => {
+    const result = await extract(new Deepnote({ token: TOKEN })).runAndWait()
+
+    expect(result.values.datasetUri).toBe('s3://bucket/data.parquet')
+    expect(result.values.rowCount).toBe(182451)
+    expect(result.values.euShare).toBe(0.96)
+    expect(result.values.firstRegion).toBe('eu')
+    expect(result.values.wholeStats).toEqual({ row_count: 182451, totals: { eu: 0.96 }, regions: [{ name: 'eu' }] })
+  })
+
+  it('names the binding, not the block, when a value is missing', async () => {
+    cloudMock.waitForRunSnapshot.mockImplementation(async (_base, _token, run) => ({
+      run,
+      content: snapshot({ row_count: 1 }),
+    }))
+
+    await expect(extract(new Deepnote({ token: TOKEN })).runAndWait()).rejects.toThrow(/Output "euShare"/)
+  })
+
+  it('refuses a path expression it does not implement rather than guessing', async () => {
+    const deepnote = new Deepnote({ token: TOKEN })
+    const notebook = deepnote.notebooks.define({
+      id: 'nb-extract',
+      outputs: { bad: outputs.json('stats-block', 'regions[*].name') },
+    })
+
+    await expect(notebook.runAndWait()).rejects.toThrow(/not a dotted path/)
+  })
+
+  it('is attachable to an existing ref', async () => {
+    const result = await new Deepnote({ token: TOKEN }).notebooks
+      .ref('nb-extract')
+      .withOutputs({ rowCount: outputs.json<number>('stats-block', 'row_count') })
+      .runAndWait()
+
+    expect(result.values.rowCount).toBe(182451)
+  })
+})
+
+describe('picking up a run this process did not start', () => {
+  it('fetches it by id and waits for it', async () => {
+    cloudMock.getRun.mockResolvedValue({ runId: 'run-earlier', status: 'running', raw: {} })
+    cloudMock.pollRunUntilComplete.mockResolvedValue({ runId: 'run-earlier', status: 'success', raw: {} })
+
+    const deepnote = new Deepnote({ token: TOKEN })
+    const run = await deepnote.getRun('run-earlier', {
+      outputs: { rowCount: outputs.json<number>('stats-block', 'row_count') },
+    })
+    const result = await run.wait()
+
+    expect(run.id).toBe('run-earlier')
+    expect(result.values.rowCount).toBe(182451)
+    expect(cloudMock.triggerNotebookRun).not.toHaveBeenCalled()
+  })
+
+  it('refreshes without waiting', async () => {
+    cloudMock.getRun.mockResolvedValue({ runId: 'run-nb-extract', status: 'success', raw: {} })
+    const run = await new Deepnote({ token: TOKEN }).notebooks.ref('nb-extract').run()
+    const refreshed = await run.refresh()
+
+    expect(run.status).toBe('running')
+    expect(refreshed.status).toBe('success')
+    expect(refreshed.isTerminal).toBe(true)
+    expect(cloudMock.pollRunUntilComplete).not.toHaveBeenCalled()
+  })
+})
+
+describe('the composition layer is the language', () => {
+  it('fans out with Promise.all and gates with an if, using no pipeline API at all', async () => {
+    const deepnote = new Deepnote({ token: TOKEN })
+    const regions = ['na', 'eu', 'apac']
+
+    const analyses = await Promise.all(
+      regions.map(region =>
+        deepnote.notebooks
+          .define({ id: `nb-${region}`, outputs: { quality: outputs.json<number>('stats-block', 'totals.eu') } })
+          .runAndWait({ inputs: { region } })
+      )
+    )
+    const failing = analyses.filter(analysis => analysis.values.quality < 0.97).length
+
+    expect(analyses.map(analysis => analysis.runId)).toEqual(['run-nb-na', 'run-nb-eu', 'run-nb-apac'])
+    expect(failing).toBe(3)
+    expect(cloudMock.triggerNotebookRun).toHaveBeenCalledTimes(3)
+  })
+})

--- a/packages/pipelines/src/client/client.ts
+++ b/packages/pipelines/src/client/client.ts
@@ -1,0 +1,91 @@
+import type { GetRunOptions, PollOptions, WaitForRunSnapshotOptions } from '@deepnote/cloud'
+import { getRun } from '@deepnote/cloud'
+import { DEFAULT_CLOUD_API_URL } from '../cloud-executor'
+import type { OutputBindings } from './bindings'
+import { NotebooksResource } from './notebooks'
+import { type ClientContext, Run } from './run'
+
+/**
+ * A Deepnote client.
+ *
+ * Two layers, deliberately: `@deepnote/cloud` is the boring, close-to-HTTP client for the v2 API,
+ * and this is a thin ergonomic layer over it — handles you can await, waiting that is an operation
+ * on a run rather than a system of its own, and named outputs. Composition is the calling language's
+ * job: `await` sequences, `Promise.all` fans out, `if` branches, `try/catch` handles failure.
+ */
+
+export interface DeepnoteOptions {
+  /**
+   * Deepnote API token.
+   *
+   * In a published app this is the short-lived, viewer-scoped token the Deepnote shell issues; in a
+   * script it is an ordinary API token. Pair it with the `baseUrl` it was issued for.
+   */
+  token: string
+  /** API origin. Defaults to Deepnote Cloud. */
+  baseUrl?: string
+  /** Default poll tuning for every `wait()` this client makes. */
+  poll?: Omit<PollOptions, 'onStatus'>
+  /** Default snapshot-settling tuning. */
+  snapshot?: WaitForRunSnapshotOptions
+  /** Abort every in-flight request this client makes. */
+  signal?: AbortSignal
+}
+
+/** Environment variables `fromEnv` reads, matching the CLI's. */
+export const TOKEN_ENV = 'DEEPNOTE_TOKEN'
+export const API_URL_ENV = 'DEEPNOTE_API_URL'
+
+export class Deepnote {
+  readonly notebooks: NotebooksResource
+  readonly baseUrl: string
+
+  private readonly context: ClientContext
+
+  constructor(options: DeepnoteOptions) {
+    if (!options.token) {
+      throw new Error(
+        `A Deepnote API token is required. Pass \`token\`, or set ${TOKEN_ENV} and use Deepnote.fromEnv().`
+      )
+    }
+    this.baseUrl = options.baseUrl ?? DEFAULT_CLOUD_API_URL
+    this.context = {
+      baseUrl: this.baseUrl,
+      token: options.token,
+      poll: options.poll,
+      snapshot: options.snapshot,
+      signal: options.signal,
+    }
+    this.notebooks = new NotebooksResource(this.context)
+  }
+
+  /**
+   * A client configured from the environment.
+   *
+   * Reading the token from the environment rather than an argument is the same choice the durable
+   * step makes: a credential that is never an argument cannot end up in a log of arguments.
+   */
+  static fromEnv(options: Partial<DeepnoteOptions> = {}): Deepnote {
+    const env = typeof process === 'undefined' ? undefined : process.env
+    const token = options.token ?? env?.[TOKEN_ENV]
+    if (!token) {
+      throw new Error(`Set ${TOKEN_ENV} to a Deepnote API token, or pass \`token\` explicitly.`)
+    }
+    return new Deepnote({ ...options, token, baseUrl: options.baseUrl ?? env?.[API_URL_ENV] })
+  }
+
+  /**
+   * Pick up a run this process did not start.
+   *
+   * The whole point of a detached run: the id is enough. A page that reloaded, a retry of a failed
+   * job, or an entirely different machine can take a run's result from here.
+   */
+  async getRun<B extends OutputBindings = Record<string, never>>(
+    runId: string,
+    options: GetRunOptions & { outputs?: B } = {}
+  ): Promise<Run<B>> {
+    const { outputs, ...rest } = options
+    const run = await getRun(this.baseUrl, this.context.token, runId, { signal: this.context.signal, ...rest })
+    return new Run(run, this.context, (outputs ?? {}) as B)
+  }
+}

--- a/packages/pipelines/src/client/errors.ts
+++ b/packages/pipelines/src/client/errors.ts
@@ -1,0 +1,47 @@
+import type { PipelineStepResult } from '../pipeline'
+
+/**
+ * A notebook run finished in a failed state.
+ *
+ * Carries the whole result, not just a message: the snapshot is usually the only place the failing
+ * block's own error is recorded, so a caller that catches this can still show how far the run got.
+ */
+export class DeepnoteRunError extends Error {
+  readonly runId: string | undefined
+  readonly status: string
+  readonly result: PipelineStepResult
+
+  constructor(result: PipelineStepResult) {
+    super(
+      `Deepnote run ${result.runId ?? '(unknown id)'} finished with status "${result.status}": ${result.error ?? 'no error reported'}`
+    )
+    this.name = 'DeepnoteRunError'
+    this.runId = result.runId
+    this.status = result.status
+    this.result = result
+  }
+}
+
+/**
+ * `wait()` gave up watching a run before it finished.
+ *
+ * Only the waiting stopped. The run itself is unaffected and continues in Deepnote; pick it up
+ * again with `deepnote.getRun(runId)`.
+ */
+export class DeepnoteRunTimeout extends Error {
+  readonly runId: string
+  /** The last status the poll saw, when it saw one. */
+  readonly lastStatus: string | undefined
+
+  constructor(runId: string, lastStatus?: string, options?: ErrorOptions) {
+    super(
+      `Gave up waiting for Deepnote run ${runId}` +
+        (lastStatus ? ` (last status: "${lastStatus}")` : '') +
+        `. The run itself is unaffected and continues in Deepnote; pick it up with deepnote.getRun("${runId}").`,
+      options
+    )
+    this.name = 'DeepnoteRunTimeout'
+    this.runId = runId
+    this.lastStatus = lastStatus
+  }
+}

--- a/packages/pipelines/src/client/index.ts
+++ b/packages/pipelines/src/client/index.ts
@@ -1,0 +1,16 @@
+/**
+ * The ergonomic client: awaitable runs, notebook handles, and named outputs.
+ *
+ * Layered strictly above `@deepnote/cloud`, which stays a plain map of the v2 API. Nothing here
+ * adds a runtime concept the API does not have — no workflow, no task, no scheduler — because the
+ * composition layer is the calling language.
+ */
+export type { BoundOutputs, OutputBinding, OutputBindings } from './bindings'
+export { outputs, resolveBindings } from './bindings'
+export type { DeepnoteOptions } from './client'
+export { API_URL_ENV, Deepnote, TOKEN_ENV } from './client'
+export { DeepnoteRunError, DeepnoteRunTimeout } from './errors'
+export type { RunOptions } from './notebooks'
+export { NotebookRef, NotebooksResource } from './notebooks'
+export type { ClientContext, RunResult, WaitOptions } from './run'
+export { Run } from './run'

--- a/packages/pipelines/src/client/notebooks.ts
+++ b/packages/pipelines/src/client/notebooks.ts
@@ -1,0 +1,105 @@
+import type { ListRunsOptions, RunsPage } from '@deepnote/cloud'
+import { listNotebookRuns, triggerNotebookRun } from '@deepnote/cloud'
+import { toRunInputs } from '../cloud-executor'
+import type { OutputBindings } from './bindings'
+import { type ClientContext, Run, type RunResult, type WaitOptions } from './run'
+
+/**
+ * A handle on a notebook that already exists in Deepnote.
+ *
+ * Notebooks are addressed by id and are never created here: running a notebook needs permission to
+ * run it, not to create one, which is what lets a published page do this with a viewer's
+ * short-lived token.
+ */
+
+/** Options for starting a run. */
+export interface RunOptions {
+  /** Values for the notebook's input blocks, keyed by variable name. */
+  inputs?: Record<string, unknown>
+  signal?: AbortSignal
+}
+
+export class NotebookRef<B extends OutputBindings = Record<string, never>> {
+  readonly id: string
+  private readonly context: ClientContext
+  private readonly bindings: B
+
+  constructor(notebookId: string, context: ClientContext, bindings: B) {
+    this.id = notebookId
+    this.context = context
+    this.bindings = bindings
+  }
+
+  /**
+   * Start a run and return as soon as Deepnote has accepted it.
+   *
+   * The run is detached: it continues in Deepnote whether or not this process stays alive, so the
+   * returned id is a durable handle and not just a local one.
+   */
+  async run(options: RunOptions = {}): Promise<Run<B>> {
+    const startedMs = Date.now()
+    const started = await triggerNotebookRun(
+      this.context.baseUrl,
+      this.context.token,
+      { notebookId: this.id, inputs: toRunInputs(options.inputs ?? {}) },
+      { signal: options.signal ?? this.context.signal }
+    )
+    return new Run(
+      started,
+      { ...this.context, signal: options.signal ?? this.context.signal },
+      this.bindings,
+      startedMs
+    )
+  }
+
+  /** Start a run and wait for it. The common case, and exactly `run()` then `wait()`. */
+  async runAndWait(options: RunOptions & WaitOptions = {}): Promise<RunResult<B>> {
+    const started = await this.run(options)
+    return started.wait(options)
+  }
+
+  /**
+   * One page of this notebook's run history, newest first.
+   *
+   * Every run of the notebook, not only ones this client started. `pageSize` and `pageToken` are
+   * passed through to the API; `nextPageToken` on the page is the token for the next call.
+   */
+  async runs(options: ListRunsOptions = {}): Promise<RunsPage> {
+    return listNotebookRuns(this.context.baseUrl, this.context.token, this.id, {
+      signal: this.context.signal,
+      ...options,
+    })
+  }
+
+  /**
+   * The same notebook with named outputs declared.
+   *
+   * Bindings are a client-side contract (see `bindings.ts`), which is why they are attached here
+   * rather than fetched: only the author knows which block holds the answer.
+   */
+  withOutputs<T extends OutputBindings>(bindings: T): NotebookRef<T> {
+    return new NotebookRef(this.id, this.context, bindings)
+  }
+}
+
+/** `deepnote.notebooks` — how you get a handle on one. */
+export class NotebooksResource {
+  private readonly context: ClientContext
+
+  constructor(context: ClientContext) {
+    this.context = context
+  }
+
+  /** A handle on a notebook by id. */
+  ref(notebookId: string): NotebookRef {
+    if (!notebookId) {
+      throw new Error('A notebook id is required.')
+    }
+    return new NotebookRef(notebookId, this.context, {} as Record<string, never>)
+  }
+
+  /** A handle on a notebook, with its named outputs declared up front. */
+  define<T extends OutputBindings>(spec: { id: string; outputs: T }): NotebookRef<T> {
+    return this.ref(spec.id).withOutputs(spec.outputs)
+  }
+}

--- a/packages/pipelines/src/client/run.ts
+++ b/packages/pipelines/src/client/run.ts
@@ -1,0 +1,168 @@
+import type { NormalizedRun, PollOptions, WaitForRunSnapshotOptions } from '@deepnote/cloud'
+import {
+  describeRunError,
+  getRun,
+  isSuccessStatus,
+  isTerminalStatus,
+  pollRunUntilComplete,
+  RunTimeoutError,
+  waitForRunSnapshot,
+} from '@deepnote/cloud'
+import type { RunBlockOutput } from '../extract-outputs'
+import { extractOutputs } from '../extract-outputs'
+import { finishResult, type PipelineStepResult } from '../pipeline'
+import type { SnapshotView } from '../snapshot-view'
+import { parseSnapshot } from '../snapshot-view'
+import type { BoundOutputs, OutputBindings } from './bindings'
+import { resolveBindings } from './bindings'
+import { DeepnoteRunError, DeepnoteRunTimeout } from './errors'
+
+/**
+ * A started Deepnote run, and its result.
+ *
+ * The run is the primitive worth making excellent, because it is the one the API already gives us:
+ * `POST /v2/runs` returns a run id and the run continues whether or not anything is watching it.
+ * Everything above this — pipelines, fan-out, gates — is the caller's own control flow awaiting
+ * these handles.
+ *
+ * `wait()` is polling and nothing more. It holds no state the server does not already have, so a
+ * process that dies mid-wait loses only the waiting: the run itself carries on, and a later
+ * `deepnote.getRun(id)` then `wait()` picks the result up.
+ */
+
+/** How to wait for a run. */
+export interface WaitOptions {
+  /**
+   * Total time to wait before giving up on watching, after which {@link DeepnoteRunTimeout} is
+   * thrown. The run itself is unaffected.
+   */
+  timeoutMs?: number
+  /** How often to poll. */
+  intervalMs?: number
+  /** Called on every status change, for a progress display. */
+  onStatus?: (status: string) => void
+  /** Return a failed run instead of throwing {@link DeepnoteRunError}. */
+  allowFailure?: boolean
+  signal?: AbortSignal
+}
+
+/** What one finished run produced. */
+export interface RunResult<B extends OutputBindings = Record<string, never>> extends PipelineStepResult {
+  /** The named outputs the notebook's bindings declared. `{}` when there are none. */
+  values: BoundOutputs<B>
+}
+
+/** The connection every handle carries: where to call, what to call it with, and how to wait. */
+export interface ClientContext {
+  baseUrl: string
+  token: string
+  poll?: Omit<PollOptions, 'onStatus'>
+  snapshot?: WaitForRunSnapshotOptions
+  signal?: AbortSignal
+}
+
+/** A started run: an id, a status, and the operations you can perform on it. */
+export class Run<B extends OutputBindings = Record<string, never>> {
+  /** The Deepnote run id. Stable, and enough on its own to pick the run up from another process. */
+  readonly id: string
+  /** Status as of the last response. Use {@link refresh} or {@link wait} for a newer one. */
+  readonly status: string
+  readonly notebookId: string | undefined
+  readonly createdAt: string | undefined
+  /** The raw normalized API response, for anything this class does not surface. */
+  readonly raw: NormalizedRun
+
+  private readonly context: ClientContext
+  private readonly bindings: B
+  private readonly startedMs: number
+
+  constructor(run: NormalizedRun, context: ClientContext, bindings: B, startedMs = Date.now()) {
+    this.id = run.runId
+    this.status = run.status
+    this.notebookId = run.notebookId
+    this.createdAt = run.createdAt
+    this.raw = run
+    this.context = context
+    this.bindings = bindings
+    this.startedMs = startedMs
+  }
+
+  /** True once the run has reached a state it will not leave. */
+  get isTerminal(): boolean {
+    return isTerminalStatus(this.status)
+  }
+
+  /** Fetch the run's current state. Returns a new handle; this one is left as it was. */
+  async refresh(): Promise<Run<B>> {
+    const run = await getRun(this.context.baseUrl, this.context.token, this.id, { signal: this.context.signal })
+    return new Run(run, this.context, this.bindings, this.startedMs)
+  }
+
+  /**
+   * Poll until the run finishes, then read its snapshot.
+   *
+   * Throws {@link DeepnoteRunError} for a failed run unless `allowFailure` is set. A failed run is
+   * still returned with its snapshot in that case, because the snapshot is where the failing
+   * block's error is. Throws {@link DeepnoteRunTimeout} when `timeoutMs` passes first; the run is
+   * untouched by that and can be picked up again by id.
+   */
+  async wait(options: WaitOptions = {}): Promise<RunResult<B>> {
+    const signal = options.signal ?? this.context.signal
+    const completed = await pollRunUntilComplete(this.context.baseUrl, this.context.token, this.id, {
+      ...this.context.poll,
+      ...(options.intervalMs === undefined ? {} : { intervalMs: options.intervalMs }),
+      ...(options.timeoutMs === undefined ? {} : { timeoutMs: options.timeoutMs }),
+      signal,
+      onStatus: options.onStatus ? status => options.onStatus?.(status) : undefined,
+    }).catch((error: unknown) => {
+      if (error instanceof RunTimeoutError) {
+        throw new DeepnoteRunTimeout(error.runId, error.lastStatus, { cause: error })
+      }
+      throw error
+    })
+
+    // Read the snapshot even for a failed run: it is usually the only record of what went wrong.
+    const settled = await waitForRunSnapshot(this.context.baseUrl, this.context.token, completed, {
+      ...this.context.snapshot,
+      signal,
+    })
+    const success = isSuccessStatus(completed.status)
+    const parsed = settled.content ? readSnapshotSafely(settled.content) : { snapshot: null, outputs: [] }
+
+    const step = finishResult(
+      {
+        id: this.id,
+        target: 'cloud',
+        success,
+        status: completed.status,
+        outputs: parsed.outputs,
+        snapshotYaml: settled.content,
+        snapshot: parsed.snapshot,
+        runId: completed.runId,
+        error: success
+          ? undefined
+          : (describeRunError(completed) ?? `the run finished with status "${completed.status}"`),
+      },
+      this.startedMs,
+      new Date(this.startedMs).toISOString()
+    )
+
+    if (!success && !options.allowFailure) {
+      throw new DeepnoteRunError(step)
+    }
+
+    // Bindings are only resolvable from a run that produced outputs; a failed run the caller chose
+    // to allow gets an empty `values` rather than an error that hides the failure it asked to see.
+    const values = success ? resolveBindings(this.bindings, step) : ({} as BoundOutputs<B>)
+    return { ...step, values }
+  }
+}
+
+/** Parse a snapshot without letting a malformed one destroy the result. */
+function readSnapshotSafely(snapshotYaml: string): { snapshot: SnapshotView | null; outputs: RunBlockOutput[] } {
+  try {
+    return { snapshot: parseSnapshot(snapshotYaml), outputs: extractOutputs(snapshotYaml) }
+  } catch {
+    return { snapshot: null, outputs: [] }
+  }
+}

--- a/packages/pipelines/src/index.ts
+++ b/packages/pipelines/src/index.ts
@@ -1,3 +1,25 @@
+export type {
+  BoundOutputs,
+  ClientContext,
+  DeepnoteOptions,
+  OutputBinding,
+  OutputBindings,
+  RunOptions,
+  RunResult,
+  WaitOptions,
+} from './client'
+export {
+  API_URL_ENV,
+  Deepnote,
+  DeepnoteRunError,
+  DeepnoteRunTimeout,
+  NotebookRef,
+  NotebooksResource,
+  outputs,
+  Run,
+  resolveBindings,
+  TOKEN_ENV,
+} from './client'
 export type { CloudExecutorOptions } from './cloud-executor'
 export { createCloudStepExecutor, DEFAULT_CLOUD_API_URL } from './cloud-executor'
 export { evaluateCondition } from './condition-expression'


### PR DESCRIPTION
**4 of 5.** Stacked on #498 → #497 → #496. The diff shown here is against #498's branch.

A JS/TS client where an agent or a person writes a deterministic pipeline as ordinary code: launch, wait, pass outputs on. No orchestration engine anywhere in the picture.

## Two layers, and only two

| Layer | Where | What it is |
| --- | --- | --- |
| Close to HTTP | `@deepnote/cloud` | A plain map of the v2 API. Unchanged by this PR. |
| Ergonomic handles | `@deepnote/pipelines` (`src/client/`) | Awaitable runs, notebook handles, named outputs. |

There is no third layer. `Workflow`, `DAG`, `Task` and `Scheduler` are deliberately not runtime concepts: the composition layer is the calling language. A caller who wants the execution graph and event stream imports `runPipeline` from `@deepnote/pipelines` directly.

```ts
const deepnote = Deepnote.fromEnv()

const extract = deepnote.notebooks.define({
  id: 'nb-extract',
  outputs: {
    datasetUri: outputs.text('uri-block'),
    rowCount: outputs.json<number>('stats-block', 'row_count'),
  },
})

const run = await extract.run({ inputs: { region: 'eu', months: 6 } })
const result = await run.wait({ onStatus: console.log })
result.values.rowCount // number
```

`Promise.all` fans out, `if` branches, `try/catch` handles failure.

## What's here

- **`Deepnote` / `Deepnote.fromEnv()`** reads `DEEPNOTE_TOKEN` and `DEEPNOTE_API_URL`. A credential that is never an argument cannot end up in a log of arguments.
- **`Run`** is the primitive. Starting and waiting are separate because they are separate in the API. `wait()` holds no state the server does not already have.
- **`deepnote.getRun(id)`** picks up a run this process did not start.
- **`notebook.runs({ pageSize, pageToken })`** lists a notebook's run history as a page with a cursor.
- **`DeepnoteRunError`** carries the whole result, since the snapshot is usually the only place the failing block's own error is recorded. `allowFailure: true` returns it instead.
- **`DeepnoteRunTimeout`** says the run itself is unaffected and names the id to pick it up with.
- **Named outputs as a client-side contract.** Inputs are named server-side; outputs are not. Errors name your binding, not a block id you never typed. `outputs.lastJson()` avoids block ids entirely.

## Deliberately not here

- No retry policy. A notebook can write files, move data, or spend model budget.
- No durability. `getRun(id)` is the resume story.
- No notebook creation. Running a notebook needs permission to run it, not to create one.
- No JSONPath. Bindings take a dotted path with numeric indexes and refuse anything else.

## Changes since the previous revision

- `deepnote.pipeline(fn)` removed, so the two-layer claim is true.
- The cloud client's timeout error is translated into `DeepnoteRunTimeout`.
- `listRuns` renamed to `runs`, returning the page object so pagination stays possible.
- Rebased onto #498; the Workflow SDK and scheduled-runner PRs it previously sat on are closed.

The Python counterpart is #505.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Deepnote client SDK for launching, monitoring, refreshing, and listing notebook runs.
  * Added typed outputs, named bindings, snapshots, cancellation, polling, and run failure and timeout handling.
  * Added JavaScript pipeline composition with concurrency, gating, sequencing, fan-out, fallbacks, and tolerated failures.
  * Added pipeline planning and file-based execution APIs.
  * Added an executable SDK pipeline example and local-runner workflow.
* **Documentation**
  * Expanded guidance for client APIs, execution lifecycle, composition, and file-based pipelines.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->