### PR TITLE
fix: remediate dependency audit vulnerabilities

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
   "devDependencies": {
     "@biomejs/biome": "2.2.7",
     "@types/node": "22.20.1",
-    "@vitest/coverage-v8": "4.1.8",
+    "@vitest/coverage-v8": "4.1.11",
     "@xterm/headless": "^6.0.0",
     "cspell": "9.2.2",
     "husky": "9.1.7",
@@ -53,7 +53,7 @@
     "sort-package-json": "3.4.0",
     "tsdown": "0.22.14",
     "typescript": "7.0.2",
-    "vitest": "4.1.8"
+    "vitest": "4.1.11"
   },
   "packageManager": "pnpm@10.19.0",
   "engines": {
@@ -77,7 +77,7 @@
       "@inquirer/select": "5.0.6",
       "@isaacs/brace-expansion": ">=5.0.1",
       "@types/node": "22.20.1",
-      "@vitest/coverage-v8": "4.1.8",
+      "@vitest/coverage-v8": "4.1.11",
       "ajv": ">=8.18.0",
       "body-parser": ">=2.3.0",
       "brace-expansion": ">=5.0.9",
@@ -87,9 +87,9 @@
       "fast-uri": ">=3.1.7 <4",
       "flatted": ">=3.4.2",
       "glob": ">=11.1.0",
-      "hono": ">=4.12.34",
+      "hono": ">=4.13.5",
       "ip-address": ">=10.3.1",
-      "js-yaml": ">=4.3.1 <5",
+      "js-yaml": ">=4.3.2 <5",
       "lodash": ">=4.18.0",
       "lodash-es": ">=4.18.0",
       "minimatch": ">=10.2.3",
@@ -102,7 +102,7 @@
       "smol-toml": ">=1.6.1",
       "undici": "6.28.0",
       "vite": ">=8.0.16",
-      "vitest": "4.1.8",
+      "vitest": "4.1.11",
       "ws": ">=8.20.1",
       "yaml": ">=2.8.3"
     },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,7 +20,7 @@ overrides:
   '@inquirer/select': 5.0.6
   '@isaacs/brace-expansion': '>=5.0.1'
   '@types/node': 22.20.1
-  '@vitest/coverage-v8': 4.1.8
+  '@vitest/coverage-v8': 4.1.11
   ajv: '>=8.18.0'
   body-parser: '>=2.3.0'
   brace-expansion: '>=5.0.9'
@@ -30,9 +30,9 @@ overrides:
   fast-uri: '>=3.1.7 <4'
   flatted: '>=3.4.2'
   glob: '>=11.1.0'
-  hono: '>=4.12.34'
+  hono: '>=4.13.5'
   ip-address: '>=10.3.1'
-  js-yaml: '>=4.3.1 <5'
+  js-yaml: '>=4.3.2 <5'
   lodash: '>=4.18.0'
   lodash-es: '>=4.18.0'
   minimatch: '>=10.2.3'
@@ -45,7 +45,7 @@ overrides:
   smol-toml: '>=1.6.1'
   undici: 6.28.0
   vite: '>=8.0.16'
-  vitest: 4.1.8
+  vitest: 4.1.11
   ws: '>=8.20.1'
   yaml: '>=2.8.3'
 
@@ -65,8 +65,8 @@ importers:
         specifier: 22.20.1
         version: 22.20.1
       '@vitest/coverage-v8':
-        specifier: 4.1.8
-        version: 4.1.8(vitest@4.1.8)
+        specifier: 4.1.11
+        version: 4.1.11(vitest@4.1.11)
       '@xterm/headless':
         specifier: ^6.0.0
         version: 6.0.0
@@ -95,8 +95,8 @@ importers:
         specifier: 7.0.2
         version: 7.0.2
       vitest:
-        specifier: 4.1.8
-        version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@22.20.1)(@vitest/coverage-v8@4.1.8)(vite@8.0.16(@types/node@22.20.1)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0))
+        specifier: 4.1.11
+        version: 4.1.11(@opentelemetry/api@1.9.1)(@types/node@22.20.1)(@vitest/coverage-v8@4.1.11)(vite@8.0.16(@types/node@22.20.1)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0))
 
   packages/blocks:
     dependencies:
@@ -175,7 +175,7 @@ importers:
     devDependencies:
       '@inquirer/testing':
         specifier: ^3.1.1
-        version: 3.1.1(patch_hash=1bb511b5888b39b10f59d61819f8635a4b99efc60a55f5b6cebb4f3fcd53f440)(@inquirer/checkbox@5.0.6(@types/node@22.20.1))(@inquirer/confirm@6.0.6(@types/node@22.20.1))(@inquirer/editor@5.0.6(@types/node@22.20.1))(@inquirer/expand@5.0.6(@types/node@22.20.1))(@inquirer/external-editor@2.0.3(@types/node@22.20.1))(@inquirer/input@5.0.6(@types/node@22.20.1))(@inquirer/number@4.0.6(@types/node@22.20.1))(@inquirer/password@5.0.6(@types/node@22.20.1))(@inquirer/prompts@8.2.1(@types/node@22.20.1))(@inquirer/rawlist@5.2.2(@types/node@22.20.1))(@inquirer/search@4.1.2(@types/node@22.20.1))(@inquirer/select@5.0.6(@types/node@22.20.1))(@types/node@22.20.1)(vitest@4.1.8)
+        version: 3.1.1(patch_hash=1bb511b5888b39b10f59d61819f8635a4b99efc60a55f5b6cebb4f3fcd53f440)(@inquirer/checkbox@5.0.6(@types/node@22.20.1))(@inquirer/confirm@6.0.6(@types/node@22.20.1))(@inquirer/editor@5.0.6(@types/node@22.20.1))(@inquirer/expand@5.0.6(@types/node@22.20.1))(@inquirer/external-editor@2.0.3(@types/node@22.20.1))(@inquirer/input@5.0.6(@types/node@22.20.1))(@inquirer/number@4.0.6(@types/node@22.20.1))(@inquirer/password@5.0.6(@types/node@22.20.1))(@inquirer/prompts@8.2.1(@types/node@22.20.1))(@inquirer/rawlist@5.2.2(@types/node@22.20.1))(@inquirer/search@4.1.2(@types/node@22.20.1))(@inquirer/select@5.0.6(@types/node@22.20.1))(@types/node@22.20.1)(vitest@4.1.11)
       fflate:
         specifier: ^0.8.3
         version: 0.8.3
@@ -846,7 +846,7 @@ packages:
     resolution: {integrity: sha512-XovyyCCnBzW+zKu+z/zq8hwNs4KOR5rEMAOxo2f40Q5xoOI37IMm6MIg2COOUtUApo0i6850MTBKH2u4QLGIqg==}
     engines: {node: '>=20'}
     peerDependencies:
-      hono: '>=4.12.34'
+      hono: '>=4.13.5'
 
   '@inquirer/ansi@2.0.7':
     resolution: {integrity: sha512-3eTuUO1vH2cZm2ZKHeQxnOqlTi9EfZDGgIe3BL3I4u+rJHocr9Fz86M4fjYABPvFnQG/gGK551HqDiIcETwU6Q==}
@@ -992,7 +992,7 @@ packages:
       '@types/jest': '>=29.0.0'
       '@types/node': 22.20.1
       jest: '>=29.0.0'
-      vitest: 4.1.8
+      vitest: 4.1.11
     peerDependenciesMeta:
       '@inquirer/checkbox':
         optional: true
@@ -1539,20 +1539,20 @@ packages:
     resolution: {integrity: sha512-UycprH3T6n3jH0k44NHMa7pnFHGu/N05MjojYr+Mc6I7obkoLIJujSWwin1pCvdy/eOxrI/l3uDLQsmcrOb4ug==}
     engines: {node: '>= 20'}
 
-  '@vitest/coverage-v8@4.1.8':
-    resolution: {integrity: sha512-lt3kovsyHwYe00wq4D1ti0Z974fWj4NLp6siqiyEufUpyFwK9Yhi7rBhac9JL5aA0zoMrJqc4vYPZRUnI7l7nw==}
+  '@vitest/coverage-v8@4.1.11':
+    resolution: {integrity: sha512-8MVGEFnJIcdGjcbfKmeq8z0pZHH0JlVtoVZH9Q/qwUp6wyFnEJUBMrw9DCaj+ra3vShGmhavjalMIhPNxZAUcw==}
     peerDependencies:
-      '@vitest/browser': 4.1.8
-      vitest: 4.1.8
+      '@vitest/browser': 4.1.11
+      vitest: 4.1.11
     peerDependenciesMeta:
       '@vitest/browser':
         optional: true
 
-  '@vitest/expect@4.1.8':
-    resolution: {integrity: sha512-h3nDO677RDLEGlBxyQ5CW8RlMThSKSRLUePLOx09gNIWRL40edgA1GCZSZgf1W55MFAG6/Sw14KeaAnqv0NKdQ==}
+  '@vitest/expect@4.1.11':
+    resolution: {integrity: sha512-VX2x5vNJXET47KAFzwERI+KRMtTTCSWTfSMKsW7JsUsXV4psq++e3DvZpuTDOpHcxytiDs6p2nhVb2tVDiiUYw==}
 
-  '@vitest/mocker@4.1.8':
-    resolution: {integrity: sha512-LEiN/xe4OSIbKe9HQIp5OC24agGD9J5CnmMgsLohVVoOPWL9a2sBoR6VBx43jQZb7Kr1l4RCuyCJzcAa0+dojw==}
+  '@vitest/mocker@4.1.11':
+    resolution: {integrity: sha512-2XJVD55d1o5AZous5CCGKS74g/riOj9odEt2bQpCVZeblHyHdnMeFl4jl0XjU21stf4mbjUkew2eXQZt65g5CQ==}
     peerDependencies:
       msw: ^2.4.9
       vite: '>=8.0.16'
@@ -1562,20 +1562,20 @@ packages:
       vite:
         optional: true
 
-  '@vitest/pretty-format@4.1.8':
-    resolution: {integrity: sha512-9GasEBxpZ1VYIpqHf/0+YGg121uSNwCKOJqIrTwWP/TB7DmFCiaBpNl3aPZzoLWfWkuqhbH8vJIVobZkvdo2cA==}
+  '@vitest/pretty-format@4.1.11':
+    resolution: {integrity: sha512-yiZzPbGTS9Sr/JpFl8zHrcIkAofNbFV6k21vIgQN/cY/oxZeXhJv5sc/MBJ5jFKWmWs+oJHw0UXLZjmf931+Vw==}
 
-  '@vitest/runner@4.1.8':
-    resolution: {integrity: sha512-EmVxeBAfMJvycdjd6Hm+RbFBbA9fKvo0Kx37hNpBYoYeavH3RNsBXWDooR1mgD52dCrxIIuP7UotpfiwOikvcg==}
+  '@vitest/runner@4.1.11':
+    resolution: {integrity: sha512-LztvUgdwMNJMIkj3hQnnxiC2Xy1zNxq928W/xhjCLaNCzqTZOudjwbQf6v9IntZGPw132i2Lq2rgTRZHD3JHNw==}
 
-  '@vitest/snapshot@4.1.8':
-    resolution: {integrity: sha512-acfZboRmAIf05DEKcBQy33VXojFJjtUdLyo7oOmV9kebb2xdU01UknNiPuPZoJZQyO7DF0gZdTGTpeAzET9QPQ==}
+  '@vitest/snapshot@4.1.11':
+    resolution: {integrity: sha512-pN7ikn1ON7h8ee4gIAp4AzyK+zBtJPzVbqOgu5LCEh4VaJVbPQcgYQYJIMGQPXVeJJq1fnfazis7a5pFNPahog==}
 
-  '@vitest/spy@4.1.8':
-    resolution: {integrity: sha512-6EevtBp6OZOPF7bmz36HrGMeP3txgVSrgebWxHOafDXGkhIzfXK14f8KF6MuFfgXXUeHxmpD3BQxkV00/3s5mA==}
+  '@vitest/spy@4.1.11':
+    resolution: {integrity: sha512-apNa/prQy2qCeywhnixOHPRCgGNhvg7T4Dapfl1GahLp/R+uhBm5cPyFoNVyqsNd2h1nJxL6BqqdIjiABL60YA==}
 
-  '@vitest/utils@4.1.8':
-    resolution: {integrity: sha512-uOJamYALNhfJ6iolExyQM40yIQwDqYnkKtQ5VCiSe17E33H0aQ/u+1GlRuz4LZBk6Mm3sg90G9hEbmEt37C1Zg==}
+  '@vitest/utils@4.1.11':
+    resolution: {integrity: sha512-zTCVGpyFsGWBhllOyKlTw/vnr6D9qxsfSDyfbyZmTyjHw5N/VuvzHpHoQjm2ZJzn4RJgx5w4r7V0er69CmLgPQ==}
 
   '@xterm/headless@5.5.0':
     resolution: {integrity: sha512-5xXB7kdQlFBP82ViMJTwwEc3gKCLGKR/eoxQm4zge7GPBl86tCdI0IdPJjoKd8mUSFXz5V7i/25sfsEkP4j46g==}
@@ -2260,8 +2260,8 @@ packages:
   highlight.js@10.7.3:
     resolution: {integrity: sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A==}
 
-  hono@4.13.2:
-    resolution: {integrity: sha512-JydRilDRkYBQMt9qR9U92mXxmbGqsqSn/IKOrh4e7/gEbn+0zSr8igTu0obwJoNGN4sez28DIql7FBHWydoJpA==}
+  hono@4.13.7:
+    resolution: {integrity: sha512-c8/gF9ac8Y78/agExVocyLevgR+JlpNB444Py0FSX8pJoPdYUfUzRcXtYEYGwt6l19qIlVZPN5Mfsw9jFShmQQ==}
     engines: {node: '>=16.9.0'}
 
   hookable@6.1.1:
@@ -2394,8 +2394,8 @@ packages:
   js-tokens@10.0.0:
     resolution: {integrity: sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==}
 
-  js-yaml@4.3.1:
-    resolution: {integrity: sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==}
+  js-yaml@4.3.2:
+    resolution: {integrity: sha512-SFNOvSJ+Dgf/9An904Yx+CgSlIPCkIpao4qo51lpee25TIRejdH3rhR4EZMGoNx3/TP3O+wzWuiTFl4sqbltzA==}
     hasBin: true
 
   json-parse-even-better-errors@3.0.2:
@@ -3259,20 +3259,20 @@ packages:
       yaml:
         optional: true
 
-  vitest@4.1.8:
-    resolution: {integrity: sha512-flY6ScbCIt9HThs+C5HS7jvGOB560DJtk/Z15IQROTA6zEy49Nh8T/dofWTQL+n3vswqn87sbJNiuqw1SDp5Ig==}
+  vitest@4.1.11:
+    resolution: {integrity: sha512-fhACrNXUidIbGSBr5FlbuBkO7VWC1ZyLl0DO4CU2DrQoAPxX84Ysxs+HeGQpii5lZWV1Q4gBZTTu49mF+A6Edw==}
     engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
     hasBin: true
     peerDependencies:
       '@edge-runtime/vm': '*'
       '@opentelemetry/api': ^1.9.0
       '@types/node': 22.20.1
-      '@vitest/browser-playwright': 4.1.8
-      '@vitest/browser-preview': 4.1.8
-      '@vitest/browser-webdriverio': 4.1.8
-      '@vitest/coverage-istanbul': 4.1.8
-      '@vitest/coverage-v8': 4.1.8
-      '@vitest/ui': 4.1.8
+      '@vitest/browser-playwright': 4.1.11
+      '@vitest/browser-preview': 4.1.11
+      '@vitest/browser-webdriverio': 4.1.11
+      '@vitest/coverage-istanbul': 4.1.11
+      '@vitest/coverage-v8': 4.1.11
+      '@vitest/ui': 4.1.11
       happy-dom: '*'
       jsdom: '*'
       vite: '>=8.0.16'
@@ -3432,7 +3432,7 @@ snapshots:
     dependencies:
       '@jsdevtools/ono': 7.1.3
       '@types/json-schema': 7.0.15
-      js-yaml: 4.3.1
+      js-yaml: 4.3.2
 
   '@babel/helper-string-parser@7.29.7': {}
 
@@ -3792,9 +3792,9 @@ snapshots:
   '@esbuild/win32-x64@0.28.2':
     optional: true
 
-  '@hono/node-server@2.1.0(hono@4.13.2)':
+  '@hono/node-server@2.1.0(hono@4.13.7)':
     dependencies:
-      hono: 4.13.2
+      hono: 4.13.7
 
   '@inquirer/ansi@2.0.7': {}
 
@@ -3911,7 +3911,7 @@ snapshots:
     optionalDependencies:
       '@types/node': 22.20.1
 
-  '@inquirer/testing@3.1.1(patch_hash=1bb511b5888b39b10f59d61819f8635a4b99efc60a55f5b6cebb4f3fcd53f440)(@inquirer/checkbox@5.0.6(@types/node@22.20.1))(@inquirer/confirm@6.0.6(@types/node@22.20.1))(@inquirer/editor@5.0.6(@types/node@22.20.1))(@inquirer/expand@5.0.6(@types/node@22.20.1))(@inquirer/external-editor@2.0.3(@types/node@22.20.1))(@inquirer/input@5.0.6(@types/node@22.20.1))(@inquirer/number@4.0.6(@types/node@22.20.1))(@inquirer/password@5.0.6(@types/node@22.20.1))(@inquirer/prompts@8.2.1(@types/node@22.20.1))(@inquirer/rawlist@5.2.2(@types/node@22.20.1))(@inquirer/search@4.1.2(@types/node@22.20.1))(@inquirer/select@5.0.6(@types/node@22.20.1))(@types/node@22.20.1)(vitest@4.1.8)':
+  '@inquirer/testing@3.1.1(patch_hash=1bb511b5888b39b10f59d61819f8635a4b99efc60a55f5b6cebb4f3fcd53f440)(@inquirer/checkbox@5.0.6(@types/node@22.20.1))(@inquirer/confirm@6.0.6(@types/node@22.20.1))(@inquirer/editor@5.0.6(@types/node@22.20.1))(@inquirer/expand@5.0.6(@types/node@22.20.1))(@inquirer/external-editor@2.0.3(@types/node@22.20.1))(@inquirer/input@5.0.6(@types/node@22.20.1))(@inquirer/number@4.0.6(@types/node@22.20.1))(@inquirer/password@5.0.6(@types/node@22.20.1))(@inquirer/prompts@8.2.1(@types/node@22.20.1))(@inquirer/rawlist@5.2.2(@types/node@22.20.1))(@inquirer/search@4.1.2(@types/node@22.20.1))(@inquirer/select@5.0.6(@types/node@22.20.1))(@types/node@22.20.1)(vitest@4.1.11)':
     dependencies:
       '@inquirer/type': 4.0.3(@types/node@22.20.1)
       '@xterm/headless': 5.5.0
@@ -3930,7 +3930,7 @@ snapshots:
       '@inquirer/search': 4.1.2(@types/node@22.20.1)
       '@inquirer/select': 5.0.6(@types/node@22.20.1)
       '@types/node': 22.20.1
-      vitest: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@22.20.1)(@vitest/coverage-v8@4.1.8)(vite@8.0.16(@types/node@22.20.1)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0))
+      vitest: 4.1.11(@opentelemetry/api@1.9.1)(@types/node@22.20.1)(@vitest/coverage-v8@4.1.11)(vite@8.0.16(@types/node@22.20.1)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0))
 
   '@inquirer/type@4.0.3(@types/node@22.20.1)':
     optionalDependencies:
@@ -4055,7 +4055,7 @@ snapshots:
 
   '@modelcontextprotocol/sdk@1.30.0(zod@3.25.76)':
     dependencies:
-      '@hono/node-server': 2.1.0(hono@4.13.2)
+      '@hono/node-server': 2.1.0(hono@4.13.7)
       ajv: 8.20.0
       ajv-formats: 3.0.1(ajv@8.20.0)
       content-type: 1.0.5
@@ -4065,7 +4065,7 @@ snapshots:
       eventsource-parser: 3.1.1
       express: 5.2.1
       express-rate-limit: 8.6.2(express@5.2.1)
-      hono: 4.13.2
+      hono: 4.13.7
       jose: 6.2.8
       json-schema-typed: 8.0.2
       pkce-challenge: 5.0.1
@@ -4356,10 +4356,10 @@ snapshots:
 
   '@vercel/oidc@3.2.0': {}
 
-  '@vitest/coverage-v8@4.1.8(vitest@4.1.8)':
+  '@vitest/coverage-v8@4.1.11(vitest@4.1.11)':
     dependencies:
       '@bcoe/v8-coverage': 1.0.2
-      '@vitest/utils': 4.1.8
+      '@vitest/utils': 4.1.11
       ast-v8-to-istanbul: 1.0.5
       istanbul-lib-coverage: 3.2.2
       istanbul-lib-report: 3.0.1
@@ -4368,46 +4368,46 @@ snapshots:
       obug: 2.1.4
       std-env: 4.2.0
       tinyrainbow: 3.1.1
-      vitest: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@22.20.1)(@vitest/coverage-v8@4.1.8)(vite@8.0.16(@types/node@22.20.1)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0))
+      vitest: 4.1.11(@opentelemetry/api@1.9.1)(@types/node@22.20.1)(@vitest/coverage-v8@4.1.11)(vite@8.0.16(@types/node@22.20.1)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0))
 
-  '@vitest/expect@4.1.8':
+  '@vitest/expect@4.1.11':
     dependencies:
       '@standard-schema/spec': 1.1.0
       '@types/chai': 5.2.3
-      '@vitest/spy': 4.1.8
-      '@vitest/utils': 4.1.8
+      '@vitest/spy': 4.1.11
+      '@vitest/utils': 4.1.11
       chai: 6.2.2
       tinyrainbow: 3.1.1
 
-  '@vitest/mocker@4.1.8(vite@8.0.16(@types/node@22.20.1)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0))':
+  '@vitest/mocker@4.1.11(vite@8.0.16(@types/node@22.20.1)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0))':
     dependencies:
-      '@vitest/spy': 4.1.8
+      '@vitest/spy': 4.1.11
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
       vite: 8.0.16(@types/node@22.20.1)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0)
 
-  '@vitest/pretty-format@4.1.8':
+  '@vitest/pretty-format@4.1.11':
     dependencies:
       tinyrainbow: 3.1.1
 
-  '@vitest/runner@4.1.8':
+  '@vitest/runner@4.1.11':
     dependencies:
-      '@vitest/utils': 4.1.8
+      '@vitest/utils': 4.1.11
       pathe: 2.0.3
 
-  '@vitest/snapshot@4.1.8':
+  '@vitest/snapshot@4.1.11':
     dependencies:
-      '@vitest/pretty-format': 4.1.8
-      '@vitest/utils': 4.1.8
+      '@vitest/pretty-format': 4.1.11
+      '@vitest/utils': 4.1.11
       magic-string: 0.30.21
       pathe: 2.0.3
 
-  '@vitest/spy@4.1.8': {}
+  '@vitest/spy@4.1.11': {}
 
-  '@vitest/utils@4.1.8':
+  '@vitest/utils@4.1.11':
     dependencies:
-      '@vitest/pretty-format': 4.1.8
+      '@vitest/pretty-format': 4.1.11
       convert-source-map: 2.0.0
       tinyrainbow: 3.1.1
 
@@ -5073,7 +5073,7 @@ snapshots:
 
   highlight.js@10.7.3: {}
 
-  hono@4.13.2: {}
+  hono@4.13.7: {}
 
   hookable@6.1.1: {}
 
@@ -5176,7 +5176,7 @@ snapshots:
 
   js-tokens@10.0.0: {}
 
-  js-yaml@4.3.1:
+  js-yaml@4.3.2:
     dependencies:
       argparse: 2.0.1
 
@@ -5198,7 +5198,7 @@ snapshots:
       '@types/json-schema': 7.0.15
       '@types/lodash': 4.17.25
       is-glob: 4.0.3
-      js-yaml: 4.3.1
+      js-yaml: 4.3.2
       lodash: 4.18.1
       minimist: 1.2.8
       prettier: 3.9.6
@@ -6066,15 +6066,15 @@ snapshots:
       tsx: 4.23.12
       yaml: 2.9.0
 
-  vitest@4.1.8(@opentelemetry/api@1.9.1)(@types/node@22.20.1)(@vitest/coverage-v8@4.1.8)(vite@8.0.16(@types/node@22.20.1)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0)):
+  vitest@4.1.11(@opentelemetry/api@1.9.1)(@types/node@22.20.1)(@vitest/coverage-v8@4.1.11)(vite@8.0.16(@types/node@22.20.1)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0)):
     dependencies:
-      '@vitest/expect': 4.1.8
-      '@vitest/mocker': 4.1.8(vite@8.0.16(@types/node@22.20.1)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0))
-      '@vitest/pretty-format': 4.1.8
-      '@vitest/runner': 4.1.8
-      '@vitest/snapshot': 4.1.8
-      '@vitest/spy': 4.1.8
-      '@vitest/utils': 4.1.8
+      '@vitest/expect': 4.1.11
+      '@vitest/mocker': 4.1.11(vite@8.0.16(@types/node@22.20.1)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0))
+      '@vitest/pretty-format': 4.1.11
+      '@vitest/runner': 4.1.11
+      '@vitest/snapshot': 4.1.11
+      '@vitest/spy': 4.1.11
+      '@vitest/utils': 4.1.11
       es-module-lexer: 2.3.1
       expect-type: 1.4.0
       magic-string: 0.30.21
@@ -6091,7 +6091,7 @@ snapshots:
     optionalDependencies:
       '@opentelemetry/api': 1.9.1
       '@types/node': 22.20.1
-      '@vitest/coverage-v8': 4.1.8(vitest@4.1.8)
+      '@vitest/coverage-v8': 4.1.11(vitest@4.1.11)
     transitivePeerDependencies:
       - msw
 


### PR DESCRIPTION
## Summary

Remediate the six advisories reported by `pnpm audit` using the repository’s existing dependency strategy.

## Decisions

- **GHSA-82fw-gwwq-j7x9 / CVE-2026-84373 (Vitest path traversal):** `vitest` and `@vitest/mocker` were development-only at `4.1.8`. Upgrade the direct Vitest test tooling and coverage package to the fixed `4.1.11` release. No standalone `@vitest/mocker` override was added because it is controlled transitively by Vitest.
- **GHSA-2883-xcg3-v3hh / CVE-2026-84375 (js-yaml CPU exhaustion):** `js-yaml` is transitive through CLI build tooling (`json-schema-to-typescript`). Raise the existing root override from `>=4.3.1 <5` to `>=4.3.2 <5`; do not add a direct dependency.
- **GHSA-gqvv-2mrq-wpjv / CVE-2026-84365 (Hono `toSSG` traversal), GHSA-g6gw-c38x-mqfc / CVE-2026-84364 (Hono `parseBody` exhaustion), and GHSA-crvj-82cr-hjcx / CVE-2026-84363 (Hono query parsing):** all affect the same transitive `hono@4.13.2` under `@modelcontextprotocol/sdk`. Raise the existing root override from `>=4.12.34` to `>=4.13.5`, resolving `4.13.7`. No MCP SDK or direct Hono dependency change is needed.

## Representative manifest diff

```diff
-"@vitest/coverage-v8": "4.1.8",
+"@vitest/coverage-v8": "4.1.11",
-"vitest": "4.1.8",
+"vitest": "4.1.11",
-"hono": ">=4.12.34",
+"hono": ">=4.13.5",
-"js-yaml": ">=4.3.1 <5",
+"js-yaml": ">=4.3.2 <5",
```

The lockfile was regenerated with pnpm and updates Vitest packages, Hono to `4.13.7`, and js-yaml to `4.3.2`.

## Validation

- `pnpm audit --json`: 0 vulnerabilities
- `pnpm audit --prod`: no known vulnerabilities
- `pnpm install --frozen-lockfile`: passed
- `pnpm test`: 3,146 passed, 1 skipped
- `pnpm typecheck`: passed
- `pnpm biome:check`: passed with 8 existing warnings in example server files

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated testing and code coverage tooling.
  - Raised minimum supported versions for select security and compatibility dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->