### PR TITLE
docs: correct ten inaccurate claims in the new CLI publish and sync pages

### DIFF
--- a/docs/deepnote-cli-publish.md
+++ b/docs/deepnote-cli-publish.md
@@ -88,9 +88,9 @@ deepnote publish ./dist --project-id <project-id> --path _deepnote_static/v2
 command touches the project. Nested path segments are percent-encoded in the printed URL, so a path
 containing `#` or `?` still yields a working link.
 
-Always use the URL the command prints rather than assembling one yourself. Deepnote serves each
-project's site from its own dedicated origin and hands out the shareable link on the main domain, so
-a hand-built URL is unlikely to resolve.
+Always use the URL the command prints rather than assembling one yourself. Deepnote returns the
+canonical site URL when it enables sharing, and its host is not something you can reliably derive
+from the project ID or your workspace URL.
 
 ## Who can view a published site
 
@@ -164,14 +164,19 @@ are absent locally:
 deepnote publish ./dist --project-id <project-id> --prune
 ```
 
-Pruning is ordered so a failed deploy cannot leave the site half-deleted. Stale paths that block a
-directory the new build needs are removed first, because the upload cannot proceed without them.
-Every other stale file is removed only after all uploads have succeeded.
+Pruning is ordered to limit what a failed deploy can leave behind. Every stale file is removed only
+after all uploads have succeeded — with one exception: a stale path that blocks a directory the new
+build needs is removed first, because the upload cannot proceed while a file occupies that path.
+
+If a later upload then fails, those blocking paths stay deleted rather than being restored, so the
+site can be left missing them. Re-run the command once the cause is fixed.
 
 <Callout status="info">
-`deepnote publish --prune` deletes **remote** files that are missing locally. The unrelated
-[`deepnote sync --prune`](/docs/deepnote-cli-sync) deletes **local** files that are missing in the
-cloud. The two flags share a name and point in opposite directions.
+`deepnote publish --prune` deletes **remote** files that are missing from your build directory, and
+inside a synced workspace it removes those same paths from the workspace's mirror under
+`.files/_deepnote_static/`. [`deepnote sync --prune`](/docs/deepnote-cli-sync) runs the other way: it
+deletes **local** files that are missing in the cloud. The two flags share a name, point in opposite
+directions, and both write the same `.deepnote-sync.json`.
 </Callout>
 
 ## Failure behavior
@@ -179,9 +184,11 @@ cloud. The two flags share a name and point in opposite directions.
 The command validates everything it can locally before touching the project, then makes remote
 changes in a fixed order.
 
-- **Local path problems abort before any upload.** A filename with a leading or trailing space, a
-  backslash, or two local files that would collide at the same remote path all stop the command with
-  exit code `2` and an unchanged project.
+- **Some local path problems abort before any upload.** A filename with a trailing space, or two
+  local files that would collide at the same remote path, stop the command with exit code `2` and an
+  unchanged project. Other unusual names are not checked: a leading space, or a backslash on Linux
+  and macOS where it is an ordinary filename character, is published verbatim. Keep build output to
+  plain path names.
 - **Each file is read before its remote copy is replaced**, so an unreadable local file leaves the
   live version intact.
 - **Website sharing is enabled only after every upload succeeds.** A partial upload is reported as a
@@ -210,15 +217,28 @@ paths. They coordinate rather than divide the namespace:
 
 - **`deepnote publish` is the write path for the static root.** It is the command that deploys a
   build, and in practice the only one that should be authoring those files.
-- **`deepnote sync` mirrors them but never silently overwrites them.** Before pushing any working
-  file it checks the current state in Deepnote, and a file that changed since it last synced is
-  surfaced as a conflict to resolve rather than overwritten.
-- **When you publish from inside a synced workspace**, publish also updates that workspace's local
-  mirror and its `.deepnote-sync.json`, so the next sync sees the deploy as already up to date
-  instead of re-downloading the whole site.
-- **If Deepnote holds changes your workspace has not pulled**, publish stops before writing anything
-  rather than destroying content you have no local copy of. Run `deepnote sync --all-files` to bring
-  it down, or pass `--force` to overwrite.
+- **`deepnote sync` mirrors them but does not overwrite them without raising a conflict first.**
+  Before pushing any working file it checks the current state in Deepnote, and a file that changed
+  since it last synced is surfaced as a conflict to resolve rather than overwritten. Resolving that
+  conflict destructively — including up front with `--on-conflict override` — does overwrite the
+  published files.
+- **When you publish from inside a synced workspace that already tracks the project**, publish also
+  updates that workspace's local mirror and its `.deepnote-sync.json`, so the next sync sees the
+  deploy as already up to date instead of re-downloading the whole site. If the workspace's manifest
+  has no entry for `--project-id`, or the directory that entry points at is gone, publish skips the
+  mirror update without reporting it — pass `--sync-root <dir>` explicitly to turn that silence into
+  an error.
+- **If Deepnote holds changes to a file your workspace has synced before**, publish stops before
+  writing anything rather than overwriting them. Run `deepnote sync --all-files` to bring them down,
+  or pass `--force` to overwrite. The check compares each path against the baseline recorded in the
+  mirror, so it covers only files that workspace has synced at least once.
+
+<Callout status="warning">
+A file added to `_deepnote_static` in Deepnote that this workspace has never synced has no recorded
+baseline, so the check above does not see it. With `--prune` that file counts as stale and is
+deleted, even without `--force`, leaving you no local copy. Run `deepnote sync --all-files` before a
+pruning publish if anyone else may have written to the static root since your last sync.
+</Callout>
 
 Use `--no-sync-root` for a CI deploy, where there is no workspace to keep in step and the extra
 lookup is pointless.

--- a/docs/deepnote-cli-sync.md
+++ b/docs/deepnote-cli-sync.md
@@ -102,20 +102,30 @@ are not part of the format, so they never sync.
 
 ## Conflicts
 
-By default sync asks, per project, whether to keep the cloud version (discarding your local changes)
-or skip the project for now.
+By default sync asks, per conflicting project, whether to resolve the conflict destructively or to
+skip that project for now. Which side a destructive answer overwrites depends on the direction the
+project is moving.
 
 ```bash
 # Answer up front instead of being prompted
 deepnote sync ./workspace --on-conflict skip
-deepnote sync ./workspace --on-conflict override
 ```
 
-| Mode       | Behavior                                       |
-| ---------- | ---------------------------------------------- |
-| `ask`      | Prompt per conflicting project (default)       |
-| `skip`     | Leave every conflicting project untouched      |
-| `override` | Overwrite local changes with the cloud version |
+| Mode       | Behavior                                                              |
+| ---------- | --------------------------------------------------------------------- |
+| `ask`      | Prompt per conflicting project (default)                              |
+| `skip`     | Leave every conflicting project untouched                             |
+| `override` | Answer every prompt destructively — read the warning below before use |
+
+<Callout status="warning">
+`override` does not mean "take the cloud version". It pre-answers whichever prompt each project
+raises, and those prompts point in opposite directions: a **pulled** project has its local files
+overwritten by the cloud copy, while a **pushed** project has its cloud copy overwritten by your
+local files. Combined with `--delete-missing-notebooks`, `override` also answers the confirmation
+that guards pushing an empty local directory — which deletes every notebook in that cloud project.
+Prefer `skip` for unattended runs, and resolve conflicts interactively when you need the other
+direction.
+</Callout>
 
 <Callout status="info">
 Without an interactive terminal — in CI, or with output piped — conflicts are skipped rather than
@@ -168,12 +178,17 @@ two commands share one rule:
 
 - **[`deepnote publish`](/docs/deepnote-cli-publish) writes it.** That is the deploy command, and the
   only one that should author those files. Its source of truth is your local build directory.
-- **`deepnote sync` mirrors it and never silently overwrites it.** The per-file check described above
-  applies to the static root too, so a site someone republished after your last sync is surfaced as
-  a conflict instead of being reverted to your older local copy.
-- **A publish inside a synced workspace keeps the mirror in step.** Publishing updates the local
-  mirror and `.deepnote-sync.json` for you, so the next sync does not see the deploy as drift and
-  re-download the whole site.
+- **`deepnote sync` mirrors it and does not overwrite it without raising a conflict first.** The
+  per-file check described above applies to the static root too, so a site someone republished after
+  your last sync is surfaced as a conflict rather than quietly reverted to your older local copy.
+  Answering that conflict destructively — including up front with `--on-conflict override` — does
+  revert the live site, so re-read [Conflicts](#conflicts) before using that flag on a workspace that
+  also publishes.
+- **A publish inside a synced workspace keeps the mirror in step**, as long as that workspace
+  already tracks the project being published. Publishing updates the local mirror and
+  `.deepnote-sync.json` for you, so the next sync does not see the deploy as drift and re-download
+  the whole site. If the workspace does not track the project, publish skips the mirror update
+  silently and the next sync re-downloads the site.
 
 <Callout status="info">
 `.files/_deepnote_static/` is build output, not source. If you commit your sync directory to Git,
@@ -194,9 +209,11 @@ Sync is deliberately conservative about deletion, in both directions.
   destructive to infer.
 
 <Callout status="info">
-`deepnote sync --prune` deletes **local** files that are missing in the cloud. The unrelated
-[`deepnote publish --prune`](/docs/deepnote-cli-publish) deletes **remote** files that are missing
-locally. The two flags share a name and point in opposite directions.
+`deepnote sync --prune` deletes **local** files that are missing in the cloud.
+[`deepnote publish --prune`](/docs/deepnote-cli-publish) runs the other way: it deletes **remote**
+files that are missing from your build directory, and inside a synced workspace it also removes those
+paths from the local mirror. The two flags share a name, point in opposite directions, and both write
+the same `.deepnote-sync.json`.
 </Callout>
 
 ## Safety rails
@@ -217,6 +234,10 @@ Use `--dry-run` to see what a run would do before it does it:
 ```bash
 deepnote sync ./workspace --all-files --dry-run
 ```
+
+A dry run never prompts, so conflicting projects are always reported as skipped — even when the real
+run would stop and ask you. Pass the `--on-conflict` mode you intend to use if you want the preview
+to match the run you are about to make.
 
 ## Automating it
 
@@ -244,7 +265,7 @@ run continues.
 | ----------------------------------------------------------------------- | ------------------------------------------------ |
 | Keep one project in a Git repo, synced automatically by Deepnote        | [Deepnote file sync](/docs/deepnote-file-sync)   |
 | Mirror many projects to your machine on demand, and push notebook edits | `deepnote sync`                                  |
-| Deploy a built static site or app to a project                          | [`deepnote publish`](/docs/deepnote-cli-publish) |
+| Deploy a built static site to a project                                 | [`deepnote publish`](/docs/deepnote-cli-publish) |
 
 ## Related
 

--- a/docs/deepnote-file-sync.md
+++ b/docs/deepnote-file-sync.md
@@ -116,6 +116,6 @@ Adding a Deepnote project file inside your Git repository makes it part of the G
 ## Related
 
 - [Syncing a workspace with the Deepnote CLI](/docs/deepnote-cli-sync) — the `deepnote sync` command, which mirrors many projects to a local directory on demand. Use it when you want a whole workspace locally, or when the project you want to work on is not linked to a Git repository.
-- [Publishing static sites with the Deepnote CLI](/docs/deepnote-cli-publish) — deploy a built site or app to a project with `deepnote publish`.
+- [Publishing static sites with the Deepnote CLI](/docs/deepnote-cli-publish) — deploy a built static site to a project with `deepnote publish`.
 - [Deepnote file format](/docs/deepnote-format) — what is inside a `.deepnote` file.
 - [How to set up Deepnote locally](/docs/local-setup) — editors and other local tooling.


### PR DESCRIPTION
Stacked on #510. Base is `docs/cli-publish-and-sync-pages`, so review only the diff of this branch.

A review of #510 found ten places where the two new pages state something the CLI does not do. These are not omissions or wording nits — each is a claim a reader could act on and be wrong. Every one was verified against `packages/cli` source and its tests.

### Doc contradicted the code

| # | Where | Claim | Reality |
|---|-------|-------|---------|
| 1 | `sync.md` Conflicts | `override` = "Overwrite local changes with the cloud version" | `resolveConflict` (`sync.ts:192-198`) passes the mode verbatim to four prompts pointing opposite ways. Three overwrite the **cloud** (`:469` with `force:true`, `:594`, `:446`); only `:749` matches the docs. With `--delete-missing-notebooks`, `override` auto-answers the guard at `:442-451` that deletes every notebook in the project. |
| 2 | `publish.md` sync coordination | "publish stops before writing anything rather than destroying content you have no local copy of" | `findDivergedPublishPaths` (`publish-mirror.ts:127-133`) requires `baseline !== undefined`. A never-synced remote file skips the guard and `--prune` deletes it without `--force`. Locked in by `publish.test.ts:510`. |
| 3 | `publish.md` prune ordering | "a failed deploy cannot leave the site half-deleted" | `blockingPaths` are deleted at `publish.ts:235-248`, before the upload loop at `:250`, and never restored. The `errors.length === 0` gate at `:272` protects only the *remaining* stale files. |
| 4 | both pages | "`deepnote sync` … never silently overwrites" | Under `--on-conflict override` the static root goes through the same push path (`sync.ts:583` → `:636-637`) with no prompt and no warning. |
| 5 | both `--prune` callouts | publish `--prune` deletes "**remote**" files; the flags are "unrelated" | `publish.ts:239,277` → `recordPrunedFile` → `publish-mirror.ts:181` does `fs.rm` on the **local** mirror copy. Both commands write the same `.deepnote-sync.json`. |
| 6 | `publish.md` failure behavior | leading space, backslash, and collisions all exit `2` | `publish.ts:66` trims the whole prefixed string, so a leading space is never at index 0, and there is no filename backslash check at all. Only trailing spaces and collisions are rejected. |
| 7 | both pages | the mirror update happens whenever you publish from a synced workspace | `locateMirror` skips it silently when the manifest has no entry for the project (`publish-mirror.ts:84-93`, no log) or the tracked directory is gone (`:96-107`, `debug` only). |
| 8 | `sync.md` safety rails | `--dry-run` shows "what a run would do" | `sync.ts:858` downgrades `ask` → `skip` under `--dry-run`, so the preview shows skips where the real run prompts. |

### Doc contradicted itself

| # | Where | Problem |
|---|-------|---------|
| 9 | `publish.md` URL section | Claimed the site is served "from its own dedicated origin" **and** that the link is "on the main domain". Both cannot be true. The advice was right; the rationale was invented, so it is now stated without one. |
| 10 | `sync.md` routing table, `deepnote-file-sync.md` Related | Routed "Deploy a built static site **or app**" to `deepnote publish`, which `publish.md` says is not the app path and is the wrong answer for reaching people without accounts. |

### Notable wording changes

- `--on-conflict override` is removed from the "answer up front" example. `skip` is what unattended runs want, and it is what the Automating it section already recommends; `override` is now introduced by the table and a warning instead of shown bare.
- Two new `<Callout status="warning">` blocks: the never-synced `--prune` gap (#2) and the direction-dependence of `override` (#1).

### Not addressed here

The review also flagged omissions and consistency issues that were deliberately left out of scope. Two are worth a follow-up because they are operationally dangerous even though nothing on the page is false: `sync --prune` is `fs.rm(..., { recursive: true })` and takes untracked local files with it, and a redeploy unconditionally re-enables website sharing, so a site taken down with `static-site access --sharing disabled` silently comes back.

Separately, `publish.md`'s access-model paragraph (workspace-level sharing setting, plan gating, "access is re-checked on every request") cannot be verified from this repo — the only access surface here is `ProjectStaticFilesSettings { sharingEnabled, apiAccessEnabled }`. It needs a check from someone with platform-side knowledge before this page ships.

### Verification

`pnpm prettier:check` passes. All in-page anchors resolve, including the new `#conflicts` reference. Docs-only change — no code, no tests affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VWb55u5XKkyCvzvoQEUwKX

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified publishing behavior, including canonical URLs, pruning failures, mirror synchronization, conflict detection, force operations, and unsynchronized remote files.
  - Documented platform-specific filename validation rules.
  - Expanded sync conflict guidance, including direction-based overrides, empty-directory handling, static-site publishing, pruning, and dry-run behavior.
  - Clarified that publishing applies to built static sites.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->