### PR TITLE
docs(skill): add an app-models reference and fix the skill sync map

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -216,8 +216,12 @@ const fixturePath = path.join(testFixturesDir, "my-fixture.ipynb");
 The `skills/deepnote/` directory contains reference documentation used by AI agents. When making changes to any of the following, you **must** also update the corresponding skill files:
 
 - **`.deepnote` file format** (block types, metadata, schema) — update `skills/deepnote/references/blocks-*.md` and `skills/deepnote/references/schema.ts`
-- **CLI commands** (options, output formats, exit codes, new commands) — update `skills/deepnote/references/cli-*.md`
-- **MCP tools** (tool names, parameters, behavior) — update `skills/deepnote/references/cli-*.md` (MCP mirrors CLI commands)
+- **CLI commands** (options, output formats, exit codes, new commands) — update the corresponding `skills/deepnote/references/cli-*.md`
+- **Local `@deepnote/mcp`** (tool names, parameters, behavior) — update `packages/mcp/README.md` and any local-MCP skill reference that describes it. Do not record local MCP behavior in the CLI references: the local MCP server is its own surface, not a mirror of the CLI
+- **Hosted MCP** (`https://deepnote.com/mcp`) — update `docs/deepnote-mcp.md`, and coordinate the separate codex-plugin consumer, which is not maintained in this repository
+- **App types, publishing ownership, runtime choices, or token boundaries** — update `skills/deepnote/references/apps.md`
+
+Update more than one reference only when the underlying behavior actually crosses those surfaces.
 
 ## Git & Pull Request Rules
 

--- a/skills/deepnote/SKILL.md
+++ b/skills/deepnote/SKILL.md
@@ -271,6 +271,15 @@ deepnote run project.deepnote -o json                  # JSON output
 3. If errors, check snapshot for details
 4. Fix and re-run
 
+## Apps
+
+Deepnote apps come in several distinct models (data apps, Streamlit apps, published static sites,
+published browser apps with viewer API access, and local `serveStatic` apps) with different
+hosting, credentials, and file ownership.
+
+- Read [Deepnote apps](references/apps.md) when choosing, building, previewing, publishing, or
+  explaining a Deepnote app.
+
 ## CLI Quick Reference
 
 | Command                                 | Description                                                                                                                                                                                                                                                                                         |

--- a/skills/deepnote/references/apps.md
+++ b/skills/deepnote/references/apps.md
@@ -58,11 +58,11 @@ deepnote publish ./dist --project-id <uuid>
 stale ones, enables website sharing, and prints the canonical URL. Use that returned URL — never
 assemble a static-site URL by hand.
 
-Ownership note: `deepnote sync --all-files` mirrors a project's working-directory files, and that
-inventory currently includes `_deepnote_static/**`, so a published build and a synced workspace can
-fight over the same paths. Coordination between the two commands is in flight; treat `publish` as the
-writer for that namespace, and re-verify this paragraph against `references/cli-publish.md` and
-`references/cli-sync.md` once the coordination lands.
+Ownership note: the static root is a subtree of the same project file store that
+`deepnote sync --all-files` mirrors, so both commands can write those paths. `publish` is the
+deploying writer — build output goes through `publish`, not through a synced workspace. How the two
+commands stay in step is the CLI's concern, not the app author's; see `references/cli-publish.md`
+and `references/cli-sync.md` before scripting a workflow that runs both.
 
 See `references/cli-publish.md` for options and exit codes.
 

--- a/skills/deepnote/references/apps.md
+++ b/skills/deepnote/references/apps.md
@@ -1,0 +1,156 @@
+# Deepnote apps
+
+Deepnote has several distinct app models. They differ in what the app is made of, where it runs, who
+hosts it, and what credentials it gets. Choosing the wrong one usually shows up late — as a file an
+agent cannot create, hardware that is not there, or an API call that silently does nothing once the
+app is published.
+
+Read this before choosing, building, previewing, publishing, or explaining a Deepnote app.
+
+## Decision table
+
+| Need                                                 | Model                                 | Hosting                     | Viewer-scoped API access               | Project hardware    | Can an agent create the files?          |
+| ---------------------------------------------------- | ------------------------------------- | --------------------------- | -------------------------------------- | ------------------- | --------------------------------------- |
+| Present notebook blocks with inputs and outputs      | Data app (notebook app)               | Deepnote                    | Not applicable (app runs the notebook) | Yes                 | No — created in the Deepnote UI         |
+| Python UI framework, custom widgets                  | Streamlit app                         | Deepnote (project hardware) | Not applicable (server-side Python)    | Yes                 | Yes — it is a `.py` file in the project |
+| Custom HTML/JS, no Deepnote calls                    | Published static site                 | Deepnote (browser only)     | No                                     | No                  | Yes — plain files + `deepnote publish`  |
+| Custom HTML/JS that starts and reads notebook runs   | Published browser app with API access | Deepnote (browser only)     | Yes, viewer-scoped, run loop only      | Yes, for the run    | Yes — same, plus `--api-access enabled` |
+| Custom UI plus local Python, scheduling, run history | Local Node app (`serveStatic`)        | Local machine               | No — it uses the operator's own token  | Only for cloud runs | Yes — static dir + a `serve.mjs`        |
+
+## 1. Data apps (notebook apps)
+
+Built from notebook blocks through Deepnote's app UI: choose which blocks appear, whether a block
+shows code, output, or both, then set app permissions independently of the project's. Viewers change
+input blocks and re-run; runs are stateless per viewer and execute on the project's hardware.
+
+This is the right model when the deliverable is the notebook itself. It is not deprecated, and it is
+not a fallback for the other models — use the product terms "data app" or "notebook app".
+
+An agent cannot create one from files: app creation and its settings live in the Deepnote product.
+An agent's contribution is the notebook — blocks, inputs, layout-friendly ordering. See
+`docs/data-apps.md` for the product behavior.
+
+## 2. Streamlit apps
+
+A `.py` entrypoint in the project, served on the **project's hardware**. Deepnote detects a Streamlit
+file and deploys it; the app inherits the project's environment, integrations, and sharing settings,
+and sleeps when the hardware is inactive.
+
+An agent working on local files can write and edit that `.py` file like any other source file. What
+it cannot do is create the file remotely: hosted MCP can activate an existing entrypoint in a
+project, but it cannot upload or author the `.py` file itself. Do not plan a workflow that assumes an
+agent can stand up a complete Streamlit app in a hosted project from scratch.
+
+Streamlit apps run server-side Python, so they use ordinary integration access, not a viewer token.
+Federated-auth integrations are the exception — each viewer authenticates individually
+(`docs/streamlit.md`).
+
+## 3. Published static sites
+
+Browser files — HTML, JS, CSS, assets — stored below `_deepnote_static/**` in the project's file
+store and served by Deepnote. There is no server: whatever the browser can do, the app can do.
+
+```bash
+deepnote publish ./dist --project-id <uuid>
+```
+
+`publish` owns the `_deepnote_static/**` namespace. It replaces matching files, optionally prunes
+stale ones, enables website sharing, and prints the canonical URL. Use that returned URL — never
+assemble a static-site URL by hand.
+
+Ownership note: `deepnote sync --all-files` mirrors a project's working-directory files, and that
+inventory currently includes `_deepnote_static/**`, so a published build and a synced workspace can
+fight over the same paths. Coordination between the two commands is in flight; treat `publish` as the
+writer for that namespace, and re-verify this paragraph against `references/cli-publish.md` and
+`references/cli-sync.md` once the coordination lands.
+
+See `references/cli-publish.md` for options and exit codes.
+
+## 4. Published browser apps with API access
+
+A published static site with **API access for static apps** enabled — a separate opt-in from website
+sharing:
+
+```bash
+deepnote publish ./dist --project-id <uuid> --api-access enabled
+```
+
+The embedded page never carries a personal token. The Deepnote shell hands it a short-lived,
+project- and viewer-scoped token over `postMessage`, together with the API origin to send it to; the
+app must pin the shell origin in both directions of that handshake. A personal token used during
+local development stays local and is never embedded in the published site.
+
+The viewer token is limited to one run loop:
+
+| Allowed                                                                          | Not allowed                    |
+| -------------------------------------------------------------------------------- | ------------------------------ |
+| Read the configured notebook's inputs and block metadata, without source content | Enumerate notebooks            |
+| Start a detached run                                                             | Enumerate run history          |
+| Poll that viewer's own run by id                                                 | Call arbitrary `/v2` endpoints |
+| Receive sanitized output blocks (`snapshotBlocks`) instead of raw snapshot YAML  | Read another viewer's run      |
+
+The consequence is a quiet failure mode: code developed against a local preview with a personal
+token keeps working there and does nothing once embedded, with no error. Guard those paths on an
+`isEmbedded` check rather than letting them fail silently — `examples/local-runner/cloud-app`
+does exactly this for its run-history panel, and is the reference implementation for the handshake.
+
+## 5. Local Node-backed apps (`serveStatic`)
+
+`serveStatic` from `@deepnote/local-runner` is a **local server runtime**, not a published site. It
+serves a static directory from `127.0.0.1` and adds a small API in front of a `.deepnote` file. This
+is the model for a local dashboard or a demo on the operator's machine; publishing its directory to
+Deepnote gives you model 3 or 4 instead, with none of these routes.
+
+```ts
+const { port, close } = await serveStatic({
+  dir,
+  notebookPath,
+  runTarget: "cloud",
+});
+```
+
+| Route                         | Request                                                             | Response                                                                                      |
+| ----------------------------- | ------------------------------------------------------------------- | --------------------------------------------------------------------------------------------- |
+| `GET /api/info`               | —                                                                   | `{ notebook, inputs, runTarget }` — input blocks for building controls, plus where runs go    |
+| `POST /api/run`               | `{ inputs }`                                                        | `{ target, success, outputs, summary, snapshotYaml, runId?, viewUrl?, created? }`             |
+| `POST /api/schedule-cloud`    | `{ schedule: { frequency, time, … }, timezone? }` or raw `{ cron }` | the created or updated cloud schedule; does not run the notebook now                          |
+| `GET /api/cloud-runs`         | —                                                                   | `{ runs, viewUrl }`; `{ runs: [] }` when there is no token or the notebook is not in Deepnote |
+| `GET /api/cloud-runs/{runId}` | —                                                                   | `{ runId, status, success, outputs, snapshotYaml }` for one past run, without re-running it   |
+
+Any other `GET` serves a file from the directory, path-traversal and symlink guarded.
+
+**Run target.** One endpoint, one button, wherever the run happens. `runTarget` defaults to `cloud`
+— `POST /api/run` goes to Deepnote (needs `DEEPNOTE_TOKEN`) and creates the notebook there if it
+does not exist yet. `runTarget: 'local'` runs in a local Python kernel instead, which needs
+`deepnote-toolkit[server]`, and writes a snapshot next to the notebook like `deepnote run`. A local
+run reports no `runId`/`viewUrl`, and the cloud-run routes answer empty.
+
+**Rendering stays in the page.** To display outputs, use the `snapshot-reader.js` browser bundle
+(`@deepnote/local-runner/snapshot-reader`) to parse snapshot YAML client-side. Embedded published
+apps (model 4) do not need it for run results — those arrive pre-parsed as `snapshotBlocks`.
+
+See `packages/local-runner/README.md` and `examples/local-runner/run-app` for the full package
+surface.
+
+## MCP surfaces are not interchangeable
+
+Three separate things, often confused:
+
+- **`@deepnote/mcp`** — the local-file MCP server shipped from this repository. It reads, writes,
+  converts, and runs `.deepnote` files on the local filesystem. It knows nothing about hosted
+  projects, publishing, or apps.
+- **Hosted MCP at `https://deepnote.com/mcp`** — operates on hosted workspace state (projects,
+  notebooks, blocks, runs, integrations) under the authenticating identity's permissions. See
+  `docs/deepnote-mcp.md`; the authoritative tool list is the server's own `tools/list`, so do not
+  assume a fixed set or count.
+- **Codex-plugin documentation and skills** — a _consumer_ of the hosted MCP, not a third MCP
+  implementation.
+
+The limitation that changes app plans:
+
+> Hosted MCP can configure static-site sharing/API access and activate existing app files, but it
+> cannot currently upload the underlying static-site or Streamlit files.
+
+So a hosted-only agent can finish an app whose files already exist, and cannot start one. Getting the
+files there is `deepnote publish` (static sites) or the Deepnote UI / a synced project file
+(Streamlit).


### PR DESCRIPTION
"Build me a Deepnote app" has five different answers, and the skill said which one to pick nowhere. An agent had to assemble the picture from `cli-publish.md`, `examples/local-runner/cloud-app/README.md`, `examples/local-runner/run-app/README.md`, and the local-runner package docs — and the only place that mentioned app tokens at all was the publish reference, describing the CLI flag rather than the boundary behind it.

## `skills/deepnote/references/apps.md`

Five models, each with what it is made of, where it runs, who hosts it, and what credentials it gets:

1. **Data apps (notebook apps)** — notebook blocks presented through Deepnote's app UI. Not deprecated, not a fallback; an agent contributes the notebook, not the app.
2. **Streamlit apps** — a `.py` entrypoint on project hardware. Hosted MCP can activate an existing entrypoint but cannot upload or author the file, so a "build a Streamlit app from scratch in a hosted project" plan does not work.
3. **Published static sites** — browser files below `_deepnote_static/**`, deployed by `deepnote publish`, which owns that namespace.
4. **Published browser apps with API access** — the same, plus a viewer token.
5. **Local Node-backed apps** (`serveStatic`) — a local server runtime, with the complete five-route contract documented.

A decision table opens the file, keyed on the questions that change the plan: notebook blocks vs. custom HTML/JS vs. Python, browser-only vs. local Node server, viewer API access, project hardware, and whether an agent can create the underlying files with its current tools.

### The two boundaries worth the file

**Publishing ownership.** `publish` owns `_deepnote_static/**`; the canonical URL comes from the API, never hand-assembled.

**The viewer token.** A published app never carries the personal token used in local preview. The shell hands it a short-lived, project- and viewer-scoped token over an origin-pinned `postMessage` handshake, limited to: read the configured notebook's inputs and block metadata without source content, start a detached run, poll that viewer's own run by id, receive sanitized `snapshotBlocks`. Not notebook enumeration, not run-history enumeration, not arbitrary `/v2`. The failure mode is silent — the same code works locally with a personal token — which is why `examples/local-runner/cloud-app` guards on `isEmbedded`.

## `AGENTS.md`

The sync section said MCP tool changes go in `skills/deepnote/references/cli-*.md` "(MCP mirrors CLI commands)". That is wrong in both directions: `@deepnote/mcp` has tools with no CLI equivalent, and the CLI has commands (`publish`, `sync`, `install-skills`) with no MCP tool. It routed local-MCP changes into the CLI references. Replaced with a map from each surface to its owning document, distinguishing three things that get conflated: local `@deepnote/mcp`, hosted MCP at `deepnote.com/mcp`, and the codex-plugin consumer of the hosted server.

## Scope

Documentation only. `cli-sync.md`, `cli-publish.md`, CLI implementation, public docs, and MCP implementation are deliberately untouched — they are moving in #492, #508, and #491.

## Relationship to #508

No conflict, and no merge order. The two PRs touch disjoint files (#508 is CLI/cloud source plus `cli-publish.md` and `cli-sync.md`; this is `AGENTS.md`, `SKILL.md`, and the new reference), and `apps.md` no longer describes the publish/sync coordination as pending. Note that #508 resolves the overlap by sharing one baseline rather than excluding `_deepnote_static` from `sync --all-files`, so this file states only the part an app author needs — `publish` is the deploying writer for the static root — and defers the mechanism to the CLI references, which #508 owns.

## Validation

`pnpm test` (3086 passed, 1 skipped), `pnpm typecheck`, `pnpm biome:check`, `pnpm prettier:check`, `pnpm spell-check` all clean. Biome reports 8 `noConsole` warnings in `examples/local-runner/*/serve.mjs`, all pre-existing and untouched here.

Packaging verified end to end rather than assumed: `pnpm build` copies the new reference into `packages/cli/dist/skills/deepnote/references/`, and `deepnote install-skills --agent "Claude Code"` in a scratch directory installs `apps.md` alongside the rest.

No skill validator (`quick_validate.py`) or skill-creator skill is present in this checkout, so that step could not be run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

