### PR TITLE
chore: ignore local worktrees under .claude/worktrees

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.claude/worktrees
 .DS_Store
 .env
 .npmrc


### PR DESCRIPTION
Agent worktrees are created inside the repo at `.claude/worktrees/`, where git sees them as untracked gitlinks — they can be (and were) accidentally staged. Adding the directory to `.gitignore`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)