### PR TITLE
fix(reactivity): resolve Python scopes correctly in the dependency analyzer

### DIFF
--- a/packages/reactivity/src/ast-analyzer.test.ts
+++ b/packages/reactivity/src/ast-analyzer.test.ts
@@ -117,6 +117,12 @@ describe('AstAnalyzer', () => {
           usedVariables: ['g'],
         },
         {
+          name: 'records an assignment to a name declared global as a module-level definition',
+          content: 'def f():\n    global g\n    g = 1',
+          definedVariables: ['f', 'g'],
+          usedVariables: [],
+        },
+        {
           name: 'evaluates decorators, defaults, and annotations in the enclosing scope',
           content: '@deco\ndef f(a=default_v, b: T = 1):\n    return a + b',
           definedVariables: ['f'],
@@ -127,6 +133,18 @@ describe('AstAnalyzer', () => {
           content: 'class K:\n    attr = base',
           definedVariables: ['K'],
           usedVariables: ['base'],
+        },
+        {
+          name: 'does not let class-body bindings shadow a global read inside a method',
+          content: 'class C:\n    attr = 2\n    def m(self):\n        return attr',
+          definedVariables: ['C'],
+          usedVariables: ['attr'],
+        },
+        {
+          name: 'keeps comprehension targets local inside a class body',
+          content: 'class C:\n    xs = [a for a in items]',
+          definedVariables: ['C'],
+          usedVariables: ['items'],
         },
         {
           name: 'keeps comprehension targets local',

--- a/packages/reactivity/src/ast-analyzer.test.ts
+++ b/packages/reactivity/src/ast-analyzer.test.ts
@@ -74,6 +74,111 @@ describe('AstAnalyzer', () => {
       ])
     })
 
+    describe('Python scoping', () => {
+      // Block boundaries are not scope boundaries: a name that no enclosing function, lambda,
+      // class body, or comprehension binds is a module-level read even when it appears deep
+      // inside a body, and a name bound by one of those scopes never leaks out as a notebook
+      // variable. See https://github.com/deepnote/deepnote/issues/512 and /issues/513.
+      it.each([
+        {
+          name: 'reports a global read inside a function body',
+          content: 'def read_source():\n    return source_value',
+          definedVariables: ['read_source'],
+          usedVariables: ['source_value'],
+        },
+        {
+          name: 'reports a global read inside a method body',
+          content: 'class C:\n    def m(self):\n        return source_value',
+          definedVariables: ['C'],
+          usedVariables: ['source_value'],
+        },
+        {
+          name: 'reports a global read from an attribute access inside a function',
+          content: 'def f():\n    return df.head()',
+          definedVariables: ['f'],
+          usedVariables: ['df'],
+        },
+        {
+          name: 'does not report parameters or local assignments',
+          content: 'def f(a):\n    x = a + 1\n    return x * k',
+          definedVariables: ['f'],
+          usedVariables: ['k'],
+        },
+        {
+          name: 'treats a name assigned anywhere in a function as local throughout it',
+          content: 'def f():\n    x = x + 1\n    return x',
+          definedVariables: ['f'],
+          usedVariables: [],
+        },
+        {
+          name: 'treats a name declared global as a module-level read',
+          content: 'def f():\n    global g\n    return g',
+          definedVariables: ['f'],
+          usedVariables: ['g'],
+        },
+        {
+          name: 'evaluates decorators, defaults, and annotations in the enclosing scope',
+          content: '@deco\ndef f(a=default_v, b: T = 1):\n    return a + b',
+          definedVariables: ['f'],
+          usedVariables: ['T', 'deco', 'default_v'],
+        },
+        {
+          name: 'reports a global read in a class body but not the class attribute itself',
+          content: 'class K:\n    attr = base',
+          definedVariables: ['K'],
+          usedVariables: ['base'],
+        },
+        {
+          name: 'keeps comprehension targets local',
+          content: 'squares = [o * o for o in items]',
+          definedVariables: ['squares'],
+          usedVariables: ['items'],
+        },
+        {
+          name: 'reports a global read from a comprehension element',
+          content: 'out = [a + b for a in items]',
+          definedVariables: ['out'],
+          usedVariables: ['b', 'items'],
+        },
+        {
+          name: 'keeps nested comprehension and dict comprehension targets local',
+          content: 'm = {k: [v for v in row] for k, row in table.items()}',
+          definedVariables: ['m'],
+          usedVariables: ['table'],
+        },
+        {
+          name: 'keeps generator expression targets local',
+          content: 'total = sum(i * w for i in items)',
+          definedVariables: ['total'],
+          usedVariables: ['items', 'w'],
+        },
+        {
+          name: 'keeps set comprehension targets local and reports its condition reads',
+          content: 'kept = {r for r in rows if r > threshold}',
+          definedVariables: ['kept'],
+          usedVariables: ['rows', 'threshold'],
+        },
+        {
+          name: 'keeps lambda parameters local',
+          content: 'double = lambda x: x * 2',
+          definedVariables: ['double'],
+          usedVariables: [],
+        },
+        {
+          name: 'evaluates lambda defaults in the enclosing scope',
+          content: 'f = lambda x, y=d: x + y',
+          definedVariables: ['f'],
+          usedVariables: ['d'],
+        },
+      ])('$name', async ({ content, definedVariables, usedVariables }) => {
+        const mockBlocks = [{ id: '1', type: 'code', content, blockGroup: 'a', sortingKey: 'a' }] as DeepnoteBlock[]
+
+        const result = await getBlockDependencies(mockBlocks)
+
+        expect(result).toEqual([expect.objectContaining({ id: '1', definedVariables, usedVariables })])
+      })
+    })
+
     it('should throw error when python interpreter is not found', async () => {
       const mockBlocks = [{ id: '1', type: 'code', content: 'a = 1' }] as DeepnoteBlock[]
       await expect(getBlockDependencies(mockBlocks, { pythonInterpreter: 'non-existent-python' })).rejects.toThrow(

--- a/packages/reactivity/src/dag.test.ts
+++ b/packages/reactivity/src/dag.test.ts
@@ -965,6 +965,113 @@ describe('DAG', () => {
       })
     })
 
+    it('should return a DAG edge for a global read inside a function body defined in another block', async () => {
+      // https://github.com/deepnote/deepnote/issues/512
+      const blocks = createBlocks([
+        {
+          id: '1',
+          type: 'code',
+          content: 'source_value = "old"',
+        },
+        {
+          id: '2',
+          type: 'code',
+          content: 'def read_source():\n    return source_value',
+        },
+        {
+          id: '3',
+          type: 'code',
+          content: 'observed = read_source()',
+        },
+      ])
+
+      const { dag } = await getDagForBlocks(blocks)
+
+      expect(dag).toEqual({
+        modulesEdges: [],
+        nodes: [
+          expect.objectContaining({
+            id: '1',
+            inputVariables: [],
+            outputVariables: ['source_value'],
+          }),
+          expect.objectContaining({
+            id: '2',
+            inputVariables: ['source_value'],
+            outputVariables: ['read_source'],
+          }),
+          expect.objectContaining({
+            id: '3',
+            inputVariables: ['read_source'],
+            outputVariables: ['observed'],
+          }),
+        ],
+        edges: [
+          expect.objectContaining({ from: '1', inputVariables: ['source_value'], to: '2' }),
+          expect.objectContaining({ from: '2', inputVariables: ['read_source'], to: '3' }),
+        ],
+      })
+    })
+
+    it('should not create DAG edges for comprehension targets or lambda parameters', async () => {
+      // https://github.com/deepnote/deepnote/issues/513
+      const blocks = createBlocks([
+        {
+          id: '1',
+          type: 'code',
+          content: 'o = 5',
+        },
+        {
+          id: '2',
+          type: 'code',
+          content: 'x = 99',
+        },
+        {
+          id: '3',
+          type: 'code',
+          content: 'items = [1, 2, 3]\nsquares = [o * o for o in items]\ndouble = lambda x: x * 2',
+        },
+        {
+          id: '4',
+          type: 'code',
+          content: 'result = (o, squares, double(3))',
+        },
+      ])
+
+      const { dag } = await getDagForBlocks(blocks)
+
+      expect(dag).toEqual({
+        modulesEdges: [],
+        nodes: [
+          expect.objectContaining({
+            id: '1',
+            inputVariables: [],
+            outputVariables: ['o'],
+          }),
+          expect.objectContaining({
+            id: '2',
+            inputVariables: [],
+            outputVariables: ['x'],
+          }),
+          expect.objectContaining({
+            id: '3',
+            inputVariables: [],
+            outputVariables: ['double', 'items', 'squares'],
+          }),
+          expect.objectContaining({
+            id: '4',
+            inputVariables: ['double', 'o', 'squares'],
+            outputVariables: ['result'],
+          }),
+        ],
+        edges: [
+          expect.objectContaining({ from: '3', inputVariables: ['double'], to: '4' }),
+          expect.objectContaining({ from: '1', inputVariables: ['o'], to: '4' }),
+          expect.objectContaining({ from: '3', inputVariables: ['squares'], to: '4' }),
+        ],
+      })
+    })
+
     it('should return a DAG with imported modules', async () => {
       const blocks = createBlocks([
         {

--- a/packages/reactivity/src/scripts/ast-analyzer.py
+++ b/packages/reactivity/src/scripts/ast-analyzer.py
@@ -17,9 +17,9 @@ class VariableVisitor(ast.NodeVisitor):
         self.used_global_vars = set()  # Variables used and defined globally
         self.imported_modules = set()  # Local names introduced by imports (aliases)
         self.imported_packages = set()  # Top-level package names from import sources
-        # Stack of scopes. Each scope is a set of names bound locally in it (parameters,
-        # assignments, comprehension targets). Block boundaries are not scope boundaries, so
-        # a load that no enclosing scope binds is a module-level read even deep inside a body.
+        # Stack of (bound names, is_class) scopes. Bound names are parameters, assignments and
+        # comprehension targets. Block boundaries are not scope boundaries, so a load that no
+        # enclosing scope binds is a module-level read even deep inside a body.
         self.scope_stack = []
         self.function_globals = set()  # Names declared `global` in the current function
 
@@ -30,7 +30,14 @@ class VariableVisitor(ast.NodeVisitor):
     def _is_local(self, name):
         if name in self.function_globals:
             return False
-        return any(name in scope for scope in self.scope_stack)
+        for depth, (names, is_class) in enumerate(reversed(self.scope_stack)):
+            # Class bodies are invisible to the scopes nested in them: a method reading a name
+            # that the class body also binds reads the module-level one.
+            if is_class and depth > 0:
+                continue
+            if name in names:
+                return True
+        return False
 
     def _record_load(self, name):
         if name in BUILTINS_SET or self._is_local(name):
@@ -38,10 +45,10 @@ class VariableVisitor(ast.NodeVisitor):
         self.used_global_vars.add(name)
 
     def _record_store(self, name):
-        if self.current_scope_is_global():
+        if self.current_scope_is_global() or name in self.function_globals:
             self.global_vars.add(name)
-        elif name not in self.function_globals:
-            self.scope_stack[-1].add(name)
+        else:
+            self.scope_stack[-1][0].add(name)
 
     def _bound_names(self, nodes):
         """Names bound by statements in `nodes`, without descending into nested scopes.
@@ -70,8 +77,8 @@ class VariableVisitor(ast.NodeVisitor):
             stack.extend(ast.iter_child_nodes(node))
         return bound
 
-    def _visit_scoped(self, bound, nodes):
-        self.scope_stack.append(set(bound))
+    def _visit_scoped(self, bound, nodes, is_class=False):
+        self.scope_stack.append((set(bound), is_class))
         for node in nodes:
             self.visit(node)
         self.scope_stack.pop()
@@ -85,8 +92,7 @@ class VariableVisitor(ast.NodeVisitor):
         self._record_store(node.name)
         for expr in node.bases + node.keywords + node.decorator_list:
             self.visit(expr)
-        # Class bodies are a scope for their own assignments, but methods cannot see them.
-        self._visit_scoped(self._bound_names(node.body), node.body)
+        self._visit_scoped(self._bound_names(node.body), node.body, is_class=True)
 
     def _visit_function(self, node):
         if not isinstance(node, ast.Lambda):
@@ -106,7 +112,7 @@ class VariableVisitor(ast.NodeVisitor):
         prev_function_globals = self.function_globals
         self.function_globals = set()
         body = node.body if isinstance(node.body, list) else [node.body]
-        self._visit_scoped(self._bound_names([node.args] + body), body)
+        self._visit_scoped(self._bound_names([node.args, *body]), body)
         self.function_globals = prev_function_globals
 
     visit_FunctionDef = _visit_function

--- a/packages/reactivity/src/scripts/ast-analyzer.py
+++ b/packages/reactivity/src/scripts/ast-analyzer.py
@@ -17,104 +17,129 @@ class VariableVisitor(ast.NodeVisitor):
         self.used_global_vars = set()  # Variables used and defined globally
         self.imported_modules = set()  # Local names introduced by imports (aliases)
         self.imported_packages = set()  # Top-level package names from import sources
-        self.scope_stack = []  # Stack to track scopes
-        self.function_globals = set()  # Global variables declared in current function
+        # Stack of scopes. Each scope is a set of names bound locally in it (parameters,
+        # assignments, comprehension targets). Block boundaries are not scope boundaries, so
+        # a load that no enclosing scope binds is a module-level read even deep inside a body.
+        self.scope_stack = []
+        self.function_globals = set()  # Names declared `global` in the current function
 
     def current_scope_is_global(self):
         # If the scope stack is empty, we are at the global level
         return not self.scope_stack
+
+    def _is_local(self, name):
+        if name in self.function_globals:
+            return False
+        return any(name in scope for scope in self.scope_stack)
+
+    def _record_load(self, name):
+        if name in BUILTINS_SET or self._is_local(name):
+            return
+        self.used_global_vars.add(name)
+
+    def _record_store(self, name):
+        if self.current_scope_is_global():
+            self.global_vars.add(name)
+        elif name not in self.function_globals:
+            self.scope_stack[-1].add(name)
+
+    def _bound_names(self, nodes):
+        """Names bound by statements in `nodes`, without descending into nested scopes.
+
+        Python binds a name for the whole function when it is assigned anywhere in it, so the
+        set has to be known before the body is walked: `x = x + 1` reads the local, not a global.
+        """
+        bound = set()
+        stack = list(nodes)
+        while stack:
+            node = stack.pop()
+            if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+                bound.add(node.name)
+                continue
+            if isinstance(node, (ast.Lambda, ast.ListComp, ast.SetComp, ast.DictComp, ast.GeneratorExp)):
+                continue
+            if isinstance(node, ast.Name) and isinstance(node.ctx, (ast.Store, ast.Del)):
+                bound.add(node.id)
+            elif isinstance(node, ast.ExceptHandler) and node.name:
+                bound.add(node.name)
+            elif isinstance(node, (ast.Import, ast.ImportFrom)):
+                for alias in node.names:
+                    bound.add((alias.asname or alias.name).split(".")[0])
+            elif isinstance(node, ast.arg):
+                bound.add(node.arg)
+            stack.extend(ast.iter_child_nodes(node))
+        return bound
+
+    def _visit_scoped(self, bound, nodes):
+        self.scope_stack.append(set(bound))
+        for node in nodes:
+            self.visit(node)
+        self.scope_stack.pop()
 
     def visit_Global(self, node):
         for name in node.names:
             self.function_globals.add(name)
         self.generic_visit(node)
 
-    def visit_Assign(self, node):
-        for target in node.targets:
-            if isinstance(target, ast.Name):
-                if self.current_scope_is_global():
-                    self.global_vars.add(target.id)
-        self.generic_visit(node)
-
-    def visit_AugAssign(self, node):
-        if isinstance(node.target, ast.Name):
-            if self.current_scope_is_global():
-                self.global_vars.add(node.target.id)
-        self.generic_visit(node)
-
-    def visit_AnnAssign(self, node):
-        target = node.target
-        if isinstance(target, ast.Name) and self.current_scope_is_global():
-            self.global_vars.add(target.id)
-        self.generic_visit(node)
-
-    def visit_NamedExpr(self, node):
-        if isinstance(node.target, ast.Name) and self.current_scope_is_global():
-            self.global_vars.add(node.target.id)
-        self.generic_visit(node)
-
     def visit_ClassDef(self, node):
-        if self.current_scope_is_global():
-            self.global_vars.add(node.name)
-        self.scope_stack.append(node.name)  # Enter class scope
-        self.generic_visit(node)
-        self.scope_stack.pop()  # Exit class scope
+        self._record_store(node.name)
+        for expr in node.bases + node.keywords + node.decorator_list:
+            self.visit(expr)
+        # Class bodies are a scope for their own assignments, but methods cannot see them.
+        self._visit_scoped(self._bound_names(node.body), node.body)
 
-    def visit_FunctionDef(self, node):
-        if self.current_scope_is_global():
-            self.global_vars.add(node.name)
-
-        prev_function_globals = self.function_globals
-        self.function_globals = set()
-
-        self.scope_stack.append(node.name)  # Enter function scope
-        self.generic_visit(node)
-        self.scope_stack.pop()  # Exit function scope
-
-        self.function_globals = prev_function_globals
-
-    def visit_AsyncFunctionDef(self, node):
-        if self.current_scope_is_global():
-            self.global_vars.add(node.name)
+    def _visit_function(self, node):
+        if not isinstance(node, ast.Lambda):
+            self._record_store(node.name)
+            for expr in node.decorator_list:
+                self.visit(expr)
+            if node.returns is not None:
+                self.visit(node.returns)
+        # Defaults and annotations are evaluated in the enclosing scope, not the function's.
+        for expr in node.args.defaults + node.args.kw_defaults:
+            if expr is not None:
+                self.visit(expr)
+        for arg in ast.walk(node.args):
+            if isinstance(arg, ast.arg) and arg.annotation is not None:
+                self.visit(arg.annotation)
 
         prev_function_globals = self.function_globals
         self.function_globals = set()
-
-        self.scope_stack.append(node.name)  # Enter function scope
-        self.generic_visit(node)
-        self.scope_stack.pop()  # Exit function scope
-
+        body = node.body if isinstance(node.body, list) else [node.body]
+        self._visit_scoped(self._bound_names([node.args] + body), body)
         self.function_globals = prev_function_globals
+
+    visit_FunctionDef = _visit_function
+    visit_AsyncFunctionDef = _visit_function
+    visit_Lambda = _visit_function
+
+    def _visit_comprehension(self, node):
+        # The first iterable is evaluated in the enclosing scope; everything else runs inside
+        # the comprehension's own scope, where its targets are bound.
+        generators = node.generators
+        self.visit(generators[0].iter)
+        bound = self._bound_names([gen.target for gen in generators])
+        elements = [node.key, node.value] if isinstance(node, ast.DictComp) else [node.elt]
+        rest = [gen.iter for gen in generators[1:]]
+        rest += [cond for gen in generators for cond in gen.ifs]
+        self._visit_scoped(bound, rest + elements)
+
+    visit_ListComp = _visit_comprehension
+    visit_SetComp = _visit_comprehension
+    visit_DictComp = _visit_comprehension
+    visit_GeneratorExp = _visit_comprehension
 
     def visit_Name(self, node):
         if isinstance(node.ctx, ast.Load):
-            if node.id in BUILTINS_SET:
-                self.generic_visit(node)
-                return
-
-            if self.current_scope_is_global():
-                self.used_global_vars.add(node.id)
-            elif node.id in self.function_globals:
-                # Variable explicitly declared as global in current function
-                self.used_global_vars.add(node.id)
-            elif node.id in self.global_vars:
-                self.used_global_vars.add(node.id)
+            self._record_load(node.id)
         elif isinstance(node.ctx, ast.Store):
-            # Only track variable assignments at global scope
-            if self.current_scope_is_global():
-                self.global_vars.add(node.id)
+            self._record_store(node.id)
         self.generic_visit(node)
 
     def visit_Attribute(self, node):
         # Attributes are part of global usage if they are prefixed by a global variable
         if isinstance(node.value, ast.Name):
-            if self.current_scope_is_global():
-                self.used_global_vars.add(node.value.id)
-            elif node.value.id in self.function_globals:
-                # Variable explicitly declared as global in current function
-                self.used_global_vars.add(node.value.id)
-            elif node.value.id in self.global_vars:
-                self.used_global_vars.add(node.value.id)
+            self._record_load(node.value.id)
         else:
             self.generic_visit(node)
 


### PR DESCRIPTION
## Problem

The dependency-graph analyzer (`packages/reactivity/src/scripts/ast-analyzer.py`) approximated Python scope with a per-block `global_vars` set and a stack of scope *names*. Block boundaries are not scope boundaries, so this went wrong in both directions:

- **Under-reporting (#512).** A global read inside a function or method body was only recorded if the global was defined in the *same* block. A global defined in another block produced no edge, so "run with dependents" scheduled nothing and downstream blocks kept showing a successful but stale result.
- **Over-reporting (#513).** There was no scope for `Lambda`, `ListComp`, `SetComp`, `DictComp` or `GeneratorExp`, so comprehension targets were published as block inputs *and* outputs, and lambda parameters as inputs. Same-named loop variables (`x`, `i`, `o`, `row`, `df`) then produced phantom edges and spurious re-execution.

The same root cause also dropped reads in decorators, default arguments and annotations, because those were walked inside the function's scope.

## Change

The visitor now tracks scope as a stack of *sets of locally bound names*, and a load is a module-level read whenever no enclosing scope binds it, at any depth:

- **Functions, async functions, lambdas** push a scope containing their parameters plus every name bound anywhere in the body (`_bound_names`, which does not descend into nested scopes). Pre-collecting is necessary because Python binds a name for the whole function: `x = x + 1` reads the local, not a global. Decorators, defaults, annotations and return annotations are visited in the enclosing scope before the push.
- **Comprehensions and generator expressions** visit the first iterable in the enclosing scope, then push a scope with their targets for the remaining iterables, conditions and element expressions.
- **Class bodies** push a scope for their own assignments; methods still cannot see class attributes, matching Python.
- `global` declarations continue to bypass the local check, so the existing `global num` behaviour is unchanged.

Analyzer diff is ~95 lines changed. No TypeScript source changes; `dag-builder.ts` consumes the same output shape.

## Tests

- `ast-analyzer.test.ts`: a `Python scoping` table of 15 cases covering both issues' repros plus the surrounding edge cases (method bodies, attribute reads, read-before-assign locals, `global`, decorators/defaults/annotations, class attributes, nested/dict/set/generator comprehensions, lambda defaults).
- `dag.test.ts`: two end-to-end DAG tests mirroring the issue reproductions — the missing `source_value` edge from #512 now exists, and the phantom `o`/`x` edges from #513 do not.
- Full suite: 3163 tests pass; `pnpm typecheck` and `pnpm biome:check` clean.

Not touched: `scripts/test-ast-analyzer.py` fails identically on `main` because its expected output predates the `importedPackages` and `linesOfCode` fields. It is not part of `pnpm test`; left for a separate cleanup.

Fixes #512
Fixes #513

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Python dependency analysis across functions, classes, lambdas, comprehensions, decorators, annotations, and default arguments.
  - Correctly handles local bindings and `global` declarations when determining variable usage.
  - Improved dependency relationships for code blocks that reference variables defined elsewhere, including code nested within separate scopes.
  - Excludes comprehension targets and lambda parameters from unrelated dependency relationships.
  - Improved handling of class-level bindings so they do not incorrectly affect variable resolution inside methods.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->