### PR TITLE
fix(blocks): keep cell magics on the first line of generated Python

### DIFF
--- a/packages/blocks/src/blocks/code-blocks.ts
+++ b/packages/blocks/src/blocks/code-blocks.ts
@@ -4,6 +4,13 @@ import type { CodeBlock, DeepnoteBlock } from '../deepnote-file/deepnote-file-sc
 import { createDataFrameConfig } from './data-frame'
 
 export function createPythonCodeForCodeBlock(block: CodeBlock): string {
+  // IPython only recognizes a cell magic (`%%bash`, `%%time`, ...) when it is on the
+  // first line of the cell, so the DataFrame config cannot be prepended in that case.
+  // The config would be meaningless there anyway: the cell body is not Python.
+  if (startsWithCellMagic(block.content)) {
+    return block.content
+  }
+
   const dataFrameConfig = createDataFrameConfig(block)
 
   return dedent`
@@ -15,4 +22,8 @@ export function createPythonCodeForCodeBlock(block: CodeBlock): string {
 
 export function isCodeBlock(block: DeepnoteBlock): block is CodeBlock {
   return block.type === 'code'
+}
+
+function startsWithCellMagic(content: string | undefined): content is string {
+  return content?.trimStart().startsWith('%%') ?? false
 }

--- a/packages/blocks/src/blocks/code-blocks.ts
+++ b/packages/blocks/src/blocks/code-blocks.ts
@@ -5,8 +5,9 @@ import { createDataFrameConfig } from './data-frame'
 
 export function createPythonCodeForCodeBlock(block: CodeBlock): string {
   // IPython only recognizes a cell magic (`%%bash`, `%%time`, ...) when it is on the
-  // first line of the cell, so the DataFrame config cannot be prepended in that case.
-  // The config would be meaningless there anyway: the cell body is not Python.
+  // first non-blank line of the cell, at column zero. Prepending the DataFrame config
+  // would push it down and make IPython parse the cell as Python, so emit the content
+  // as-is. The config would be meaningless there anyway: the cell body is not Python.
   if (startsWithCellMagic(block.content)) {
     return block.content
   }
@@ -25,5 +26,9 @@ export function isCodeBlock(block: DeepnoteBlock): block is CodeBlock {
 }
 
 function startsWithCellMagic(content: string | undefined): content is string {
-  return content?.trimStart().startsWith('%%') ?? false
+  // Mirrors IPython's input cleanup: leading blank lines are dropped, but indentation
+  // before `%%` is not reliably stripped, so it must sit at column zero.
+  const firstNonBlankLine = content?.split('\n').find(line => line.trim() !== '')
+
+  return firstNonBlankLine?.startsWith('%%') ?? false
 }

--- a/packages/blocks/src/python-code.test.ts
+++ b/packages/blocks/src/python-code.test.ts
@@ -388,6 +388,85 @@ describe('createPythonCode', () => {
         df
       `)
     })
+
+    it('keeps a cell magic on the first line without the DataFrame config', () => {
+      const block: CodeBlock = {
+        id: '123',
+        type: 'code',
+        content: '%%bash\necho 123',
+        blockGroup: 'abc',
+        sortingKey: 'a0',
+        metadata: {},
+      }
+
+      const result = createPythonCode(block)
+
+      expect(result).toEqual('%%bash\necho 123')
+    })
+
+    it('detects a cell magic preceded by blank lines and whitespace', () => {
+      const block: CodeBlock = {
+        id: '123',
+        type: 'code',
+        content: '\n  \n  %%bash\necho 123',
+        blockGroup: 'abc',
+        sortingKey: 'a0',
+        metadata: {
+          deepnote_table_state: { pageSize: 25 },
+        },
+      }
+
+      const result = createPythonCode(block)
+
+      expect(result).toEqual('\n  \n  %%bash\necho 123')
+      expect(result).not.toContain('_dntk')
+    })
+
+    it('still prepends the DataFrame config for a line magic', () => {
+      const block: CodeBlock = {
+        id: '123',
+        type: 'code',
+        content: '%time df.head()',
+        blockGroup: 'abc',
+        sortingKey: 'a0',
+        metadata: {},
+      }
+
+      const result = createPythonCode(block)
+
+      expect(result).toEqual(dedent`
+        if '_dntk' in globals():
+          _dntk.dataframe_utils.configure_dataframe_formatter('{}')
+        else:
+          _deepnote_current_table_attrs = '{}'
+
+        %time df.head()
+      `)
+    })
+
+    it('still prepends the DataFrame config when a cell magic is not on the first line', () => {
+      const block: CodeBlock = {
+        id: '123',
+        type: 'code',
+        content: '%matplotlib inline\n%%bash\necho 123',
+        blockGroup: 'abc',
+        sortingKey: 'a0',
+        metadata: {},
+      }
+
+      const result = createPythonCode(block)
+
+      expect(result).toEqual(dedent`
+        if '_dntk' in globals():
+          _dntk.dataframe_utils.configure_dataframe_formatter('{}')
+        else:
+          _deepnote_current_table_attrs = '{}'
+
+        %matplotlib inline
+        %%bash
+        echo 123
+      `)
+    })
   })
 
   describe('Input blocks', () => {

--- a/packages/blocks/src/python-code.test.ts
+++ b/packages/blocks/src/python-code.test.ts
@@ -404,11 +404,11 @@ describe('createPythonCode', () => {
       expect(result).toEqual('%%bash\necho 123')
     })
 
-    it('detects a cell magic preceded by blank lines and whitespace', () => {
+    it('detects a cell magic preceded by blank lines', () => {
       const block: CodeBlock = {
         id: '123',
         type: 'code',
-        content: '\n  \n  %%bash\necho 123',
+        content: '\n  \n%%bash\necho 123',
         blockGroup: 'abc',
         sortingKey: 'a0',
         metadata: {
@@ -418,8 +418,31 @@ describe('createPythonCode', () => {
 
       const result = createPythonCode(block)
 
-      expect(result).toEqual('\n  \n  %%bash\necho 123')
+      expect(result).toEqual('\n  \n%%bash\necho 123')
       expect(result).not.toContain('_dntk')
+    })
+
+    it('still prepends the DataFrame config for an indented cell magic', () => {
+      const block: CodeBlock = {
+        id: '123',
+        type: 'code',
+        content: '  %%bash\necho 123',
+        blockGroup: 'abc',
+        sortingKey: 'a0',
+        metadata: {},
+      }
+
+      const result = createPythonCode(block)
+
+      expect(result).toEqual(dedent`
+        if '_dntk' in globals():
+          _dntk.dataframe_utils.configure_dataframe_formatter('{}')
+        else:
+          _deepnote_current_table_attrs = '{}'
+
+          %%bash
+        echo 123
+      `)
     })
 
     it('still prepends the DataFrame config for a line magic', () => {


### PR DESCRIPTION
## Summary

`createPythonCodeForCodeBlock` now returns the block content untouched when the first non-blank line starts with a cell magic (`%%`). Every other code block keeps the existing behaviour: DataFrame config, blank line, content.

Fixes (after downstream merge) deepnote/vscode-deepnote#175 (once released and bumped downstream).

## Root cause

IPython only recognises a cell magic when `%%...` is the very first line of the cell (after its own stripping of leading blank lines and common indentation). `createPythonCodeForCodeBlock` always prepends the `configure_dataframe_formatter` snippet before the block content, so for a block that starts with `%%bash` the magic lands on line 6 and IPython parses the whole cell as Python, failing on `%%bash` with a syntax error. Any cell magic is affected, not just `%%bash`; the fix therefore detects `%%` generically rather than a list of known magics.

## Before / after

Block content:

```
%%bash
echo 123
```

Generated Python before:

```python
if '_dntk' in globals():
  _dntk.dataframe_utils.configure_dataframe_formatter('{}')
else:
  _deepnote_current_table_attrs = '{}'

%%bash
echo 123
```

Generated Python after:

```
%%bash
echo 123
```

Detection takes the first non-blank line and requires `%%` at column zero. This mirrors IPython's input cleanup, verified against IPython 9.9.0: `leading_empty_lines` drops leading blank lines, but `leading_indent` dedents the whole cell rather than the first line, so an indented `%%bash` followed by unindented lines is not recognized as a cell magic (and older IPython versions handled that case differently again). Indented `%%` therefore takes the normal Python path. Line magics (`%time`, `%matplotlib inline`) are single `%` and are unaffected. The content is returned exactly as stored; nothing is trimmed or re-indented.

## Is dropping the DataFrame config for magic cells a problem?

No. The snippet configures how a DataFrame returned by the cell is rendered. A cell-magic cell hands its body to the magic (bash, time, writefile, html, ...) rather than evaluating it as Python, so there is no DataFrame display for the config to apply to. Not running it also means `_deepnote_current_table_attrs` is not reassigned by these cells, which is harmless because the next Python code/SQL block sets it again. Blocks with a `deepnote_table_state` that start with `%%` simply ignore that state, which matches what happens today when the cell errors out.

## Tests

Added to `packages/blocks/src/python-code.test.ts` (Code blocks):

- `%%bash\necho 123` yields exactly the content, no DataFrame config
- blank lines before a column-zero `%%bash` are still detected, even with a `deepnote_table_state` set
- an indented `  %%bash` keeps the existing DataFrame config prefix (IPython would not treat it as a cell magic)
- a `%time` line magic keeps the existing DataFrame config prefix
- a `%%bash` that is not on the first non-blank line (after `%matplotlib inline`) keeps the existing behaviour
- existing plain-Python code block expectations are unchanged

`pnpm --filter @deepnote/blocks exec vitest run`: 12 files, 223 tests passed. `pnpm lintAndFormat`, `pnpm typecheck` and `pnpm --filter @deepnote/blocks build` all pass.

## Downstream

vscode-deepnote consumes this via `createPythonCode` in `src/kernels/execution/cellExecution.ts` and will pick the fix up on the next `@deepnote/blocks` bump; that bump closes deepnote/vscode-deepnote#175. No version bump is included here since releases follow the manual package-scoped tag flow in CONTRIBUTING.md.

Note: AGENTS.md's "Always include DataFrame config when generating code for code/SQL blocks" now has this one deliberate exception; I left the guide untouched to keep the PR scoped, happy to add a sentence there if preferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Python code generation for IPython cell magics.
  - Cell magic commands at the beginning of a code block—including those preceded by whitespace or blank lines—are now preserved unchanged.
  - DataFrame configuration continues to be applied when appropriate, including for line magics and cell magics that appear after other code.
- **Tests**
  - Added coverage for whitespace, blank-line, and magic-command scenarios to help ensure consistent behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
