### PR TITLE
docs: format FAQs for schema extraction

### DIFF
--- a/docs/machine-hours.md
+++ b/docs/machine-hours.md
@@ -6,26 +6,26 @@ noContent: false
 
 Every workspace in Deepnote has free machine hours that replenish every month. If you need additional machine hours or more powerful machines, you can always upgrade your hardware.
 
-###### **What are machine hours?**
+#### What are machine hours?
 
 When you run your notebooks, we use cloud-based hardware to execute your code. Machine hours are the total amount of hours our hardware was running to execute this code.
 
-###### **How many machine hours are offered for free?**
+#### How many machine hours are offered for free?
 
 Our goal is to provide an unlimited number of free machine hours for all workspaces. However, in certain cases we might limit a workspace’s compute hours when we detect irregular activity or extremely high usage. In case this happens, we will be in touch with you.
 
-###### **How can I add more machine hours?**
+#### How can I add more machine hours?
 
 In the rare occasion that a workspace exceeds the free machine hours we provide, workspaces on the Team and Enterprise plans can purchase additional machine hours. The per-minute cost of these machines can be found in the Machines menu.
 
 <VideoLoop src="../assets/docs/caOM1cDyQWyQR6Tkn4Im.mp4" />
 
-###### **How can I upgrade to more RAM or CPU?**
+#### How can I upgrade to more RAM or CPU?
 
 Workspaces on the Team and Enterprise plans can choose to switch to stronger machines, with higher computation power and RAM. The per-minute cost of these machines can be found in the Machines menu.
 
 <VideoLoop src="../assets/docs/caOM1cDyQWyQR6Tkn4Im.mp4" />
 
-###### **How much will I be charged for machines?**
+#### How much will I be charged for machines?
 
 If you decide to purchase machine hours beyond the free machine hours we provide, you will be charged on a per-minute basis. Machine prices are shown per minute in the Machines menu, so you only pay for the exact time your hardware runs.

--- a/docs/machine-hours.md
+++ b/docs/machine-hours.md
@@ -6,26 +6,26 @@ noContent: false
 
 Every workspace in Deepnote has free machine hours that replenish every month. If you need additional machine hours or more powerful machines, you can always upgrade your hardware.
 
-#### What are machine hours?
+### What are machine hours?
 
 When you run your notebooks, we use cloud-based hardware to execute your code. Machine hours are the total amount of hours our hardware was running to execute this code.
 
-#### How many machine hours are offered for free?
+### How many machine hours are offered for free?
 
 Our goal is to provide an unlimited number of free machine hours for all workspaces. However, in certain cases we might limit a workspace’s compute hours when we detect irregular activity or extremely high usage. In case this happens, we will be in touch with you.
 
-#### How can I add more machine hours?
+### How can I add more machine hours?
 
 In the rare occasion that a workspace exceeds the free machine hours we provide, workspaces on the Team and Enterprise plans can purchase additional machine hours. The per-minute cost of these machines can be found in the Machines menu.
 
 <VideoLoop src="../assets/docs/caOM1cDyQWyQR6Tkn4Im.mp4" />
 
-#### How can I upgrade to more RAM or CPU?
+### How can I upgrade to more RAM or CPU?
 
 Workspaces on the Team and Enterprise plans can choose to switch to stronger machines, with higher computation power and RAM. The per-minute cost of these machines can be found in the Machines menu.
 
 <VideoLoop src="../assets/docs/caOM1cDyQWyQR6Tkn4Im.mp4" />
 
-#### How much will I be charged for machines?
+### How much will I be charged for machines?
 
 If you decide to purchase machine hours beyond the free machine hours we provide, you will be charged on a per-minute basis. Machine prices are shown per minute in the Machines menu, so you only pay for the exact time your hardware runs.

--- a/docs/machine-hours.md
+++ b/docs/machine-hours.md
@@ -6,26 +6,26 @@ noContent: false
 
 Every workspace in Deepnote has free machine hours that replenish every month. If you need additional machine hours or more powerful machines, you can always upgrade your hardware.
 
-### What are machine hours?
+## What are machine hours?
 
 When you run your notebooks, we use cloud-based hardware to execute your code. Machine hours are the total amount of hours our hardware was running to execute this code.
 
-### How many machine hours are offered for free?
+## How many machine hours are offered for free?
 
 Our goal is to provide an unlimited number of free machine hours for all workspaces. However, in certain cases we might limit a workspace’s compute hours when we detect irregular activity or extremely high usage. In case this happens, we will be in touch with you.
 
-### How can I add more machine hours?
+## How can I add more machine hours?
 
 In the rare occasion that a workspace exceeds the free machine hours we provide, workspaces on the Team and Enterprise plans can purchase additional machine hours. The per-minute cost of these machines can be found in the Machines menu.
 
 <VideoLoop src="../assets/docs/caOM1cDyQWyQR6Tkn4Im.mp4" />
 
-### How can I upgrade to more RAM or CPU?
+## How can I upgrade to more RAM or CPU?
 
 Workspaces on the Team and Enterprise plans can choose to switch to stronger machines, with higher computation power and RAM. The per-minute cost of these machines can be found in the Machines menu.
 
 <VideoLoop src="../assets/docs/caOM1cDyQWyQR6Tkn4Im.mp4" />
 
-### How much will I be charged for machines?
+## How much will I be charged for machines?
 
 If you decide to purchase machine hours beyond the free machine hours we provide, you will be charged on a per-minute basis. Machine prices are shown per minute in the Machines menu, so you only pay for the exact time your hardware runs.

--- a/docs/pricing.md
+++ b/docs/pricing.md
@@ -7,15 +7,15 @@ noContent: false
 
 Deepnote currently offers 3 plans: Free, Team, and Enterprise. You can read more about the features of each plan on our [Pricing page](https://deepnote.com/pricing).
 
-###### **How do I upgrade my plan?**
+#### How do I upgrade my plan?
 
 You can upgrade or downgrade your plan from the Plans page in your workspace settings. If you need to upgrade to the Enterprise plan, you can schedule a quick chat with our customer success team here.
 
-###### **How much will I be charged when I upgrade**
+#### How much will I be charged when I upgrade?
 
 When you upgrade to a paid plan, you will be charged per editor and admin seat in your workspace. For example, if you have 1 Admin seat and 4 Editor seats, you will be charged for 5 total seats. You will not be charged for other roles, such as Viewers.
 
-###### **Can I still add or remove seats in my workspace after upgrading?**
+#### Can I still add or remove seats in my workspace after upgrading?
 
 Yes! While on a paid plan, you can add or remove Editor/Admin seats at any time. At the start of the next subscription period, you will be billed for the number of Editor/Admin seats present at the time of billing. If you are on annual billing, you will be charged for the added seats a prorated price for remaining time of the annual billing period. All charges when adding new seats are billed when the added users accept the invites.
 
@@ -23,20 +23,20 @@ _Example 1_: You created a workspace with 1 admin and 3 editors on the 1st of th
 
 _Example 2_: You created a workspace with 1 admin and 3 editors on January 1st 2023 and selected yearly billing. At the beginning of the year, you paid for 4 seats. In June, you decided to add 1 more editor. When the new editor accepted your invite, your card was charged for the remaining 6 months for this user. On January 1st 2024 you will be charged for 5 seats. If you decide to remove one of the members at any point during the annual period, the seat that you paid for will stay available for anyone else to join. If you then add a new editor again, you will not be charged during the current billing period.
 
-###### **How do I downgrade or cancel my plan?**
+#### How do I downgrade or cancel my plan?
 
 You can downgrade or cancel your plan from the Plans page in your workspace settings. If you are on a monthly plan, you will receive a prorated refund for any unused days once you downgrade. Annual plans are not eligible for refunds upon downgrade or cancellation.
 
-###### **Will I receive a refund if I downgrade or cancel my plan?**
+#### Will I receive a refund if I downgrade or cancel my plan?
 
 If you remove a paid seat, we won’t issue a prorated refund. However, someone else at your company can use their paid seat when it becomes available.
 If you are on a monthly plan and downgrade or cancel your subscription, we will refund you a prorated amount for any unused days of the month. Annual plans are not eligible for refunds upon downgrade or cancellation.
 
-###### **How is AI usage billed?**
+#### How is AI usage billed?
 
 Deepnote AI usage is billed on a usage basis. Each plan includes a monthly AI quota, and usage beyond the quota is billed as pay-as-you-go. Workspace admins can set a custom monthly overage limit to cap spending, and receive quota-related emails as usage approaches or exceeds the included allowance. Admins can also review detailed AI usage — token consumption and cost per user and across the workspace — in the workspace settings. Note that the Free plan includes a limited number of AI requests per month.
 
-###### **Do you offer any plans or discounts for schools and NGOs?**
+#### Do you offer any plans or discounts for schools and NGOs?
 
 Members of educational institutions, such as students, teachers, and researchers, are all eligible for our Education plan. The Education plan has almost all the same features of the Team plan, except that it’s completely free! To find out more about the Education plan, visit our website and sign up with your educational email.
 

--- a/docs/pricing.md
+++ b/docs/pricing.md
@@ -7,15 +7,15 @@ noContent: false
 
 Deepnote currently offers 3 plans: Free, Team, and Enterprise. You can read more about the features of each plan on our [Pricing page](https://deepnote.com/pricing).
 
-#### How do I upgrade my plan?
+### How do I upgrade my plan?
 
 You can upgrade or downgrade your plan from the Plans page in your workspace settings. If you need to upgrade to the Enterprise plan, you can schedule a quick chat with our customer success team here.
 
-#### How much will I be charged when I upgrade?
+### How much will I be charged when I upgrade?
 
 When you upgrade to a paid plan, you will be charged per editor and admin seat in your workspace. For example, if you have 1 Admin seat and 4 Editor seats, you will be charged for 5 total seats. You will not be charged for other roles, such as Viewers.
 
-#### Can I still add or remove seats in my workspace after upgrading?
+### Can I still add or remove seats in my workspace after upgrading?
 
 Yes! While on a paid plan, you can add or remove Editor/Admin seats at any time. At the start of the next subscription period, you will be billed for the number of Editor/Admin seats present at the time of billing. If you are on annual billing, you will be charged for the added seats a prorated price for remaining time of the annual billing period. All charges when adding new seats are billed when the added users accept the invites.
 
@@ -23,20 +23,20 @@ _Example 1_: You created a workspace with 1 admin and 3 editors on the 1st of th
 
 _Example 2_: You created a workspace with 1 admin and 3 editors on January 1st 2023 and selected yearly billing. At the beginning of the year, you paid for 4 seats. In June, you decided to add 1 more editor. When the new editor accepted your invite, your card was charged for the remaining 6 months for this user. On January 1st 2024 you will be charged for 5 seats. If you decide to remove one of the members at any point during the annual period, the seat that you paid for will stay available for anyone else to join. If you then add a new editor again, you will not be charged during the current billing period.
 
-#### How do I downgrade or cancel my plan?
+### How do I downgrade or cancel my plan?
 
 You can downgrade or cancel your plan from the Plans page in your workspace settings. If you are on a monthly plan, you will receive a prorated refund for any unused days once you downgrade. Annual plans are not eligible for refunds upon downgrade or cancellation.
 
-#### Will I receive a refund if I downgrade or cancel my plan?
+### Will I receive a refund if I downgrade or cancel my plan?
 
 If you remove a paid seat, we won’t issue a prorated refund. However, someone else at your company can use their paid seat when it becomes available.
 If you are on a monthly plan and downgrade or cancel your subscription, we will refund you a prorated amount for any unused days of the month. Annual plans are not eligible for refunds upon downgrade or cancellation.
 
-#### How is AI usage billed?
+### How is AI usage billed?
 
 Deepnote AI usage is billed on a usage basis. Each plan includes a monthly AI quota, and usage beyond the quota is billed as pay-as-you-go. Workspace admins can set a custom monthly overage limit to cap spending, and receive quota-related emails as usage approaches or exceeds the included allowance. Admins can also review detailed AI usage — token consumption and cost per user and across the workspace — in the workspace settings. Note that the Free plan includes a limited number of AI requests per month.
 
-#### Do you offer any plans or discounts for schools and NGOs?
+### Do you offer any plans or discounts for schools and NGOs?
 
 Members of educational institutions, such as students, teachers, and researchers, are all eligible for our Education plan. The Education plan has almost all the same features of the Team plan, except that it’s completely free! To find out more about the Education plan, visit our website and sign up with your educational email.
 

--- a/docs/pricing.md
+++ b/docs/pricing.md
@@ -7,15 +7,15 @@ noContent: false
 
 Deepnote currently offers 3 plans: Free, Team, and Enterprise. You can read more about the features of each plan on our [Pricing page](https://deepnote.com/pricing).
 
-### How do I upgrade my plan?
+## How do I upgrade my plan?
 
 You can upgrade or downgrade your plan from the Plans page in your workspace settings. If you need to upgrade to the Enterprise plan, you can schedule a quick chat with our customer success team here.
 
-### How much will I be charged when I upgrade?
+## How much will I be charged when I upgrade?
 
 When you upgrade to a paid plan, you will be charged per editor and admin seat in your workspace. For example, if you have 1 Admin seat and 4 Editor seats, you will be charged for 5 total seats. You will not be charged for other roles, such as Viewers.
 
-### Can I still add or remove seats in my workspace after upgrading?
+## Can I still add or remove seats in my workspace after upgrading?
 
 Yes! While on a paid plan, you can add or remove Editor/Admin seats at any time. At the start of the next subscription period, you will be billed for the number of Editor/Admin seats present at the time of billing. If you are on annual billing, you will be charged for the added seats a prorated price for remaining time of the annual billing period. All charges when adding new seats are billed when the added users accept the invites.
 
@@ -23,20 +23,20 @@ _Example 1_: You created a workspace with 1 admin and 3 editors on the 1st of th
 
 _Example 2_: You created a workspace with 1 admin and 3 editors on January 1st 2023 and selected yearly billing. At the beginning of the year, you paid for 4 seats. In June, you decided to add 1 more editor. When the new editor accepted your invite, your card was charged for the remaining 6 months for this user. On January 1st 2024 you will be charged for 5 seats. If you decide to remove one of the members at any point during the annual period, the seat that you paid for will stay available for anyone else to join. If you then add a new editor again, you will not be charged during the current billing period.
 
-### How do I downgrade or cancel my plan?
+## How do I downgrade or cancel my plan?
 
 You can downgrade or cancel your plan from the Plans page in your workspace settings. If you are on a monthly plan, you will receive a prorated refund for any unused days once you downgrade. Annual plans are not eligible for refunds upon downgrade or cancellation.
 
-### Will I receive a refund if I downgrade or cancel my plan?
+## Will I receive a refund if I downgrade or cancel my plan?
 
 If you remove a paid seat, we won’t issue a prorated refund. However, someone else at your company can use their paid seat when it becomes available.
 If you are on a monthly plan and downgrade or cancel your subscription, we will refund you a prorated amount for any unused days of the month. Annual plans are not eligible for refunds upon downgrade or cancellation.
 
-### How is AI usage billed?
+## How is AI usage billed?
 
 Deepnote AI usage is billed on a usage basis. Each plan includes a monthly AI quota, and usage beyond the quota is billed as pay-as-you-go. Workspace admins can set a custom monthly overage limit to cap spending, and receive quota-related emails as usage approaches or exceeds the included allowance. Admins can also review detailed AI usage — token consumption and cost per user and across the workspace — in the workspace settings. Note that the Free plan includes a limited number of AI requests per month.
 
-### Do you offer any plans or discounts for schools and NGOs?
+## Do you offer any plans or discounts for schools and NGOs?
 
 Members of educational institutions, such as students, teachers, and researchers, are all eligible for our Education plan. The Education plan has almost all the same features of the Team plan, except that it’s completely free! To find out more about the Education plan, visit our website and sign up with your educational email.
 

--- a/docs/sql-cells.md
+++ b/docs/sql-cells.md
@@ -76,21 +76,21 @@ SQL blocks offer two distinct output modes: **DataFrame** mode and **Query previ
 Under the hood, Deepnote appends a LIMIT clause to your query preview mode queries.
 </Callout>
 
-Q: When should I use query preview mode instead of DataFrame mode?
+#### When should I use query preview mode instead of DataFrame mode?
 
-A: Use query preview mode when you want to defer from pulling data into memory or when you are building complex SQL queries that you want to test in iterations. Use DataFrame mode when you want to process the full results of a query at once.
+Use query preview mode when you want to defer from pulling data into memory or when you are building complex SQL queries that you want to test in iterations. Use DataFrame mode when you want to process the full results of a query at once.
 
-Q: Can I reference DataFrame variables in SQL blocks?
+#### Can I reference DataFrame variables in SQL blocks?
 
-A: No, you cannot reference DataFrame variables in SQL blocks. You can only reference query preview objects.
+No, you cannot reference DataFrame variables in SQL blocks. You can only reference query preview objects.
 
-Q: Can I use query preview mode with DataFrame SQL blocks?
+#### Can I use query preview mode with DataFrame SQL blocks?
 
-A: Yes! even though you are querying a DataFrame, you may want to retrieve only a subset of the data and reference the query later.
+Yes! even though you are querying a DataFrame, you may want to retrieve only a subset of the data and reference the query later.
 
-Q: Can I use query preview objects in other blocks?
+#### Can I use query preview objects in other blocks?
 
-A: Yes, you can use query previews exactly as you would use a DataFrame. Actually, the `DeepnoteQueryPreview` object that is returned is a subclass of a Pandas DataFrame. This means you can also plot it in a Chart block. However, do keep in mind that the preview only contains first 100 rows.
+Yes, you can use query previews exactly as you would use a DataFrame. Actually, the `DeepnoteQueryPreview` object that is returned is a subclass of a Pandas DataFrame. This means you can also plot it in a Chart block. However, do keep in mind that the preview only contains first 100 rows.
 
 ![SQL using DeepnoteQueryPreview](../assets/docs/WmfGCeTZRyC2eKRG6qdB.webp)
 

--- a/docs/team-permissions.md
+++ b/docs/team-permissions.md
@@ -65,13 +65,13 @@ When the setting is disabled, it will offer Admins the SSO provider they are cur
 
 ### FAQ
 
-_How do I prevent certain members from seeing one of the workspace projects?_
+#### How do I prevent certain members from seeing one of the workspace projects?
 
 To share a project only with certain workspace members, change the project access from _Full access_ to _No access_. This will make the project only visible to you. It will show up in your workspace as a Private project. If you would like certain workspace members to have access, you can add them as project collaborators.
 
 Private projects still have access to the workspace resources, such as integrations and machine hours. Note that only **Editors** and **Admins** can create private projects.
 
-_How can I lock a project?_
+#### How can I lock a project?
 
 From within a project, you can set the workspace member permissions to **View** in "one fell swoop". Note that **Admins** will always be able to edit projects. If the option is set to "Full access" then all members of a workspace will follow their respective roles according to the **Workspace** settings.
 


### PR DESCRIPTION
Deepnote's landing app reads FAQ entries from question headings and the answer text below them. Several FAQ sections did not match that parser, so the landing app skipped them when it generated FAQPage schema.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated FAQ formatting across machine-hours, pricing, SQL cells, and team permissions documentation.
  - Standardized question titles as Markdown headings for clearer navigation.
  - Reformatted query preview FAQs while preserving existing behavior and guidance.
  - Added a question mark to the pricing upgrade billing question.
  - Preserved all existing explanations, instructions, video embeds, and documented limitations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->